### PR TITLE
Pulling all matching packages from a snapshot

### DIFF
--- a/cmd/snapshot_pull.go
+++ b/cmd/snapshot_pull.go
@@ -18,6 +18,7 @@ func aptlySnapshotPull(cmd *commander.Command, args []string) error {
 
 	noDeps := context.flags.Lookup("no-deps").Value.Get().(bool)
 	noRemove := context.flags.Lookup("no-remove").Value.Get().(bool)
+	allMatches := context.flags.Lookup("all-matches").Value.Get().(bool)
 
 	// Load <name> snapshot
 	snapshot, err := context.CollectionFactory().SnapshotCollection().ByName(args[0])
@@ -97,24 +98,30 @@ func aptlySnapshotPull(cmd *commander.Command, args []string) error {
 			dep := dependencies[i]
 
 			// Search for package that can satisfy dependencies
-			pkg := sourcePackageList.Search(dep)
-			if pkg == nil {
+			searchResults := sourcePackageList.Search(dep, allMatches)
+			if searchResults == nil {
 				context.Progress().ColoredPrintf("@y[!]@| @!Dependency %s can't be satisfied with source %s@|", &dep, source)
 				continue
 			}
 
 			if !noRemove {
 				// Remove all packages with the same name and architecture
-				for p := packageList.Search(deb.Dependency{Architecture: pkg.Architecture, Pkg: pkg.Name}); p != nil; {
-					packageList.Remove(p)
-					context.Progress().ColoredPrintf("@r[-]@| %s removed", p)
-					p = packageList.Search(deb.Dependency{Architecture: pkg.Architecture, Pkg: pkg.Name})
+				for _, pkg := range searchResults {
+					for pS := packageList.Search(deb.Dependency{Architecture: pkg.Architecture, Pkg: pkg.Name}, allMatches); pS != nil; {
+						for _, p := range pS {
+							packageList.Remove(p)
+							context.Progress().ColoredPrintf("@r[-]@| %s removed", p)
+						}
+						pS = packageList.Search(deb.Dependency{Architecture: pkg.Architecture, Pkg: pkg.Name}, allMatches)
+					}
 				}
 			}
 
 			// Add new discovered package
-			packageList.Add(pkg)
-			context.Progress().ColoredPrintf("@g[+]@| %s added", pkg)
+			for _, pkg := range searchResults {
+				packageList.Add(pkg)
+				context.Progress().ColoredPrintf("@g[+]@| %s added", pkg)
+			}
 
 			if noDeps {
 				continue
@@ -122,26 +129,28 @@ func aptlySnapshotPull(cmd *commander.Command, args []string) error {
 
 			// Find missing dependencies for single added package
 			pL := deb.NewPackageList()
-			pL.Add(pkg)
+			for _, pkg := range searchResults {
+				pL.Add(pkg)
 
-			var missing []deb.Dependency
-			missing, err = pL.VerifyDependencies(context.DependencyOptions(), []string{arch}, packageList, nil)
-			if err != nil {
-				context.Progress().ColoredPrintf("@y[!]@| @!Error while verifying dependencies for pkg %s: %s@|", pkg, err)
-			}
-
-			// Append missing dependencies to the list of dependencies to satisfy
-			for _, misDep := range missing {
-				found := false
-				for _, d := range dependencies {
-					if d == misDep {
-						found = true
-						break
-					}
+				var missing []deb.Dependency
+				missing, err = pL.VerifyDependencies(context.DependencyOptions(), []string{arch}, packageList, nil)
+				if err != nil {
+					context.Progress().ColoredPrintf("@y[!]@| @!Error while verifying dependencies for pkg %s: %s@|", pkg, err)
 				}
 
-				if !found {
-					dependencies = append(dependencies, misDep)
+				// Append missing dependencies to the list of dependencies to satisfy
+				for _, misDep := range missing {
+					found := false
+					for _, d := range dependencies {
+						if d == misDep {
+							found = true
+							break
+						}
+					}
+
+					if !found {
+						dependencies = append(dependencies, misDep)
+					}
 				}
 			}
 		}
@@ -186,6 +195,8 @@ Example:
 	cmd.Flag.Bool("dry-run", false, "don't create destination snapshot, just show what would be pulled")
 	cmd.Flag.Bool("no-deps", false, "don't process dependencies, just pull listed packages")
 	cmd.Flag.Bool("no-remove", false, "don't remove other package versions when pulling package")
+	cmd.Flag.Bool("all-matches", false, "pull all the packages that satisfy the dependency version requirements")
+
 
 	return cmd
 }

--- a/deb/list.go
+++ b/deb/list.go
@@ -263,7 +263,7 @@ func (l *PackageList) VerifyDependencies(options int, architectures []string, so
 						continue
 					}
 
-					if sources.Search(dep) == nil {
+					if sources.Search(dep, false) == nil {
 						variantsMissing = append(variantsMissing, dep)
 						missingCount++
 					} else {
@@ -334,16 +334,25 @@ func (l *PackageList) PrepareIndex() {
 }
 
 // Search searches package index for specified package
-func (l *PackageList) Search(dep Dependency) *Package {
+func (l *PackageList) Search(dep Dependency, allMatches bool) []*Package {
 	if !l.indexed {
 		panic("list not indexed, can't search")
 	}
 
+	searchResults := []*Package{}
+
 	if dep.Relation == VersionDontCare {
 		for _, p := range l.providesIndex[dep.Pkg] {
 			if p.MatchesArchitecture(dep.Architecture) {
-				return p
+				searchResults = append(searchResults, p)
+
+				if !allMatches {
+					break
+				}
 			}
+		}
+		if len(searchResults) != 0 {
+			return searchResults
 		}
 	}
 
@@ -351,12 +360,21 @@ func (l *PackageList) Search(dep Dependency) *Package {
 
 	for i < len(l.packagesIndex) && l.packagesIndex[i].Name == dep.Pkg {
 		p := l.packagesIndex[i]
-		if p.MatchesDependency(dep) {
-			return p
+		if p.MatchesDependency(dep, allMatches) {
+			searchResults = append(searchResults, p)
+
+			if !allMatches {
+				break
+			}
 		}
 
 		i++
 	}
+
+	if len(searchResults) != 0 {
+		return searchResults
+	}
+
 	return nil
 }
 
@@ -404,7 +422,7 @@ func (l *PackageList) Filter(queries []string, withDependencies bool, source *Pa
 
 		for i < len(l.packagesIndex) && l.packagesIndex[i].Name == dep.Pkg {
 			p := l.packagesIndex[i]
-			if p.MatchesDependency(dep) {
+			if p.MatchesDependency(dep, false) {
 				result.Add(p)
 			}
 			i++
@@ -431,11 +449,13 @@ func (l *PackageList) Filter(queries []string, withDependencies bool, source *Pa
 
 			// try to satisfy dependencies
 			for _, dep := range missing {
-				p := l.Search(dep)
-				if p != nil {
-					result.Add(p)
-					dependencySource.Add(p)
-					added++
+				searchResults := l.Search(dep, false)
+				if searchResults != nil {
+					for _, p := range searchResults {
+						result.Add(p)
+						dependencySource.Add(p)
+						added++
+					}
 				}
 			}
 		}

--- a/deb/package.go
+++ b/deb/package.go
@@ -198,7 +198,7 @@ func (p *Package) MatchesArchitecture(arch string) bool {
 }
 
 // MatchesDependency checks whether package matches specified dependency
-func (p *Package) MatchesDependency(dep Dependency) bool {
+func (p *Package) MatchesDependency(dep Dependency, allMatches bool) bool {
 	if dep.Pkg != p.Name {
 		return false
 	}
@@ -212,9 +212,15 @@ func (p *Package) MatchesDependency(dep Dependency) bool {
 	}
 
 	r := CompareVersions(p.Version, dep.Version)
+
 	switch dep.Relation {
 	case VersionEqual:
-		return r == 0
+		if allMatches {
+			rn := CompareVersions(p.Version, dep.NextVersion())
+			return r+rn == 0 || r == 0
+		} else {
+			return r == 0
+		}
 	case VersionLess:
 		return r < 0
 	case VersionGreater:

--- a/deb/package_test.go
+++ b/deb/package_test.go
@@ -172,38 +172,44 @@ func (s *PackageSuite) TestMatchesDependency(c *C) {
 	p := NewPackageFromControlFile(s.stanza)
 
 	// exact match
-	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "i386", Relation: VersionEqual, Version: "7.40-2"}), Equals, true)
+	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "i386", Relation: VersionEqual, Version: "7.40-2"}, false), Equals, true)
+
+	// exact match, same version, no revision specified
+	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "i386", Relation: VersionEqual, Version: "7.40"}, false), Equals, false)
+
+	// non-exact match, same version, no revision specified
+	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "i386", Relation: VersionEqual, Version: "7.40"}, true), Equals, true)
 
 	// different name
-	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena", Architecture: "i386", Relation: VersionEqual, Version: "7.40-2"}), Equals, false)
+	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena", Architecture: "i386", Relation: VersionEqual, Version: "7.40-2"}, false), Equals, false)
 
 	// different version
-	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "i386", Relation: VersionEqual, Version: "7.40-3"}), Equals, false)
+	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "i386", Relation: VersionEqual, Version: "7.40-3"}, false), Equals, false)
 
 	// different arch
-	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "amd64", Relation: VersionEqual, Version: "7.40-2"}), Equals, false)
+	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "amd64", Relation: VersionEqual, Version: "7.40-2"}, false), Equals, false)
 
 	// empty arch
-	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "", Relation: VersionEqual, Version: "7.40-2"}), Equals, true)
+	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "", Relation: VersionEqual, Version: "7.40-2"}, false), Equals, true)
 
 	// version don't care
-	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "i386", Relation: VersionDontCare, Version: ""}), Equals, true)
+	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "i386", Relation: VersionDontCare, Version: ""}, false), Equals, true)
 
 	// >
-	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "i386", Relation: VersionGreater, Version: "7.40-2"}), Equals, false)
-	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "i386", Relation: VersionGreater, Version: "7.40-1"}), Equals, true)
+	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "i386", Relation: VersionGreater, Version: "7.40-2"}, false), Equals, false)
+	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "i386", Relation: VersionGreater, Version: "7.40-1"}, false), Equals, true)
 
 	// <
-	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "i386", Relation: VersionLess, Version: "7.40-2"}), Equals, false)
-	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "i386", Relation: VersionLess, Version: "7.40-3"}), Equals, true)
+	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "i386", Relation: VersionLess, Version: "7.40-2"}, false), Equals, false)
+	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "i386", Relation: VersionLess, Version: "7.40-3"}, false), Equals, true)
 
 	// >=
-	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "i386", Relation: VersionGreaterOrEqual, Version: "7.40-2"}), Equals, true)
-	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "i386", Relation: VersionGreaterOrEqual, Version: "7.40-3"}), Equals, false)
+	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "i386", Relation: VersionGreaterOrEqual, Version: "7.40-2"}, false), Equals, true)
+	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "i386", Relation: VersionGreaterOrEqual, Version: "7.40-3"}, false), Equals, false)
 
 	// <=
-	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "i386", Relation: VersionLessOrEqual, Version: "7.40-2"}), Equals, true)
-	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "i386", Relation: VersionLessOrEqual, Version: "7.40-1"}), Equals, false)
+	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "i386", Relation: VersionLessOrEqual, Version: "7.40-2"}, false), Equals, true)
+	c.Check(p.MatchesDependency(Dependency{Pkg: "alien-arena-common", Architecture: "i386", Relation: VersionLessOrEqual, Version: "7.40-1"}, false), Equals, false)
 }
 
 func (s *PackageSuite) TestGetDependencies(c *C) {

--- a/deb/version.go
+++ b/deb/version.go
@@ -188,6 +188,29 @@ type Dependency struct {
 	Architecture string
 }
 
+// NextVersion returns the next version of a dependency (eg. if d.Version = 1.9, it returns 1.10)
+func (d *Dependency) NextVersion() string {
+	l := len(d.Version)
+
+	if l == 0 {
+		return ""
+	}
+
+	i := l
+	for  i > 0  {
+		_, err := strconv.ParseUint(d.Version[i-1:l],10,0)
+		if err != nil { break }
+		i--
+	}
+
+	v, err := strconv.ParseUint(d.Version[i:l],10,0)
+	if err != nil {
+		return d.Version
+	}
+
+	return d.Version[0:i] + strconv.Itoa(int(v)+1)
+}
+
 // Hash calculates some predefined unique ID of Dependency
 func (d *Dependency) Hash() string {
 	return fmt.Sprintf("%s:%s:%d:%s", d.Architecture, d.Pkg, d.Relation, d.Version)

--- a/deb/version_test.go
+++ b/deb/version_test.go
@@ -217,3 +217,45 @@ func (s *VersionSuite) TestDependencyString(c *C) {
 	d.Architecture = "i386"
 	c.Check(d.String(), Equals, "dpkg [i386]")
 }
+
+func (s *VersionSuite) TestDependencyNextVersion(c *C){
+	d, _ := ParseDependency("dpkg(=1.7)")
+	d.Architecture = "i386"
+	c.Check(d.NextVersion(), Equals, "1.8")
+
+	d, _ = ParseDependency("dpkg(=1.9)")
+	d.Architecture = "i386"
+	c.Check(d.NextVersion(), Equals, "1.10")
+
+	d, _ = ParseDependency("dpkg(=9)")
+	d.Architecture = "i386"
+	c.Check(d.NextVersion(), Equals, "10")
+
+	d, _ = ParseDependency("dpkg(=9.909)")
+	d.Architecture = "i386"
+	c.Check(d.NextVersion(), Equals, "9.910")
+
+	d, _ = ParseDependency("dpkg(=9.0.9)")
+	d.Architecture = "i386"
+	c.Check(d.NextVersion(), Equals, "9.0.10")
+
+	d, _ = ParseDependency("dpkg(=9.0.100)")
+	d.Architecture = "i386"
+	c.Check(d.NextVersion(), Equals, "9.0.101")
+
+	d, _ = ParseDependency("dpkg(=9.0.0-209)")
+	d.Architecture = "i386"
+	c.Check(d.NextVersion(), Equals, "9.0.0-210")
+
+	d, _ = ParseDependency("dpkg(=9.0.0-209rel)")
+	d.Architecture = "i386"
+	c.Check(d.NextVersion(), Equals, "9.0.0-209rel")
+
+	d, _ = ParseDependency("dpkg(=9.0.0-rel219)")
+	d.Architecture = "i386"
+	c.Check(d.NextVersion(), Equals, "9.0.0-rel220")
+
+	d, _ = ParseDependency("dpkg")
+	d.Architecture = "i386"
+	c.Check(d.NextVersion(), Equals, "")
+}


### PR DESCRIPTION
When performing an _aptly snapshot pull_, users might list dependency
versions that can potentially match multiple packages in the source snapshot. However,
the current implementation of the 'snapshot pull' command only allows one package
to be pulled from a snapshot at a time for a given dependency.

The newly implemented all-matches flag allows users to pull all the
matching packages from a source snapshot, provided that they satisfy the
version requirements indicated by the dependencies.

The all-matches flag defaults to false and only produces the described
behaviour when it is explicitly set to true.

For example, I created a _source_snap_ snapshot from a _sensu_ mirror:

```
root@sim-tst-lb1:~# aptly mirror create sensu http://repos.sensuapp.org/apt sensu
...
root@sim-tst-lb1:~# aptly mirror update sensu
...
root@sim-tst-lb1:~# aptly snapshot create source_snap from mirror sensu
...
root@sim-tst-lb1:~# aptly snapshot create empty empty
...
```

The **current behaviour** of _aptly snapshot pull_ is shown below.
Only one package satisfying dependency _sensu > 0.11_ is added to _dest_snap_.

```
root@sim-tst-lb1:~# aptly snapshot pull -architectures=amd64 --dry-run empty sensu-snap dest_snap 'sensu (> 0.11)'
Dependencies would be pulled into snapshot:
    [empty]: Created as empty
from snapshot:
    [sensu-snap]: Snapshot from mirror [sensu]: http://repos.sensuapp.org/apt/ sensu
and result would be saved as new snapshot dest_snap.
Loading packages (154)...
Building indexes...
[+] sensu_0.12.1-1_amd64 added

Not creating snapshot, as dry run was requested.
```

The **proposed** _all-matches_ flag **behaviour** is shown below.
All the packages that satisfy dependency _sensu > 0.11_ are added to _dest_snap_.

```
root@sim-tst-lb1:~# aptly snapshot pull -architectures=amd64 --all-matches --dry-run empty sensu-snap dest_snap 'sensu (> 0.11)'
Dependencies would be pulled into snapshot:
    [empty]: Created as empty
from snapshot:
    [sensu-snap]: Snapshot from mirror [sensu]: http://repos.sensuapp.org/apt/ sensu
and result would be saved as new snapshot dest_snap.
Loading packages (154)...
Building indexes...
[+] sensu_0.11.0.beta.3-1_amd64 added
[+] sensu_0.11.0.beta.2-1_amd64 added
[+] sensu_0.11.3-1_amd64 added
[+] sensu_0.11.0-1_amd64 added
[+] sensu_0.11.0.beta.4-1_amd64 added
[+] sensu_0.11.0.beta.1-1_amd64 added
[+] sensu_0.12.0-1_amd64 added
[+] sensu_0.12.3-1_amd64 added
[+] sensu_0.11.1-1_amd64 added
[+] sensu_0.12.1-1_amd64 added
[+] sensu_0.12.4-1_amd64 added
[+] sensu_0.12.6-4_amd64 added
[+] sensu_0.12.2-1_amd64 added
[+] sensu_0.12.6-5_amd64 added
[+] sensu_0.12.5-1_amd64 added
[+] sensu_0.12.6-2_amd64 added
[+] sensu_0.12.6-3_amd64 added
[+] sensu_0.12.6-1_amd64 added
[+] sensu_0.11.0.beta-1_amd64 added

Not creating snapshot, as dry run was requested.
```

When the dependency listed is:
- equal to a set version, for example _(= 0.11)_
  **and**
- the _all-matches_ flag is set to _true_

under the proposed changes aptly returns all the versions between _0.11_ and _0.12_ (effectively 0.11.*):

```
root@sim-tst-lb1:~# aptly snapshot pull -architectures=amd64 --all-matches --dry-run empty sensu-snap dest_snap 'sensu (= 0.11)'
Dependencies would be pulled into snapshot:
    [empty]: Created as empty
from snapshot:
    [sensu-snap]: Snapshot from mirror [sensu]: http://repos.sensuapp.org/apt/ sensu
and result would be saved as new snapshot dest_snap.
Loading packages (154)...
Building indexes...
[+] sensu_0.11.0.beta.4-1_amd64 added
[+] sensu_0.11.0.beta.1-1_amd64 added
[+] sensu_0.11.0.beta.2-1_amd64 added
[+] sensu_0.11.1-1_amd64 added
[+] sensu_0.11.0.beta-1_amd64 added
[+] sensu_0.11.0.beta.3-1_amd64 added
[+] sensu_0.11.0-1_amd64 added
[+] sensu_0.11.3-1_amd64 added

Not creating snapshot, as dry run was requested.
```
