### PR TITLE
Allow variation of formatting of Debian control.tar.gz

### DIFF
--- a/deb/deb.go
+++ b/deb/deb.go
@@ -47,7 +47,7 @@ func GetControlFileFromDeb(packageFile string) (Stanza, error) {
 					return nil, fmt.Errorf("unable to read .tar archive: %s", err)
 				}
 
-				if tarHeader.Name == "./control" {
+				if tarHeader.Name == "./control" || tarHeader.Name == "control" {
 					reader := NewControlFileReader(untar)
 					stanza, err := reader.ReadStanza()
 					if err != nil {


### PR DESCRIPTION
While all the normal Debian package building tools create a
control.tar.gz archive member that contains files with a leading
"./" path element, such as "./control", dpkg and other archive tools
like reprepro are happy with omitting the "./" path element and
having files like "control".  Allow for either for compatibility
with weird packages that people may want to import into aptly.
