### PR TITLE
Add support for flat repositories with no Release file.

### DIFF
--- a/cmd/mirror_update.go
+++ b/cmd/mirror_update.go
@@ -53,6 +53,11 @@ func aptlyMirrorUpdate(cmd *commander.Command, args []string) error {
 		return fmt.Errorf("unable to update: %s", err)
 	}
 
+	if len(repo.ReleaseFiles) == 0 {
+		context.Progress().Printf("Repository %s has no Release file, disabling checksum verification.\n", repo.Name)
+		ignoreMismatch = true
+	}
+
 	context.Progress().Printf("Downloading & parsing package files...\n")
 	err = repo.DownloadPackageIndexes(context.Progress(), context.Downloader(), context.CollectionFactory(), ignoreMismatch, maxTries)
 	if err != nil {

--- a/deb/remote.go
+++ b/deb/remote.go
@@ -261,6 +261,10 @@ func (repo *RemoteRepo) Fetch(d aptly.Downloader, verifier pgp.Verifier) error {
 		// 0. Just download release file to temporary URL
 		release, err = http.DownloadTemp(gocontext.TODO(), d, repo.ReleaseURL("Release").String())
 		if err != nil {
+			if err1, ok := err.(*http.Error); ok && (err1.Code == 404 || err1.Code == 403) {
+				// this repo has no Release file - ignore
+				return nil
+			}
 			return err
 		}
 	} else {
@@ -289,6 +293,10 @@ func (repo *RemoteRepo) Fetch(d aptly.Downloader, verifier pgp.Verifier) error {
 		// 2. try Release + Release.gpg
 		release, err = http.DownloadTemp(gocontext.TODO(), d, repo.ReleaseURL("Release").String())
 		if err != nil {
+			if err1, ok := err.(*http.Error); ok && (err1.Code == 404 || err1.Code == 403) {
+				// this repo has no Release file - ignore
+				return nil
+			}
 			return err
 		}
 

--- a/system/t04_mirror/CreateMirror6Test_gold
+++ b/system/t04_mirror/CreateMirror6Test_gold
@@ -1,3 +1,5 @@
 Downloading http://mirror.yandex.ru/debian/dists/suslik/InRelease...
 Downloading http://mirror.yandex.ru/debian/dists/suslik/Release...
-ERROR: unable to fetch mirror: HTTP code 404 while fetching http://mirror.yandex.ru/debian/dists/suslik/Release
+
+Mirror [mirror6]: http://mirror.yandex.ru/debian/ suslik successfully added.
+You can run 'aptly mirror update mirror6' to download repository contents.

--- a/system/t04_mirror/create.py
+++ b/system/t04_mirror/create.py
@@ -58,8 +58,6 @@ class CreateMirror6Test(BaseTest):
     """
     create mirror: missing release
     """
-    expectedCode = 1
-
     runCmd = "aptly mirror create --keyring=aptlytest.gpg mirror6 http://mirror.yandex.ru/debian/ suslik"
 
 


### PR DESCRIPTION
In flat repositories, the Release file is supported, but not mandatory,
according to the specification here:

https://wiki.debian.org/RepositoryFormat#Flat_Repository_Format

An example for such a repository is the MapR ecosystem:

http://archive.mapr.com/releases/ecosystem-5.x/ubuntu/binary/

Before this patch, it was not possible to create a mirror of that
repository. The new behavior is to ignore the missing metadata, and
to implicitly disable checksum checks, since there are no checksums to check.
