### PR TITLE
 #408 adding basic prometheus instrumentation

### DIFF
--- a/Gomfile
+++ b/Gomfile
@@ -25,6 +25,7 @@ gom 'github.com/ugorji/go/codec', :commit => '71c2886f5a673a35f909803f38ece58101
 gom 'github.com/vaughan0/go-ini', :commit => 'a98ad7ee00ec53921f08832bc06ecf7fd600e6a1'
 gom 'github.com/wsxiaoys/terminal/color', :commit => '5668e431776a7957528361f90ce828266c69ed08'
 gom 'golang.org/x/crypto/ssh/terminal', :commit => 'a7ead6ddf06233883deca151dffaef2effbf498f'
+gom 'github.com/DanielHeckrath/gin-prometheus', :commit => '496506645290f808c96e35926ef192e538371b1d'
 
 group :test do
     gom 'gopkg.in/check.v1'


### PR DESCRIPTION
creating basic instrumentation. 

The library imported I'm not teh biggest fan of. It basically re-does the same named prometheus client functions (https://godoc.org/github.com/prometheus/client_golang/prometheus#InstrumentHandlerFunc) with the gin context.

metrics exposed at /metrics
