### PR TITLE
Deterministic PackageList search

### DIFF
--- a/deb/list.go
+++ b/deb/list.go
@@ -300,13 +300,13 @@ func (l *PackageList) Swap(i, j int) {
 	l.packagesIndex[i], l.packagesIndex[j] = l.packagesIndex[j], l.packagesIndex[i]
 }
 
-// Compare compares two packages by name in lexographical order and version
+// Compare compares two packages by name (lexographical) and version (latest to oldest)
 func (l *PackageList) Less(i, j int) bool {
 	iPkg := l.packagesIndex[i]
 	jPkg := l.packagesIndex[j]
 
 	if iPkg.Name == jPkg.Name {
-		return CompareVersions(iPkg.Version, jPkg.Version) == -1
+		return CompareVersions(iPkg.Version, jPkg.Version) == 1
 	}
 
 	return iPkg.Name < jPkg.Name


### PR DESCRIPTION
We have noticed non-deterministic behaviour when pulling a package without specifying a version from a snapshot.
In fact, we would expect to always pull the latest version of a package, but what we were seeing was that a random version was being chosen instead.

For example, we created a _sensu_ mirror and created a snapshot _source_snap_ from it:

```
root@sim-tst-lb1:~# aptly mirror create sensu http://repos.sensuapp.org/apt sensu
...
root@sim-tst-lb1:~# aptly mirror update sensu
...
root@sim-tst-lb1:~# aptly snapshot create source_snap from mirror sensu
...
root@sim-tst-lb1:~# aptly snapshot create empty empty
...
root@sim-tst-lb1:~# aptly snapshot pull --dry-run -architectures=amd64 empty source_snap dest_snap 'sensu'
Dependencies would be pulled into snapshot:
    [empty]: Created as empty
from snapshot:
    [source_snap]: Snapshot from mirror [sensu]: http://repos.sensuapp.org/apt/ sensu
and result would be saved as new snapshot dest_snap.
Loading packages (154)...
Building indexes...
[+] sensu_0.11.0-1_amd64 added

Not creating snapshot, as dry run was requested.
root@sim-tst-lb1:~# aptly snapshot pull --dry-run -architectures=amd64 empty source_snap dest_snap 'sensu'
Dependencies would be pulled into snapshot:
    [empty]: Created as empty
from snapshot:
    [source_snap]: Snapshot from mirror [sensu]: http://repos.sensuapp.org/apt/ sensu
and result would be saved as new snapshot dest_snap.
Loading packages (154)...
Building indexes...
[+] sensu_0.9.12.beta.5-2_amd64 added

Not creating snapshot, as dry run was requested.
root@sim-tst-lb1:~# aptly snapshot pull --dry-run -architectures=amd64 empty source_snap dest_snap 'sensu'
Dependencies would be pulled into snapshot:
    [empty]: Created as empty
from snapshot:
    [source_snap]: Snapshot from mirror [sensu]: http://repos.sensuapp.org/apt/ sensu
and result would be saved as new snapshot dest_snap.
Loading packages (154)...
Building indexes...
[+] sensu_0.9.9.beta.3-1_amd64 added
```

Whenever we pull the _sensu_ package from _source_snap_, aptly returns a random version of it.

The changes we have made to the code order the PackageList by version (latest first) as well as name so that  the search function returns a consistent result. 
