### PR TITLE
debian-installer support

### DIFF
--- a/deb/publish.go
+++ b/deb/publish.go
@@ -443,8 +443,11 @@ func (p *PublishedRepo) Publish(packagePool aptly.PackagePool, publishedStorage 
 		st["Archive"] = p.Distribution
 		st["Architecture"] = arch
 
-		file, err := publishedStorage.CreateFile(filepath.Join(basePath, p.Component,
-			fmt.Sprintf("binary-%s", arch), "Release"))
+		if arch != "source" {
+			arch = fmt.Sprintf("binary-%s", arch)
+		}
+
+		file, err := publishedStorage.CreateFile(filepath.Join(basePath, p.Component, arch, "Release"))
 		if err != nil {
 			return fmt.Errorf("unable to create Release file: %s", err)
 		}


### PR DESCRIPTION
Hey @smira!

I recently needed to use a published Aptly repo from `d-i`, and ran across the following warning on the homepage:

```
aptly doesn't yet support debian-installer and translations
```

I found the main problem for debian-installer in the system log, which is that in the `dists/<dist>/<repo>/<arch>` directory (parallel to `Packages[.gz/.bz2]`), there is no `Release` file, one like you would find [here](http://us.archive.ubuntu.com/ubuntu/dists/precise/main/binary-amd64/Release). During `d-i`, a curl request is made to this URL, and if successful, the result is grep'ed for `Architecture`, at which point it tries to make sure that the repo architecture matches the box it is running on (probably through lsb_release).

I took a quick stab at adding this into Aptly today. I'm not entirely sure what all of the different fields in the file are really supposed to be, but `Archive` and `Architecture` alone are enough to make the repo usable from `d-i`.

Let me know what you think. Thanks!
