### PR TITLE
aplty mirror update support regular expression as parameter

### DIFF
--- a/cmd/mirror_update.go
+++ b/cmd/mirror_update.go
@@ -6,6 +6,24 @@ import (
 	"github.com/smira/flag"
 )
 
+func aptlyMirrorUpdates(cmd *commander.Command, args []string) error {
+	var err error
+	if len(args) != 1 {
+		cmd.Usage()
+		return err
+	}
+  repo_regexp := args[0]
+  repo, err := context.CollectionFactory().RemoteRepoCollection().ByRegexp(repo_regexp)
+  if nil != repo{
+  for e := repo.Front(); e != nil; e = e.Next() {
+      // there is probably a better way to do directly use e.Value as a string...  
+      result := fmt.Sprintf("%s", e.Value)
+      aptlyMirrorUpdate(cmd, []string{result})
+    }
+  }
+  return err
+}
+
 func aptlyMirrorUpdate(cmd *commander.Command, args []string) error {
 	var err error
 	if len(args) != 1 {
@@ -53,7 +71,7 @@ func aptlyMirrorUpdate(cmd *commander.Command, args []string) error {
 
 func makeCmdMirrorUpdate() *commander.Command {
 	cmd := &commander.Command{
-		Run:       aptlyMirrorUpdate,
+		Run:       aptlyMirrorUpdates,
 		UsageLine: "update <name>",
 		Short:     "update mirror",
 		Long: `

--- a/deb/remote.go
+++ b/deb/remote.go
@@ -16,6 +16,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+  "container/list"
+  "regexp"
 )
 
 // RemoteRepo represents remote (fetchable) Debian repository.
@@ -568,7 +570,24 @@ func (collection *RemoteRepoCollection) ByName(name string) (*RemoteRepo, error)
 			return r, nil
 		}
 	}
-	return nil, fmt.Errorf("mirror with name %s not found", name)
+	return nil, fmt.Errorf("mirror with name %s not found. Use 'aptly mirror list' to display the availbe mirror", name)
+}
+
+// ByRegexp looks for repository matching a regular expression
+func (collection *RemoteRepoCollection) ByRegexp(aregexp string) (*list.List, error) {
+  repo_list := list.New()
+  for _, r := range collection.list {
+    // add the repository name to the list if it matches
+    matched, _ := regexp.MatchString(aregexp, r.Name)
+    if true == matched{
+      repo_list.PushBack(r.Name)
+    }
+  }
+  if 0 == repo_list.Len(){
+  // return empty list in case the regular expression was no match
+    return nil, fmt.Errorf("no mirror name matching %s was found. Use 'aptly mirror list' to display the availbe mirror", aregexp)
+  }
+  return repo_list,nil
 }
 
 // ByUUID looks up repository by uuid


### PR DESCRIPTION
allowing multiple update of repositories matching this regexp fixes #27

could you take a look at my first attempt of go coding, please make some improvement...
This does support regular expression on the mirror list internally in aptly...
I still did not figure out how to implement a test for this...

let me know what you think
