### PR TITLE
Continue even when a server replies with 403

### DIFF
--- a/http/download.go
+++ b/http/download.go
@@ -318,7 +318,7 @@ func DownloadTryCompression(downloader aptly.Downloader, url string, expectedChe
 		}
 
 		if err != nil {
-			if err1, ok := err.(*HTTPError); ok && err1.Code == 404 {
+			if err1, ok := err.(*HTTPError); ok && err1.Code == 404 || err1.Code == 403 {
 				continue
 			}
 			return nil, nil, err


### PR DESCRIPTION
Amazon S3 replies with a 403 when accessing files that don't exist,
while this should be fixed at Amazon, we can workaround it in aptly
for the moment.
