### PR TITLE
Add mirror api

### DIFF
--- a/api/gpg.go
+++ b/api/gpg.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/gin-gonic/gin"
+)
+
+// POST /api/gpg
+func apiGPGAddKey(c *gin.Context) {
+	var b struct {
+		Keyserver   string
+		GpgKeyID    string
+		GpgKeyArmor string
+		Keyring     string
+	}
+
+	if c.Bind(&b) != nil {
+		return
+	}
+
+	var err error
+	args := []string{"--no-default-keyring"}
+	keyring := "trustedkeys.gpg"
+	if len(b.Keyring) > 0 {
+		keyring = b.Keyring
+	}
+	args = append(args, "--keyring", keyring)
+	if len(b.Keyserver) > 0 {
+		args = append(args, "--keyserver", b.Keyserver)
+	}
+	if len(b.GpgKeyArmor) > 0 {
+		var tempdir string
+		tempdir, err = ioutil.TempDir(os.TempDir(), "aptly")
+		if err != nil {
+			c.AbortWithError(400, err)
+			return
+		}
+		defer os.RemoveAll(tempdir)
+
+		keypath := filepath.Join(tempdir, "key")
+		keyfile, e := os.Create(keypath)
+		if e != nil {
+			c.AbortWithError(400, e)
+			return
+		}
+		if _, e = keyfile.WriteString(b.GpgKeyArmor); e != nil {
+			c.AbortWithError(400, e)
+		}
+		args = append(args, "--import", keypath)
+
+	}
+	if len(b.GpgKeyID) > 0 {
+		args = append(args, "--recv", b.GpgKeyID)
+	}
+
+	// it might happened that we have a situation with an erroneous
+	// gpg command (e.g. when GpgKeyID and GpgKeyArmor is set).
+	// there is no error handling for such as gpg will do this for us
+	cmd := exec.Command("gpg", args...)
+	cmd.Stdout = os.Stdout
+	if err = cmd.Run(); err != nil {
+		c.AbortWithError(400, err)
+		return
+	}
+
+	c.JSON(200, gin.H{})
+}

--- a/api/graph.go
+++ b/api/graph.go
@@ -21,17 +21,7 @@ func apiGraph(c *gin.Context) {
 
 	ext := c.Params.ByName("ext")
 	layout := c.Request.URL.Query().Get("layout")
-
-	factory := context.CollectionFactory()
-
-	factory.RemoteRepoCollection().Lock()
-	defer factory.RemoteRepoCollection().Unlock()
-	factory.LocalRepoCollection().Lock()
-	defer factory.LocalRepoCollection().Unlock()
-	factory.SnapshotCollection().Lock()
-	defer factory.SnapshotCollection().Unlock()
-	factory.PublishedRepoCollection().Lock()
-	defer factory.PublishedRepoCollection().Unlock()
+	factory := context.NewCollectionFactory()
 
 	graph, err := deb.BuildGraph(factory, layout)
 	if err != nil {

--- a/api/mirror.go
+++ b/api/mirror.go
@@ -1,0 +1,561 @@
+package api
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/aptly-dev/aptly/aptly"
+	"github.com/aptly-dev/aptly/deb"
+	"github.com/aptly-dev/aptly/pgp"
+	"github.com/aptly-dev/aptly/query"
+	"github.com/aptly-dev/aptly/task"
+	"github.com/gin-gonic/gin"
+)
+
+func getVerifier(ignoreSignatures bool, keyRings []string) (pgp.Verifier, error) {
+	if ignoreSignatures {
+		return nil, nil
+	}
+
+	verifier := &pgp.GpgVerifier{}
+	for _, keyRing := range keyRings {
+		verifier.AddKeyring(keyRing)
+	}
+
+	err := verifier.InitKeyring()
+	if err != nil {
+		return nil, err
+	}
+
+	return verifier, nil
+}
+
+// GET /api/mirrors
+func apiMirrorsList(c *gin.Context) {
+	collectionFactory := context.NewCollectionFactory()
+	collection := collectionFactory.RemoteRepoCollection()
+
+	result := []*deb.RemoteRepo{}
+	collection.ForEach(func(repo *deb.RemoteRepo) error {
+		result = append(result, repo)
+		return nil
+	})
+
+	c.JSON(200, result)
+}
+
+// POST /api/mirrors
+func apiMirrorsCreate(c *gin.Context) {
+	var err error
+	var b struct {
+		Name               string `binding:"required"`
+		ArchiveURL         string `binding:"required"`
+		Distribution       string
+		Filter             string
+		Components         []string
+		Architectures      []string
+		Keyrings           []string
+		DownloadSources    bool
+		DownloadUdebs      bool
+		FilterWithDeps     bool
+		SkipComponentCheck bool
+		IgnoreSignatures   bool
+	}
+
+	b.DownloadSources = context.Config().DownloadSourcePackages
+	b.IgnoreSignatures = context.Config().GpgDisableVerify
+	b.Architectures = context.ArchitecturesList()
+
+	if c.Bind(&b) != nil {
+		return
+	}
+
+	collectionFactory := context.NewCollectionFactory()
+	collection := collectionFactory.RemoteRepoCollection()
+
+	if strings.HasPrefix(b.ArchiveURL, "ppa:") {
+		b.ArchiveURL, b.Distribution, b.Components, err = deb.ParsePPA(b.ArchiveURL, context.Config())
+		if err != nil {
+			c.AbortWithError(400, err)
+			return
+		}
+	}
+
+	if b.Filter != "" {
+		_, err = query.Parse(b.Filter)
+		if err != nil {
+			c.AbortWithError(400, fmt.Errorf("unable to create mirror: %s", err))
+			return
+		}
+	}
+
+	repo, err := deb.NewRemoteRepo(b.Name, b.ArchiveURL, b.Distribution, b.Components, b.Architectures,
+		b.DownloadSources, b.DownloadUdebs)
+
+	if err != nil {
+		c.AbortWithError(400, fmt.Errorf("unable to create mirror: %s", err))
+		return
+	}
+
+	repo.Filter = b.Filter
+	repo.FilterWithDeps = b.FilterWithDeps
+	repo.SkipComponentCheck = b.SkipComponentCheck
+	repo.DownloadSources = b.DownloadSources
+	repo.DownloadUdebs = b.DownloadUdebs
+
+	verifier, err := getVerifier(b.IgnoreSignatures, b.Keyrings)
+	if err != nil {
+		c.AbortWithError(400, fmt.Errorf("unable to initialize GPG verifier: %s", err))
+		return
+	}
+
+	downloader := context.NewDownloader(nil)
+	err = repo.Fetch(downloader, verifier)
+	if err != nil {
+		c.AbortWithError(400, fmt.Errorf("unable to fetch mirror: %s", err))
+		return
+	}
+
+	err = collection.Add(repo)
+	if err != nil {
+		c.AbortWithError(500, fmt.Errorf("unable to add mirror: %s", err))
+		return
+	}
+
+	c.JSON(201, repo)
+}
+
+// DELETE /api/mirrors/:name
+func apiMirrorsDrop(c *gin.Context) {
+	name := c.Params.ByName("name")
+	force := c.Request.URL.Query().Get("force") == "1"
+
+	collectionFactory := context.NewCollectionFactory()
+	mirrorCollection := collectionFactory.RemoteRepoCollection()
+	snapshotCollection := collectionFactory.SnapshotCollection()
+
+	repo, err := mirrorCollection.ByName(name)
+	if err != nil {
+		c.AbortWithError(404, fmt.Errorf("unable to drop: %s", err))
+		return
+	}
+
+	resources := []string{string(repo.Key())}
+	taskName := fmt.Sprintf("Delete mirror %s", name)
+	task, conflictErr := runTaskInBackground(taskName, resources, func(out *task.Output, detail *task.Detail) error {
+		err := repo.CheckLock()
+		if err != nil {
+			return fmt.Errorf("unable to drop: %s", err)
+		}
+
+		if !force {
+			snapshots := snapshotCollection.ByRemoteRepoSource(repo)
+
+			if len(snapshots) > 0 {
+				return fmt.Errorf("won't delete mirror with snapshots, use 'force=1' to override")
+			}
+		}
+
+		return mirrorCollection.Drop(repo)
+	})
+
+	if conflictErr != nil {
+		c.AbortWithError(409, conflictErr)
+		return
+	}
+
+	c.JSON(202, task)
+}
+
+// GET /api/mirrors/:name
+func apiMirrorsShow(c *gin.Context) {
+	collectionFactory := context.NewCollectionFactory()
+	collection := collectionFactory.RemoteRepoCollection()
+
+	name := c.Params.ByName("name")
+	repo, err := collection.ByName(name)
+	if err != nil {
+		c.AbortWithError(404, fmt.Errorf("unable to show: %s", err))
+		return
+	}
+
+	err = collection.LoadComplete(repo)
+	if err != nil {
+		c.AbortWithError(500, fmt.Errorf("unable to show: %s", err))
+	}
+
+	c.JSON(200, repo)
+}
+
+// GET /api/mirrors/:name/packages
+func apiMirrorsPackages(c *gin.Context) {
+	collectionFactory := context.NewCollectionFactory()
+	collection := collectionFactory.RemoteRepoCollection()
+
+	name := c.Params.ByName("name")
+	repo, err := collection.ByName(name)
+	if err != nil {
+		c.AbortWithError(404, fmt.Errorf("unable to show: %s", err))
+		return
+	}
+
+	err = collection.LoadComplete(repo)
+	if err != nil {
+		c.AbortWithError(500, fmt.Errorf("unable to show: %s", err))
+	}
+
+	if repo.LastDownloadDate.IsZero() {
+		c.AbortWithError(404, fmt.Errorf("unable to show package list, mirror hasn't been downloaded yet"))
+		return
+	}
+
+	reflist := repo.RefList()
+	result := []*deb.Package{}
+
+	list, err := deb.NewPackageListFromRefList(reflist, collectionFactory.PackageCollection(), nil)
+	if err != nil {
+		c.AbortWithError(404, err)
+		return
+	}
+
+	queryS := c.Request.URL.Query().Get("q")
+	if queryS != "" {
+		q, err := query.Parse(c.Request.URL.Query().Get("q"))
+		if err != nil {
+			c.AbortWithError(400, err)
+			return
+		}
+
+		withDeps := c.Request.URL.Query().Get("withDeps") == "1"
+		architecturesList := []string{}
+
+		if withDeps {
+			if len(context.ArchitecturesList()) > 0 {
+				architecturesList = context.ArchitecturesList()
+			} else {
+				architecturesList = list.Architectures(false)
+			}
+
+			sort.Strings(architecturesList)
+
+			if len(architecturesList) == 0 {
+				c.AbortWithError(400, fmt.Errorf("unable to determine list of architectures, please specify explicitly"))
+				return
+			}
+		}
+
+		list.PrepareIndex()
+
+		list, err = list.Filter([]deb.PackageQuery{q}, withDeps,
+			nil, context.DependencyOptions(), architecturesList)
+		if err != nil {
+			c.AbortWithError(500, fmt.Errorf("unable to search: %s", err))
+		}
+	}
+
+	if c.Request.URL.Query().Get("format") == "details" {
+		list.ForEach(func(p *deb.Package) error {
+			result = append(result, p)
+			return nil
+		})
+
+		c.JSON(200, result)
+	} else {
+		c.JSON(200, list.Strings())
+	}
+}
+
+// PUT /api/mirrors/:name
+func apiMirrorsUpdate(c *gin.Context) {
+	var (
+		err    error
+		remote *deb.RemoteRepo
+	)
+
+	var b struct {
+		Name                 string
+		ArchiveURL           string
+		Filter               string
+		Architectures        []string
+		Components           []string
+		Keyrings             []string
+		FilterWithDeps       bool
+		DownloadSources      bool
+		DownloadUdebs        bool
+		SkipComponentCheck   bool
+		IgnoreChecksums      bool
+		IgnoreSignatures     bool
+		ForceUpdate          bool
+		SkipExistingPackages bool
+		MaxTries             int
+	}
+
+	collectionFactory := context.NewCollectionFactory()
+	collection := collectionFactory.RemoteRepoCollection()
+
+	remote, err = collection.ByName(c.Params.ByName("name"))
+	if err != nil {
+		c.AbortWithError(404, err)
+		return
+	}
+
+	b.Name = remote.Name
+	b.DownloadUdebs = remote.DownloadUdebs
+	b.DownloadSources = remote.DownloadSources
+	b.SkipComponentCheck = remote.SkipComponentCheck
+	b.FilterWithDeps = remote.FilterWithDeps
+	b.Filter = remote.Filter
+	b.Architectures = remote.Architectures
+	b.Components = remote.Components
+
+	if c.Bind(&b) != nil {
+		return
+	}
+
+	if b.Name != remote.Name {
+		_, err = collection.ByName(b.Name)
+		if err == nil {
+			c.AbortWithError(409, fmt.Errorf("unable to rename: mirror %s already exists", b.Name))
+			return
+		}
+	}
+
+	if b.DownloadUdebs != remote.DownloadUdebs {
+		if remote.IsFlat() && b.DownloadUdebs {
+			c.AbortWithError(400, fmt.Errorf("unable to update: flat mirrors don't support udebs"))
+			return
+		}
+	}
+
+	if b.ArchiveURL != "" {
+		remote.SetArchiveRoot(b.ArchiveURL)
+	}
+
+	remote.Name = b.Name
+	remote.DownloadUdebs = b.DownloadUdebs
+	remote.DownloadSources = b.DownloadSources
+	remote.SkipComponentCheck = b.SkipComponentCheck
+	remote.FilterWithDeps = b.FilterWithDeps
+	remote.Filter = b.Filter
+	remote.Architectures = b.Architectures
+	remote.Components = b.Components
+
+	verifier, err := getVerifier(b.IgnoreSignatures, b.Keyrings)
+	if err != nil {
+		c.AbortWithError(400, fmt.Errorf("unable to initialize GPG verifier: %s", err))
+		return
+	}
+
+	resources := []string{string(remote.Key())}
+	currTask, conflictErr := runTaskInBackground("Update mirror "+b.Name, resources, func(out *task.Output, detail *task.Detail) error {
+
+		downloader := context.NewDownloader(out)
+		err := remote.Fetch(downloader, verifier)
+		if err != nil {
+			return fmt.Errorf("unable to update: %s", err)
+		}
+
+		if !b.ForceUpdate {
+			err = remote.CheckLock()
+			if err != nil {
+				return fmt.Errorf("unable to update: %s", err)
+			}
+		}
+
+		if b.MaxTries <= 0 {
+			b.MaxTries = 1
+		}
+
+		err = remote.DownloadPackageIndexes(out, downloader, collectionFactory, b.SkipComponentCheck, b.MaxTries)
+		if err != nil {
+			return fmt.Errorf("unable to update: %s", err)
+		}
+
+		if remote.Filter != "" {
+			var filterQuery deb.PackageQuery
+
+			filterQuery, err = query.Parse(remote.Filter)
+			if err != nil {
+				return fmt.Errorf("unable to update: %s", err)
+			}
+
+			_, _, err = remote.ApplyFilter(context.DependencyOptions(), filterQuery, out)
+			if err != nil {
+				return fmt.Errorf("unable to update: %s", err)
+			}
+		}
+
+		queue, downloadSize, err := remote.BuildDownloadQueue(context.PackagePool(), collectionFactory.PackageCollection(),
+			collectionFactory.ChecksumCollection(), b.SkipExistingPackages)
+		if err != nil {
+			return fmt.Errorf("unable to update: %s", err)
+		}
+
+		defer func() {
+			// on any interruption, unlock the mirror
+			e := context.ReOpenDatabase()
+			if e == nil {
+				remote.MarkAsIdle()
+				collection.Update(remote)
+			}
+		}()
+
+		remote.MarkAsUpdating()
+		err = collection.Update(remote)
+		if err != nil {
+			return fmt.Errorf("unable to update: %s", err)
+		}
+
+		context.GoContextHandleSignals()
+
+		count := len(queue)
+		taskDetail := struct {
+			TotalDownloadSize         int64
+			RemainingDownloadSize     int64
+			TotalNumberOfPackages     int
+			RemainingNumberOfPackages int
+		}{
+			downloadSize, downloadSize, count, count,
+		}
+		detail.Store(taskDetail)
+
+		downloadQueue := make(chan int)
+		taskFinished := make(chan *deb.PackageDownloadTask)
+
+		var (
+			errors  []string
+			errLock sync.Mutex
+		)
+
+		pushError := func(err error) {
+			errLock.Lock()
+			errors = append(errors, err.Error())
+			errLock.Unlock()
+		}
+
+		go func() {
+			for idx := range queue {
+				select {
+				case downloadQueue <- idx:
+				case <-context.Done():
+					return
+				}
+			}
+
+			close(downloadQueue)
+		}()
+
+		// update of task details need to be done in order
+		go func() {
+			for {
+				task, ok := <-taskFinished
+				if !ok {
+					return
+				}
+
+				taskDetail.RemainingDownloadSize -= task.File.Checksums.Size
+				taskDetail.RemainingNumberOfPackages--
+				detail.Store(taskDetail)
+			}
+		}()
+
+		var wg sync.WaitGroup
+		for i := 0; i < context.Config().DownloadConcurrency; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for {
+					select {
+					case idx, ok := <-downloadQueue:
+						if !ok {
+							return
+						}
+
+						task := &queue[idx]
+
+						var e error
+
+						// provision download location
+						task.TempDownPath, e = context.PackagePool().(aptly.LocalPackagePool).GenerateTempPath(task.File.Filename)
+						if e != nil {
+							pushError(e)
+							continue
+						}
+
+						// download file...
+						e = context.Downloader().DownloadWithChecksum(
+							context,
+							remote.PackageURL(task.File.DownloadURL()).String(),
+							task.TempDownPath,
+							&task.File.Checksums,
+							b.IgnoreChecksums,
+							b.MaxTries)
+						if e != nil {
+							pushError(e)
+							continue
+						}
+
+						task.Done = true
+						taskFinished <- task
+					case <-context.Done():
+						continue
+					}
+
+				}
+			}()
+		}
+
+		// Wait for all download goroutines to finish
+		wg.Wait()
+		close(taskFinished)
+
+		for idx := range queue {
+
+			task := &queue[idx]
+
+			if !task.Done {
+				// download not finished yet
+				continue
+			}
+
+			// and import it back to the pool
+			task.File.PoolPath, err = context.PackagePool().Import(task.TempDownPath, task.File.Filename, &task.File.Checksums, true, collectionFactory.ChecksumCollection())
+			if err != nil {
+				return fmt.Errorf("unable to import file: %s", err)
+			}
+
+			// update "attached" files if any
+			for _, additionalTask := range task.Additional {
+				additionalTask.File.PoolPath = task.File.PoolPath
+				additionalTask.File.Checksums = task.File.Checksums
+			}
+		}
+
+		select {
+		case <-context.Done():
+			return fmt.Errorf("unable to update: interrupted")
+		default:
+		}
+
+		if len(errors) > 0 {
+			return fmt.Errorf("unable to update: download errors:\n  %s", strings.Join(errors, "\n  "))
+		}
+
+		remote.FinalizeDownload(collectionFactory, out)
+		err = collectionFactory.RemoteRepoCollection().Update(remote)
+		if err != nil {
+			return fmt.Errorf("unable to update: %s", err)
+		}
+
+		return nil
+	})
+
+	if conflictErr != nil {
+		c.AbortWithError(409, conflictErr)
+		return
+	}
+
+	c.JSON(202, currTask)
+}

--- a/api/packages.go
+++ b/api/packages.go
@@ -6,7 +6,8 @@ import (
 
 // GET /api/packages/:key
 func apiPackagesShow(c *gin.Context) {
-	p, err := context.CollectionFactory().PackageCollection().ByKey([]byte(c.Params.ByName("key")))
+	collectionFactory := context.NewCollectionFactory()
+	p, err := collectionFactory.PackageCollection().ByKey([]byte(c.Params.ByName("key")))
 	if err != nil {
 		c.AbortWithError(404, err)
 		return

--- a/api/publish.go
+++ b/api/publish.go
@@ -166,8 +166,6 @@ func apiPublishRepoOrSnapshot(c *gin.Context) {
 	}
 
 	collection := collectionFactory.PublishedRepoCollection()
-	collection.Lock()
-	defer collection.Unlock()
 
 	published, err := deb.NewPublishedRepo(storage, prefix, b.Distribution, b.Architectures, components, sources, collectionFactory)
 	if err != nil {

--- a/api/publish.go
+++ b/api/publish.go
@@ -51,22 +51,13 @@ func parseEscapedPath(path string) string {
 
 // GET /publish
 func apiPublishList(c *gin.Context) {
-	localCollection := context.CollectionFactory().LocalRepoCollection()
-	localCollection.RLock()
-	defer localCollection.RUnlock()
-
-	snapshotCollection := context.CollectionFactory().SnapshotCollection()
-	snapshotCollection.RLock()
-	defer snapshotCollection.RUnlock()
-
-	collection := context.CollectionFactory().PublishedRepoCollection()
-	collection.Lock()
-	defer collection.Unlock()
+	collectionFactory := context.NewCollectionFactory()
+	collection := collectionFactory.PublishedRepoCollection()
 
 	result := make([]*deb.PublishedRepo, 0, collection.Len())
 
 	err := collection.ForEach(func(repo *deb.PublishedRepo) error {
-		err := collection.LoadComplete(repo, context.CollectionFactory())
+		err := collection.LoadComplete(repo, collectionFactory)
 		if err != nil {
 			return err
 		}
@@ -124,13 +115,12 @@ func apiPublishRepoOrSnapshot(c *gin.Context) {
 
 	var components []string
 	var sources []interface{}
+	collectionFactory := context.NewCollectionFactory()
 
 	if b.SourceKind == "snapshot" {
 		var snapshot *deb.Snapshot
 
-		snapshotCollection := context.CollectionFactory().SnapshotCollection()
-		snapshotCollection.Lock()
-		defer snapshotCollection.Unlock()
+		snapshotCollection := collectionFactory.SnapshotCollection()
 
 		for _, source := range b.Sources {
 			components = append(components, source.Component)
@@ -152,9 +142,7 @@ func apiPublishRepoOrSnapshot(c *gin.Context) {
 	} else if b.SourceKind == deb.SourceLocalRepo {
 		var localRepo *deb.LocalRepo
 
-		localCollection := context.CollectionFactory().LocalRepoCollection()
-		localCollection.Lock()
-		defer localCollection.Unlock()
+		localCollection := collectionFactory.LocalRepoCollection()
 
 		for _, source := range b.Sources {
 			components = append(components, source.Component)
@@ -177,11 +165,11 @@ func apiPublishRepoOrSnapshot(c *gin.Context) {
 		return
 	}
 
-	collection := context.CollectionFactory().PublishedRepoCollection()
+	collection := collectionFactory.PublishedRepoCollection()
 	collection.Lock()
 	defer collection.Unlock()
 
-	published, err := deb.NewPublishedRepo(storage, prefix, b.Distribution, b.Architectures, components, sources, context.CollectionFactory())
+	published, err := deb.NewPublishedRepo(storage, prefix, b.Distribution, b.Architectures, components, sources, collectionFactory)
 	if err != nil {
 		c.AbortWithError(500, fmt.Errorf("unable to publish: %s", err))
 		return
@@ -208,12 +196,12 @@ func apiPublishRepoOrSnapshot(c *gin.Context) {
 
 	duplicate := collection.CheckDuplicate(published)
 	if duplicate != nil {
-		context.CollectionFactory().PublishedRepoCollection().LoadComplete(duplicate, context.CollectionFactory())
+		collectionFactory.PublishedRepoCollection().LoadComplete(duplicate, collectionFactory)
 		c.AbortWithError(400, fmt.Errorf("prefix/distribution already used by another published repo: %s", duplicate))
 		return
 	}
 
-	err = published.Publish(context.PackagePool(), context, context.CollectionFactory(), signer, nil, b.ForceOverwrite)
+	err = published.Publish(context.PackagePool(), context, collectionFactory, signer, nil, b.ForceOverwrite)
 	if err != nil {
 		c.AbortWithError(500, fmt.Errorf("unable to publish: %s", err))
 		return
@@ -256,25 +244,15 @@ func apiPublishUpdateSwitch(c *gin.Context) {
 		return
 	}
 
-	// published.LoadComplete would touch local repo collection
-	localRepoCollection := context.CollectionFactory().LocalRepoCollection()
-	localRepoCollection.Lock()
-	defer localRepoCollection.Unlock()
-
-	snapshotCollection := context.CollectionFactory().SnapshotCollection()
-	snapshotCollection.Lock()
-	defer snapshotCollection.Unlock()
-
-	collection := context.CollectionFactory().PublishedRepoCollection()
-	collection.Lock()
-	defer collection.Unlock()
+	collectionFactory := context.NewCollectionFactory()
+	collection := collectionFactory.PublishedRepoCollection()
 
 	published, err := collection.ByStoragePrefixDistribution(storage, prefix, distribution)
 	if err != nil {
 		c.AbortWithError(404, fmt.Errorf("unable to update: %s", err))
 		return
 	}
-	err = collection.LoadComplete(published, context.CollectionFactory())
+	err = collection.LoadComplete(published, collectionFactory)
 	if err != nil {
 		c.AbortWithError(500, fmt.Errorf("unable to update: %s", err))
 		return
@@ -299,6 +277,7 @@ func apiPublishUpdateSwitch(c *gin.Context) {
 				return
 			}
 
+			snapshotCollection := collectionFactory.SnapshotCollection()
 			snapshot, err2 := snapshotCollection.ByName(snapshotInfo.Name)
 			if err != nil {
 				c.AbortWithError(404, err2)
@@ -327,7 +306,7 @@ func apiPublishUpdateSwitch(c *gin.Context) {
 		published.AcquireByHash = *b.AcquireByHash
 	}
 
-	err = published.Publish(context.PackagePool(), context, context.CollectionFactory(), signer, nil, b.ForceOverwrite)
+	err = published.Publish(context.PackagePool(), context, collectionFactory, signer, nil, b.ForceOverwrite)
 	if err != nil {
 		c.AbortWithError(500, fmt.Errorf("unable to update: %s", err))
 		return
@@ -341,7 +320,7 @@ func apiPublishUpdateSwitch(c *gin.Context) {
 
 	if b.SkipCleanup == nil || !*b.SkipCleanup {
 		err = collection.CleanupPrefixComponentFiles(published.Prefix, updatedComponents,
-			context.GetPublishedStorage(storage), context.CollectionFactory(), nil)
+			context.GetPublishedStorage(storage), collectionFactory, nil)
 		if err != nil {
 			c.AbortWithError(500, fmt.Errorf("unable to update: %s", err))
 			return
@@ -360,17 +339,11 @@ func apiPublishDrop(c *gin.Context) {
 	storage, prefix := deb.ParsePrefix(param)
 	distribution := c.Params.ByName("distribution")
 
-	// published.LoadComplete would touch local repo collection
-	localRepoCollection := context.CollectionFactory().LocalRepoCollection()
-	localRepoCollection.Lock()
-	defer localRepoCollection.Unlock()
-
-	collection := context.CollectionFactory().PublishedRepoCollection()
-	collection.Lock()
-	defer collection.Unlock()
+	collectionFactory := context.NewCollectionFactory()
+	collection := collectionFactory.PublishedRepoCollection()
 
 	err := collection.Remove(context, storage, prefix, distribution,
-		context.CollectionFactory(), context.Progress(), force, skipCleanup)
+		collectionFactory, context.Progress(), force, skipCleanup)
 	if err != nil {
 		c.AbortWithError(500, fmt.Errorf("unable to drop: %s", err))
 		return

--- a/api/repos.go
+++ b/api/repos.go
@@ -17,11 +17,9 @@ import (
 func apiReposList(c *gin.Context) {
 	result := []*deb.LocalRepo{}
 
-	collection := context.CollectionFactory().LocalRepoCollection()
-	collection.RLock()
-	defer collection.RUnlock()
-
-	context.CollectionFactory().LocalRepoCollection().ForEach(func(r *deb.LocalRepo) error {
+	collectionFactory := context.NewCollectionFactory()
+	collection := collectionFactory.LocalRepoCollection()
+	collection.ForEach(func(r *deb.LocalRepo) error {
 		result = append(result, r)
 		return nil
 	})
@@ -46,11 +44,9 @@ func apiReposCreate(c *gin.Context) {
 	repo.DefaultComponent = b.DefaultComponent
 	repo.DefaultDistribution = b.DefaultDistribution
 
-	collection := context.CollectionFactory().LocalRepoCollection()
-	collection.Lock()
-	defer collection.Unlock()
-
-	err := context.CollectionFactory().LocalRepoCollection().Add(repo)
+	collectionFactory := context.NewCollectionFactory()
+	collection := collectionFactory.LocalRepoCollection()
+	err := collection.Add(repo)
 	if err != nil {
 		c.AbortWithError(400, err)
 		return
@@ -71,9 +67,8 @@ func apiReposEdit(c *gin.Context) {
 		return
 	}
 
-	collection := context.CollectionFactory().LocalRepoCollection()
-	collection.Lock()
-	defer collection.Unlock()
+	collectionFactory := context.NewCollectionFactory()
+	collection := collectionFactory.LocalRepoCollection()
 
 	repo, err := collection.ByName(c.Params.ByName("name"))
 	if err != nil {
@@ -102,9 +97,8 @@ func apiReposEdit(c *gin.Context) {
 
 // GET /api/repos/:name
 func apiReposShow(c *gin.Context) {
-	collection := context.CollectionFactory().LocalRepoCollection()
-	collection.RLock()
-	defer collection.RUnlock()
+	collectionFactory := context.NewCollectionFactory()
+	collection := collectionFactory.LocalRepoCollection()
 
 	repo, err := collection.ByName(c.Params.ByName("name"))
 	if err != nil {
@@ -119,17 +113,10 @@ func apiReposShow(c *gin.Context) {
 func apiReposDrop(c *gin.Context) {
 	force := c.Request.URL.Query().Get("force") == "1"
 
-	collection := context.CollectionFactory().LocalRepoCollection()
-	collection.Lock()
-	defer collection.Unlock()
-
-	snapshotCollection := context.CollectionFactory().SnapshotCollection()
-	snapshotCollection.RLock()
-	defer snapshotCollection.RUnlock()
-
-	publishedCollection := context.CollectionFactory().PublishedRepoCollection()
-	publishedCollection.RLock()
-	defer publishedCollection.RUnlock()
+	collectionFactory := context.NewCollectionFactory()
+	collection := collectionFactory.LocalRepoCollection()
+	snapshotCollection := collectionFactory.SnapshotCollection()
+	publishedCollection := collectionFactory.PublishedRepoCollection()
 
 	repo, err := collection.ByName(c.Params.ByName("name"))
 	if err != nil {
@@ -162,9 +149,8 @@ func apiReposDrop(c *gin.Context) {
 
 // GET /api/repos/:name/packages
 func apiReposPackagesShow(c *gin.Context) {
-	collection := context.CollectionFactory().LocalRepoCollection()
-	collection.Lock()
-	defer collection.Unlock()
+	collectionFactory := context.NewCollectionFactory()
+	collection := collectionFactory.LocalRepoCollection()
 
 	repo, err := collection.ByName(c.Params.ByName("name"))
 	if err != nil {
@@ -178,7 +164,7 @@ func apiReposPackagesShow(c *gin.Context) {
 		return
 	}
 
-	showPackages(c, repo.RefList())
+	showPackages(c, repo.RefList(), collectionFactory)
 }
 
 // Handler for both add and delete
@@ -191,9 +177,8 @@ func apiReposPackagesAddDelete(c *gin.Context, cb func(list *deb.PackageList, p 
 		return
 	}
 
-	collection := context.CollectionFactory().LocalRepoCollection()
-	collection.Lock()
-	defer collection.Unlock()
+	collectionFactory := context.NewCollectionFactory()
+	collection := collectionFactory.LocalRepoCollection()
 
 	repo, err := collection.ByName(c.Params.ByName("name"))
 	if err != nil {
@@ -207,7 +192,7 @@ func apiReposPackagesAddDelete(c *gin.Context, cb func(list *deb.PackageList, p 
 		return
 	}
 
-	list, err := deb.NewPackageListFromRefList(repo.RefList(), context.CollectionFactory().PackageCollection(), nil)
+	list, err := deb.NewPackageListFromRefList(repo.RefList(), collectionFactory.PackageCollection(), nil)
 	if err != nil {
 		c.AbortWithError(500, err)
 		return
@@ -217,7 +202,7 @@ func apiReposPackagesAddDelete(c *gin.Context, cb func(list *deb.PackageList, p 
 	for _, ref := range b.PackageRefs {
 		var p *deb.Package
 
-		p, err = context.CollectionFactory().PackageCollection().ByKey([]byte(ref))
+		p, err = collectionFactory.PackageCollection().ByKey([]byte(ref))
 		if err != nil {
 			if err == database.ErrNotFound {
 				c.AbortWithError(404, fmt.Errorf("package %s: %s", ref, err))
@@ -235,7 +220,7 @@ func apiReposPackagesAddDelete(c *gin.Context, cb func(list *deb.PackageList, p 
 
 	repo.UpdateRefList(deb.NewPackageRefListFromPackageList(list))
 
-	err = context.CollectionFactory().LocalRepoCollection().Update(repo)
+	err = collectionFactory.LocalRepoCollection().Update(repo)
 	if err != nil {
 		c.AbortWithError(500, fmt.Errorf("unable to save: %s", err))
 		return
@@ -281,9 +266,8 @@ func apiReposPackageFromDir(c *gin.Context) {
 		return
 	}
 
-	collection := context.CollectionFactory().LocalRepoCollection()
-	collection.Lock()
-	defer collection.Unlock()
+	collectionFactory := context.NewCollectionFactory()
+	collection := collectionFactory.LocalRepoCollection()
 
 	repo, err := collection.ByName(c.Params.ByName("name"))
 	if err != nil {
@@ -320,14 +304,14 @@ func apiReposPackageFromDir(c *gin.Context) {
 
 	packageFiles, otherFiles, failedFiles = deb.CollectPackageFiles(sources, reporter)
 
-	list, err = deb.NewPackageListFromRefList(repo.RefList(), context.CollectionFactory().PackageCollection(), nil)
+	list, err = deb.NewPackageListFromRefList(repo.RefList(), collectionFactory.PackageCollection(), nil)
 	if err != nil {
 		c.AbortWithError(500, fmt.Errorf("unable to load packages: %s", err))
 		return
 	}
 
 	processedFiles, failedFiles2, err = deb.ImportPackageFiles(list, packageFiles, forceReplace, verifier, context.PackagePool(),
-		context.CollectionFactory().PackageCollection(), reporter, nil, context.CollectionFactory().ChecksumCollection())
+		collectionFactory.PackageCollection(), reporter, nil, collectionFactory.ChecksumCollection())
 	failedFiles = append(failedFiles, failedFiles2...)
 
 	processedFiles = append(processedFiles, otherFiles...)
@@ -339,7 +323,7 @@ func apiReposPackageFromDir(c *gin.Context) {
 
 	repo.UpdateRefList(deb.NewPackageRefListFromPackageList(list))
 
-	err = context.CollectionFactory().LocalRepoCollection().Update(repo)
+	err = collectionFactory.LocalRepoCollection().Update(repo)
 	if err != nil {
 		c.AbortWithError(500, fmt.Errorf("unable to save: %s", err))
 		return
@@ -412,15 +396,12 @@ func apiReposIncludePackageFromDir(c *gin.Context) {
 		sources = []string{filepath.Join(context.UploadPath(), c.Params.ByName("dir"), c.Params.ByName("file"))}
 	}
 
-	localRepoCollection := context.CollectionFactory().LocalRepoCollection()
-	localRepoCollection.Lock()
-	defer localRepoCollection.Unlock()
-
+	collectionFactory := context.NewCollectionFactory()
 	changesFiles, failedFiles = deb.CollectChangesFiles(sources, reporter)
 	_, failedFiles2, err = deb.ImportChangesFiles(
 		changesFiles, reporter, acceptUnsigned, ignoreSignature, forceReplace, noRemoveFiles, verifier,
-		repoTemplateString, context.Progress(), localRepoCollection, context.CollectionFactory().PackageCollection(),
-		context.PackagePool(), context.CollectionFactory().ChecksumCollection(), nil, query.Parse)
+		repoTemplateString, context.Progress(), collectionFactory.LocalRepoCollection(), collectionFactory.PackageCollection(),
+		context.PackagePool(), collectionFactory.ChecksumCollection(), nil, query.Parse)
 	failedFiles = append(failedFiles, failedFiles2...)
 
 	if err != nil {

--- a/api/repos.go
+++ b/api/repos.go
@@ -4,11 +4,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"text/template"
 
 	"github.com/aptly-dev/aptly/aptly"
 	"github.com/aptly-dev/aptly/database"
 	"github.com/aptly-dev/aptly/deb"
 	"github.com/aptly-dev/aptly/query"
+	"github.com/aptly-dev/aptly/task"
 	"github.com/aptly-dev/aptly/utils"
 	"github.com/gin-gonic/gin"
 )
@@ -112,39 +115,43 @@ func apiReposShow(c *gin.Context) {
 // DELETE /api/repos/:name
 func apiReposDrop(c *gin.Context) {
 	force := c.Request.URL.Query().Get("force") == "1"
+	name := c.Params.ByName("name")
 
 	collectionFactory := context.NewCollectionFactory()
 	collection := collectionFactory.LocalRepoCollection()
 	snapshotCollection := collectionFactory.SnapshotCollection()
 	publishedCollection := collectionFactory.PublishedRepoCollection()
 
-	repo, err := collection.ByName(c.Params.ByName("name"))
+	repo, err := collection.ByName(name)
 	if err != nil {
 		c.AbortWithError(404, err)
 		return
 	}
 
-	published := publishedCollection.ByLocalRepo(repo)
-	if len(published) > 0 {
-		c.AbortWithError(409, fmt.Errorf("unable to drop, local repo is published"))
-		return
-	}
-
-	if !force {
-		snapshots := snapshotCollection.ByLocalRepoSource(repo)
-		if len(snapshots) > 0 {
-			c.AbortWithError(409, fmt.Errorf("unable to drop, local repo has snapshots, use ?force=1 to override"))
-			return
+	resources := []string{string(repo.Key())}
+	taskName := fmt.Sprintf("Delete repo %s", name)
+	task, conflictErr := runTaskInBackground(taskName, resources, func(out *task.Output, detail *task.Detail) error {
+		published := publishedCollection.ByLocalRepo(repo)
+		if len(published) > 0 {
+			return fmt.Errorf("unable to drop, local repo is published")
 		}
-	}
 
-	err = collection.Drop(repo)
-	if err != nil {
-		c.AbortWithError(500, err)
+		if !force {
+			snapshots := snapshotCollection.ByLocalRepoSource(repo)
+			if len(snapshots) > 0 {
+				return fmt.Errorf("unable to drop, local repo has snapshots, use ?force=1 to override")
+			}
+		}
+
+		return collection.Drop(repo)
+	})
+
+	if conflictErr != nil {
+		c.AbortWithError(409, conflictErr)
 		return
 	}
 
-	c.JSON(200, gin.H{})
+	c.JSON(202, task)
 }
 
 // GET /api/repos/:name/packages
@@ -168,7 +175,7 @@ func apiReposPackagesShow(c *gin.Context) {
 }
 
 // Handler for both add and delete
-func apiReposPackagesAddDelete(c *gin.Context, cb func(list *deb.PackageList, p *deb.Package) error) {
+func apiReposPackagesAddDelete(c *gin.Context, taskNamePrefix string, cb func(list *deb.PackageList, p *deb.Package, out *task.Output) error) {
 	var b struct {
 		PackageRefs []string
 	}
@@ -192,54 +199,57 @@ func apiReposPackagesAddDelete(c *gin.Context, cb func(list *deb.PackageList, p 
 		return
 	}
 
-	list, err := deb.NewPackageListFromRefList(repo.RefList(), collectionFactory.PackageCollection(), nil)
-	if err != nil {
-		c.AbortWithError(500, err)
-		return
-	}
-
-	// verify package refs and build package list
-	for _, ref := range b.PackageRefs {
-		var p *deb.Package
-
-		p, err = collectionFactory.PackageCollection().ByKey([]byte(ref))
+	resources := []string{string(repo.Key())}
+	currTask, conflictErr := runTaskInBackground(taskNamePrefix+repo.Name, resources, func(out *task.Output, detail *task.Detail) error {
+		out.Print("Loading packages...\n")
+		list, err := deb.NewPackageListFromRefList(repo.RefList(), collectionFactory.PackageCollection(), nil)
 		if err != nil {
-			if err == database.ErrNotFound {
-				c.AbortWithError(404, fmt.Errorf("package %s: %s", ref, err))
-			} else {
-				c.AbortWithError(500, err)
+			return err
+		}
+
+		// verify package refs and build package list
+		for _, ref := range b.PackageRefs {
+			var p *deb.Package
+
+			p, err = collectionFactory.PackageCollection().ByKey([]byte(ref))
+			if err != nil {
+				if err == database.ErrNotFound {
+					return fmt.Errorf("packages %s: %s", ref, err)
+				}
+
+				return err
 			}
-			return
+			err = cb(list, p, out)
+			if err != nil {
+				return err
+			}
 		}
-		err = cb(list, p)
-		if err != nil {
-			c.AbortWithError(400, err)
-			return
-		}
-	}
 
-	repo.UpdateRefList(deb.NewPackageRefListFromPackageList(list))
+		repo.UpdateRefList(deb.NewPackageRefListFromPackageList(list))
 
-	err = collectionFactory.LocalRepoCollection().Update(repo)
-	if err != nil {
-		c.AbortWithError(500, fmt.Errorf("unable to save: %s", err))
+		return collectionFactory.LocalRepoCollection().Update(repo)
+	})
+
+	if conflictErr != nil {
+		c.AbortWithError(409, conflictErr)
 		return
 	}
 
-	c.JSON(200, repo)
-
+	c.JSON(202, currTask)
 }
 
 // POST /repos/:name/packages
 func apiReposPackagesAdd(c *gin.Context) {
-	apiReposPackagesAddDelete(c, func(list *deb.PackageList, p *deb.Package) error {
+	apiReposPackagesAddDelete(c, "Add packages to repo ", func(list *deb.PackageList, p *deb.Package, out *task.Output) error {
+		out.Printf("Adding package %s\n", p.Name)
 		return list.Add(p)
 	})
 }
 
 // DELETE /repos/:name/packages
 func apiReposPackagesDelete(c *gin.Context) {
-	apiReposPackagesAddDelete(c, func(list *deb.PackageList, p *deb.Package) error {
+	apiReposPackagesAddDelete(c, "Delete packages from repo ", func(list *deb.PackageList, p *deb.Package, out *task.Output) error {
+		out.Printf("Removing package %s\n", p.Name)
 		list.Remove(p)
 		return nil
 	})
@@ -260,6 +270,7 @@ func apiReposPackageFromDir(c *gin.Context) {
 		return
 	}
 
+	dirParam := c.Params.ByName("dir")
 	fileParam := c.Params.ByName("file")
 	if fileParam != "" && !verifyPath(fileParam) {
 		c.AbortWithError(400, fmt.Errorf("wrong file"))
@@ -269,7 +280,8 @@ func apiReposPackageFromDir(c *gin.Context) {
 	collectionFactory := context.NewCollectionFactory()
 	collection := collectionFactory.LocalRepoCollection()
 
-	repo, err := collection.ByName(c.Params.ByName("name"))
+	name := c.Params.ByName("name")
+	repo, err := collection.ByName(name)
 	if err != nil {
 		c.AbortWithError(404, err)
 		return
@@ -281,76 +293,96 @@ func apiReposPackageFromDir(c *gin.Context) {
 		return
 	}
 
-	verifier := context.GetVerifier()
-
-	var (
-		sources                      []string
-		packageFiles, failedFiles    []string
-		otherFiles                   []string
-		processedFiles, failedFiles2 []string
-		reporter                     = &aptly.RecordingResultReporter{
-			Warnings:     []string{},
-			AddedLines:   []string{},
-			RemovedLines: []string{},
-		}
-		list *deb.PackageList
-	)
-
+	var taskName string
+	var sources []string
 	if fileParam == "" {
-		sources = []string{filepath.Join(context.UploadPath(), c.Params.ByName("dir"))}
+		taskName = fmt.Sprintf("Add packages from dir %s to repo %s", dirParam, name)
+		sources = []string{filepath.Join(context.UploadPath(), dirParam)}
 	} else {
-		sources = []string{filepath.Join(context.UploadPath(), c.Params.ByName("dir"), c.Params.ByName("file"))}
+		sources = []string{filepath.Join(context.UploadPath(), dirParam, fileParam)}
+		taskName = fmt.Sprintf("Add package %s from dir %s to repo %s", fileParam, dirParam, name)
 	}
 
-	packageFiles, otherFiles, failedFiles = deb.CollectPackageFiles(sources, reporter)
+	resources := []string{string(repo.Key())}
+	resources = append(resources, sources...)
+	currTask, conflictErr := runTaskInBackground(taskName, resources, func(out *task.Output, detail *task.Detail) error {
+		verifier := context.GetVerifier()
 
-	list, err = deb.NewPackageListFromRefList(repo.RefList(), collectionFactory.PackageCollection(), nil)
-	if err != nil {
-		c.AbortWithError(500, fmt.Errorf("unable to load packages: %s", err))
-		return
-	}
-
-	processedFiles, failedFiles2, err = deb.ImportPackageFiles(list, packageFiles, forceReplace, verifier, context.PackagePool(),
-		collectionFactory.PackageCollection(), reporter, nil, collectionFactory.ChecksumCollection())
-	failedFiles = append(failedFiles, failedFiles2...)
-
-	processedFiles = append(processedFiles, otherFiles...)
-
-	if err != nil {
-		c.AbortWithError(500, fmt.Errorf("unable to import package files: %s", err))
-		return
-	}
-
-	repo.UpdateRefList(deb.NewPackageRefListFromPackageList(list))
-
-	err = collectionFactory.LocalRepoCollection().Update(repo)
-	if err != nil {
-		c.AbortWithError(500, fmt.Errorf("unable to save: %s", err))
-		return
-	}
-
-	if !noRemove {
-		processedFiles = utils.StrSliceDeduplicate(processedFiles)
-
-		for _, file := range processedFiles {
-			err := os.Remove(file)
-			if err != nil {
-				reporter.Warning("unable to remove file %s: %s", file, err)
+		var (
+			packageFiles, failedFiles    []string
+			otherFiles                   []string
+			processedFiles, failedFiles2 []string
+			reporter                     = &aptly.RecordingResultReporter{
+				Warnings:     []string{},
+				AddedLines:   []string{},
+				RemovedLines: []string{},
 			}
+			list *deb.PackageList
+		)
+
+		packageFiles, otherFiles, failedFiles = deb.CollectPackageFiles(sources, reporter)
+
+		list, err := deb.NewPackageListFromRefList(repo.RefList(), collectionFactory.PackageCollection(), nil)
+		if err != nil {
+			return fmt.Errorf("unable to load packages: %s", err)
 		}
 
-		// atempt to remove dir, if it fails, that's fine: probably it's not empty
-		os.Remove(filepath.Join(context.UploadPath(), c.Params.ByName("dir")))
-	}
+		processedFiles, failedFiles2, err = deb.ImportPackageFiles(list, packageFiles, forceReplace, verifier, context.PackagePool(),
+			collectionFactory.PackageCollection(), reporter, nil, collectionFactory.ChecksumCollection())
+		failedFiles = append(failedFiles, failedFiles2...)
+		processedFiles = append(processedFiles, otherFiles...)
 
-	if failedFiles == nil {
-		failedFiles = []string{}
-	}
+		if err != nil {
+			return fmt.Errorf("unable to import package files: %s", err)
+		}
 
-	c.JSON(200, gin.H{
-		"Report":      reporter,
-		"FailedFiles": failedFiles,
+		repo.UpdateRefList(deb.NewPackageRefListFromPackageList(list))
+
+		err = collectionFactory.LocalRepoCollection().Update(repo)
+		if err != nil {
+			return fmt.Errorf("unable to save: %s", err)
+		}
+
+		if !noRemove {
+			processedFiles = utils.StrSliceDeduplicate(processedFiles)
+
+			for _, file := range processedFiles {
+				err := os.Remove(file)
+				if err != nil {
+					reporter.Warning("unable to remove file %s: %s", file, err)
+				}
+			}
+
+			// atempt to remove dir, if it fails, that's fine: probably it's not empty
+			os.Remove(filepath.Join(context.UploadPath(), dirParam))
+		}
+
+		if failedFiles == nil {
+			failedFiles = []string{}
+		}
+
+		if len(reporter.AddedLines) > 0 {
+			out.Printf("Added: %s\n", strings.Join(reporter.AddedLines, ", "))
+		}
+		if len(reporter.RemovedLines) > 0 {
+			out.Printf("Removed: %s\n", strings.Join(reporter.RemovedLines, ", "))
+		}
+		if len(reporter.Warnings) > 0 {
+			out.Printf("Warnings: %s\n", strings.Join(reporter.Warnings, ", "))
+		}
+		if len(failedFiles) > 0 {
+			out.Printf("Failed files: %s\n", strings.Join(failedFiles, ", "))
+		}
+
+		return nil
 	})
+
+	if conflictErr != nil {
+		c.AbortWithError(409, conflictErr)
+		return
+	}
+
+	c.JSON(202, currTask)
 }
 
 // POST /repos/:name/include/:dir/:file
@@ -367,59 +399,103 @@ func apiReposIncludePackageFromDir(c *gin.Context) {
 	ignoreSignature := c.Request.URL.Query().Get("ignoreSignature") == "1"
 
 	repoTemplateString := c.Params.ByName("name")
+	collectionFactory := context.NewCollectionFactory()
 
 	if !verifyDir(c) {
 		return
 	}
 
+	var sources []string
+	var taskName string
+	dirParam := c.Params.ByName("dir")
 	fileParam := c.Params.ByName("file")
 	if fileParam != "" && !verifyPath(fileParam) {
 		c.AbortWithError(400, fmt.Errorf("wrong file"))
 		return
 	}
 
-	var (
-		err                       error
-		verifier                  = context.GetVerifier()
-		sources, changesFiles     []string
-		failedFiles, failedFiles2 []string
-		reporter                  = &aptly.RecordingResultReporter{
-			Warnings:     []string{},
-			AddedLines:   []string{},
-			RemovedLines: []string{},
-		}
-	)
-
 	if fileParam == "" {
-		sources = []string{filepath.Join(context.UploadPath(), c.Params.ByName("dir"))}
+		taskName = fmt.Sprintf("Include packages from changes files in dir %s to repo matching template %s", dirParam, repoTemplateString)
+		sources = []string{filepath.Join(context.UploadPath(), dirParam)}
 	} else {
-		sources = []string{filepath.Join(context.UploadPath(), c.Params.ByName("dir"), c.Params.ByName("file"))}
+		taskName = fmt.Sprintf("Include packages from changes file %s from dir %s to repo matching template %s", fileParam, dirParam, repoTemplateString)
+		sources = []string{filepath.Join(context.UploadPath(), dirParam, fileParam)}
 	}
 
-	collectionFactory := context.NewCollectionFactory()
-	changesFiles, failedFiles = deb.CollectChangesFiles(sources, reporter)
-	_, failedFiles2, err = deb.ImportChangesFiles(
-		changesFiles, reporter, acceptUnsigned, ignoreSignature, forceReplace, noRemoveFiles, verifier,
-		repoTemplateString, context.Progress(), collectionFactory.LocalRepoCollection(), collectionFactory.PackageCollection(),
-		context.PackagePool(), collectionFactory.ChecksumCollection(), nil, query.Parse)
-	failedFiles = append(failedFiles, failedFiles2...)
-
+	repoTemplate, err := template.New("repo").Parse(repoTemplateString)
 	if err != nil {
-		c.AbortWithError(500, fmt.Errorf("unable to import changes files: %s", err))
+		c.AbortWithError(400, fmt.Errorf("error parsing repo template: %s", err))
 		return
 	}
 
-	if !noRemoveFiles {
-		// atempt to remove dir, if it fails, that's fine: probably it's not empty
-		os.Remove(filepath.Join(context.UploadPath(), c.Params.ByName("dir")))
-	}
+	var resources []string
+	if len(repoTemplate.Tree.Root.Nodes) > 1 {
+		resources = append(resources, task.AllLocalReposResourcesKey)
+	} else {
+		// repo template string is simple text so only use resource key of specific repository
+		repo, err := collectionFactory.LocalRepoCollection().ByName(repoTemplateString)
+		if err != nil {
+			c.AbortWithError(404, err)
+			return
+		}
 
-	if failedFiles == nil {
-		failedFiles = []string{}
+		resources = append(resources, string(repo.Key()))
 	}
+	resources = append(resources, sources...)
 
-	c.JSON(200, gin.H{
-		"Report":      reporter,
-		"FailedFiles": failedFiles,
+	currTask, conflictErr := runTaskInBackground(taskName, resources, func(out *task.Output, detail *task.Detail) error {
+		var (
+			err                       error
+			verifier                  = context.GetVerifier()
+			changesFiles              []string
+			failedFiles, failedFiles2 []string
+			reporter                  = &aptly.RecordingResultReporter{
+				Warnings:     []string{},
+				AddedLines:   []string{},
+				RemovedLines: []string{},
+			}
+		)
+
+		changesFiles, failedFiles = deb.CollectChangesFiles(sources, reporter)
+		_, failedFiles2, err = deb.ImportChangesFiles(
+			changesFiles, reporter, acceptUnsigned, ignoreSignature, forceReplace, noRemoveFiles, verifier,
+			repoTemplate, context.Progress(), collectionFactory.LocalRepoCollection(), collectionFactory.PackageCollection(),
+			context.PackagePool(), collectionFactory.ChecksumCollection(), nil, query.Parse)
+		failedFiles = append(failedFiles, failedFiles2...)
+
+		if err != nil {
+			return fmt.Errorf("unable to import changes files: %s", err)
+		}
+
+		if !noRemoveFiles {
+			// atempt to remove dir, if it fails, that's fine: probably it's not empty
+			os.Remove(filepath.Join(context.UploadPath(), dirParam))
+		}
+
+		if failedFiles == nil {
+			failedFiles = []string{}
+		}
+
+		if len(reporter.AddedLines) > 0 {
+			out.Printf("Added: %s\n", strings.Join(reporter.AddedLines, ", "))
+		}
+		if len(reporter.RemovedLines) > 0 {
+			out.Printf("Removed: %s\n", strings.Join(reporter.RemovedLines, ", "))
+		}
+		if len(reporter.Warnings) > 0 {
+			out.Printf("Warnings: %s\n", strings.Join(reporter.Warnings, ", "))
+		}
+		if len(failedFiles) > 0 {
+			out.Printf("Failed files: %s\n", strings.Join(failedFiles, ", "))
+		}
+
+		return nil
 	})
+
+	if conflictErr != nil {
+		c.AbortWithError(409, conflictErr)
+		return
+	}
+
+	c.JSON(202, currTask)
 }

--- a/api/router.go
+++ b/api/router.go
@@ -88,6 +88,10 @@ func Router(c *ctx.AptlyContext) http.Handler {
 	}
 
 	{
+		root.POST("/gpg/key", apiGPGAddKey)
+	}
+
+	{
 		root.GET("/files", apiFilesListDirs)
 		root.POST("/files/:dir", apiFilesUpload)
 		root.GET("/files/:dir", apiFilesListFiles)

--- a/api/router.go
+++ b/api/router.go
@@ -46,9 +46,6 @@ func Router(c *ctx.AptlyContext) http.Handler {
 
 			c.Next()
 		})
-
-	} else {
-		go cacheFlusher()
 	}
 
 	root := router.Group("/api")

--- a/api/router.go
+++ b/api/router.go
@@ -79,6 +79,15 @@ func Router(c *ctx.AptlyContext) http.Handler {
 	}
 
 	{
+		root.GET("/mirrors", apiMirrorsList)
+		root.GET("/mirrors/:name", apiMirrorsShow)
+		root.GET("/mirrors/:name/packages", apiMirrorsPackages)
+		root.POST("/mirrors", apiMirrorsCreate)
+		root.PUT("/mirrors/:name", apiMirrorsUpdate)
+		root.DELETE("/mirrors/:name", apiMirrorsDrop)
+	}
+
+	{
 		root.GET("/files", apiFilesListDirs)
 		root.POST("/files/:dir", apiFilesUpload)
 		root.GET("/files/:dir", apiFilesListFiles)

--- a/api/router.go
+++ b/api/router.go
@@ -20,15 +20,15 @@ func Router(c *ctx.AptlyContext) http.Handler {
 		// We use a goroutine to count the number of
 		// concurrent requests. When no more requests are
 		// running, we close the database to free the lock.
-		requests := make(chan dbRequest)
+		dbRequests = make(chan dbRequest)
 
-		go acquireDatabase(requests)
+		go acquireDatabase()
 
 		router.Use(func(c *gin.Context) {
 			var err error
 
 			errCh := make(chan error)
-			requests <- dbRequest{acquiredb, errCh}
+			dbRequests <- dbRequest{acquiredb, errCh}
 
 			err = <-errCh
 			if err != nil {
@@ -37,7 +37,7 @@ func Router(c *ctx.AptlyContext) http.Handler {
 			}
 
 			defer func() {
-				requests <- dbRequest{releasedb, errCh}
+				dbRequests <- dbRequest{releasedb, errCh}
 				err = <-errCh
 				if err != nil {
 					c.AbortWithError(500, err)
@@ -110,6 +110,16 @@ func Router(c *ctx.AptlyContext) http.Handler {
 
 	{
 		root.GET("/graph.:ext", apiGraph)
+	}
+	{
+		root.GET("/tasks", apiTasksList)
+		root.POST("/tasks-clear", apiTasksClear)
+		root.GET("/tasks-wait", apiTasksWait)
+		root.GET("/tasks/:id/wait", apiTasksWaitForTaskByID)
+		root.GET("/tasks/:id/output", apiTasksOutputShow)
+		root.GET("/tasks/:id/detail", apiTasksDetailShow)
+		root.GET("/tasks/:id", apiTasksShow)
+		root.DELETE("/tasks/:id", apiTasksDelete)
 	}
 
 	return router

--- a/api/task.go
+++ b/api/task.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"strconv"
+
+	"github.com/aptly-dev/aptly/task"
+	"github.com/gin-gonic/gin"
+)
+
+// GET /tasks
+func apiTasksList(c *gin.Context) {
+	list := context.TaskList()
+	c.JSON(200, list.GetTasks())
+}
+
+// POST /tasks/clear
+func apiTasksClear(c *gin.Context) {
+	list := context.TaskList()
+	list.Clear()
+	c.JSON(200, gin.H{})
+}
+
+// GET /tasks-wait
+func apiTasksWait(c *gin.Context) {
+	list := context.TaskList()
+	list.Wait()
+	c.JSON(200, gin.H{})
+}
+
+// GET /tasks/:id/wait
+func apiTasksWaitForTaskByID(c *gin.Context) {
+	list := context.TaskList()
+	id, err := strconv.ParseInt(c.Params.ByName("id"), 10, 0)
+	if err != nil {
+		c.AbortWithError(500, err)
+		return
+	}
+
+	task, err := list.WaitForTaskByID(int(id))
+	if err != nil {
+		c.AbortWithError(400, err)
+		return
+	}
+
+	c.JSON(200, task)
+}
+
+// GET /tasks/:id
+func apiTasksShow(c *gin.Context) {
+	list := context.TaskList()
+	id, err := strconv.ParseInt(c.Params.ByName("id"), 10, 0)
+	if err != nil {
+		c.AbortWithError(500, err)
+		return
+	}
+
+	var task task.Task
+	task, err = list.GetTaskByID(int(id))
+	if err != nil {
+		c.AbortWithError(404, err)
+		return
+	}
+
+	c.JSON(200, task)
+}
+
+// GET /tasks/:id/output
+func apiTasksOutputShow(c *gin.Context) {
+	list := context.TaskList()
+	id, err := strconv.ParseInt(c.Params.ByName("id"), 10, 0)
+	if err != nil {
+		c.AbortWithError(500, err)
+		return
+	}
+
+	var output string
+	output, err = list.GetTaskOutputByID(int(id))
+	if err != nil {
+		c.AbortWithError(404, err)
+		return
+	}
+
+	c.JSON(200, output)
+}
+
+// GET /tasks/:id/detail
+func apiTasksDetailShow(c *gin.Context) {
+	list := context.TaskList()
+	id, err := strconv.ParseInt(c.Params.ByName("id"), 10, 0)
+	if err != nil {
+		c.AbortWithError(500, err)
+		return
+	}
+
+	var detail interface{}
+	detail, err = list.GetTaskDetailByID(int(id))
+	if err != nil {
+		c.AbortWithError(404, err)
+		return
+	}
+
+	c.JSON(200, detail)
+}
+
+// DELETE /tasks/:id
+func apiTasksDelete(c *gin.Context) {
+	list := context.TaskList()
+	id, err := strconv.ParseInt(c.Params.ByName("id"), 10, 0)
+	if err != nil {
+		c.AbortWithError(500, err)
+		return
+	}
+
+	var delTask task.Task
+	delTask, err = list.DeleteTaskByID(int(id))
+	if err != nil {
+		c.AbortWithError(400, err)
+		return
+	}
+
+	c.JSON(200, delTask)
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -21,14 +21,14 @@ const (
 )
 
 // ListPackagesRefList shows list of packages in PackageRefList
-func ListPackagesRefList(reflist *deb.PackageRefList) (err error) {
+func ListPackagesRefList(reflist *deb.PackageRefList, collectionFactory *deb.CollectionFactory) (err error) {
 	fmt.Printf("Packages:\n")
 
 	if reflist == nil {
 		return
 	}
 
-	list, err := deb.NewPackageListFromRefList(reflist, context.CollectionFactory().PackageCollection(), context.Progress())
+	list, err := deb.NewPackageListFromRefList(reflist, collectionFactory.PackageCollection(), context.Progress())
 	if err != nil {
 		return fmt.Errorf("unable to load packages: %s", err)
 	}

--- a/cmd/db_cleanup.go
+++ b/cmd/db_cleanup.go
@@ -21,6 +21,7 @@ func aptlyDbCleanup(cmd *commander.Command, args []string) error {
 
 	verbose := context.Flags().Lookup("verbose").Value.Get().(bool)
 	dryRun := context.Flags().Lookup("dry-run").Value.Get().(bool)
+	collectionFactory := context.NewCollectionFactory()
 
 	// collect information about references packages...
 	existingPackageRefs := deb.NewPackageRefList()
@@ -32,12 +33,12 @@ func aptlyDbCleanup(cmd *commander.Command, args []string) error {
 	if verbose {
 		context.Progress().ColoredPrintf("@{y}Loading mirrors:@|")
 	}
-	err = context.CollectionFactory().RemoteRepoCollection().ForEach(func(repo *deb.RemoteRepo) error {
+	err = collectionFactory.RemoteRepoCollection().ForEach(func(repo *deb.RemoteRepo) error {
 		if verbose {
 			context.Progress().ColoredPrintf("- @{g}%s@|", repo.Name)
 		}
 
-		e := context.CollectionFactory().RemoteRepoCollection().LoadComplete(repo)
+		e := collectionFactory.RemoteRepoCollection().LoadComplete(repo)
 		if e != nil {
 			return e
 		}
@@ -62,12 +63,12 @@ func aptlyDbCleanup(cmd *commander.Command, args []string) error {
 	if verbose {
 		context.Progress().ColoredPrintf("@{y}Loading local repos:@|")
 	}
-	err = context.CollectionFactory().LocalRepoCollection().ForEach(func(repo *deb.LocalRepo) error {
+	err = collectionFactory.LocalRepoCollection().ForEach(func(repo *deb.LocalRepo) error {
 		if verbose {
 			context.Progress().ColoredPrintf("- @{g}%s@|", repo.Name)
 		}
 
-		e := context.CollectionFactory().LocalRepoCollection().LoadComplete(repo)
+		e := collectionFactory.LocalRepoCollection().LoadComplete(repo)
 		if e != nil {
 			return e
 		}
@@ -93,12 +94,12 @@ func aptlyDbCleanup(cmd *commander.Command, args []string) error {
 	if verbose {
 		context.Progress().ColoredPrintf("@{y}Loading snapshots:@|")
 	}
-	err = context.CollectionFactory().SnapshotCollection().ForEach(func(snapshot *deb.Snapshot) error {
+	err = collectionFactory.SnapshotCollection().ForEach(func(snapshot *deb.Snapshot) error {
 		if verbose {
 			context.Progress().ColoredPrintf("- @{g}%s@|", snapshot.Name)
 		}
 
-		e := context.CollectionFactory().SnapshotCollection().LoadComplete(snapshot)
+		e := collectionFactory.SnapshotCollection().LoadComplete(snapshot)
 		if e != nil {
 			return e
 		}
@@ -121,14 +122,14 @@ func aptlyDbCleanup(cmd *commander.Command, args []string) error {
 	if verbose {
 		context.Progress().ColoredPrintf("@{y}Loading published repositories:@|")
 	}
-	err = context.CollectionFactory().PublishedRepoCollection().ForEach(func(published *deb.PublishedRepo) error {
+	err = collectionFactory.PublishedRepoCollection().ForEach(func(published *deb.PublishedRepo) error {
 		if verbose {
 			context.Progress().ColoredPrintf("- @{g}%s:%s/%s{|}", published.Storage, published.Prefix, published.Distribution)
 		}
 		if published.SourceKind != deb.SourceLocalRepo {
 			return nil
 		}
-		e := context.CollectionFactory().PublishedRepoCollection().LoadComplete(published, context.CollectionFactory())
+		e := collectionFactory.PublishedRepoCollection().LoadComplete(published, collectionFactory)
 		if e != nil {
 			return e
 		}
@@ -152,7 +153,7 @@ func aptlyDbCleanup(cmd *commander.Command, args []string) error {
 
 	// ... and compare it to the list of all packages
 	context.Progress().ColoredPrintf("@{w!}Loading list of all packages...@|")
-	allPackageRefs := context.CollectionFactory().PackageCollection().AllPackageRefs()
+	allPackageRefs := collectionFactory.PackageCollection().AllPackageRefs()
 
 	toDelete := allPackageRefs.Subtract(existingPackageRefs)
 
@@ -177,7 +178,7 @@ func aptlyDbCleanup(cmd *commander.Command, args []string) error {
 		if !dryRun {
 			db.StartBatch()
 			err = toDelete.ForEach(func(ref []byte) error {
-				return context.CollectionFactory().PackageCollection().DeleteByKey(ref)
+				return collectionFactory.PackageCollection().DeleteByKey(ref)
 			})
 			if err != nil {
 				return err
@@ -198,7 +199,7 @@ func aptlyDbCleanup(cmd *commander.Command, args []string) error {
 	context.Progress().InitBar(int64(existingPackageRefs.Len()), false)
 
 	err = existingPackageRefs.ForEach(func(key []byte) error {
-		pkg, err2 := context.CollectionFactory().PackageCollection().ByKey(key)
+		pkg, err2 := collectionFactory.PackageCollection().ByKey(key)
 		if err2 != nil {
 			tail := ""
 			if verbose {

--- a/cmd/db_cleanup.go
+++ b/cmd/db_cleanup.go
@@ -176,15 +176,13 @@ func aptlyDbCleanup(cmd *commander.Command, args []string) error {
 		}
 
 		if !dryRun {
-			db.StartBatch()
-			err = toDelete.ForEach(func(ref []byte) error {
-				return collectionFactory.PackageCollection().DeleteByKey(ref)
+			batch := db.StartBatch()
+			toDelete.ForEach(func(ref []byte) error {
+				collectionFactory.PackageCollection().DeleteByKey(ref, batch)
+				return nil
 			})
-			if err != nil {
-				return err
-			}
 
-			err = db.FinishBatch()
+			err = db.FinishBatch(batch)
 			if err != nil {
 				return fmt.Errorf("unable to write to DB: %s", err)
 			}

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -28,8 +28,8 @@ func aptlyGraph(cmd *commander.Command, args []string) error {
 	layout := context.Flags().Lookup("layout").Value.String()
 
 	fmt.Printf("Generating graph...\n")
-	graph, err := deb.BuildGraph(context.CollectionFactory(), layout)
-
+	collectionFactory := context.NewCollectionFactory()
+	graph, err := deb.BuildGraph(collectionFactory, layout)
 	if err != nil {
 		return err
 	}

--- a/cmd/mirror_create.go
+++ b/cmd/mirror_create.go
@@ -63,7 +63,8 @@ func aptlyMirrorCreate(cmd *commander.Command, args []string) error {
 		return fmt.Errorf("unable to fetch mirror: %s", err)
 	}
 
-	err = context.CollectionFactory().RemoteRepoCollection().Add(repo)
+	collectionFactory := context.NewCollectionFactory()
+	err = collectionFactory.RemoteRepoCollection().Add(repo)
 	if err != nil {
 		return fmt.Errorf("unable to add mirror: %s", err)
 	}

--- a/cmd/mirror_drop.go
+++ b/cmd/mirror_drop.go
@@ -15,8 +15,9 @@ func aptlyMirrorDrop(cmd *commander.Command, args []string) error {
 	}
 
 	name := args[0]
+	collectionFactory := context.NewCollectionFactory()
 
-	repo, err := context.CollectionFactory().RemoteRepoCollection().ByName(name)
+	repo, err := collectionFactory.RemoteRepoCollection().ByName(name)
 	if err != nil {
 		return fmt.Errorf("unable to drop: %s", err)
 	}
@@ -28,7 +29,7 @@ func aptlyMirrorDrop(cmd *commander.Command, args []string) error {
 
 	force := context.Flags().Lookup("force").Value.Get().(bool)
 	if !force {
-		snapshots := context.CollectionFactory().SnapshotCollection().ByRemoteRepoSource(repo)
+		snapshots := collectionFactory.SnapshotCollection().ByRemoteRepoSource(repo)
 
 		if len(snapshots) > 0 {
 			fmt.Printf("Mirror `%s` was used to create following snapshots:\n", repo.Name)
@@ -40,7 +41,7 @@ func aptlyMirrorDrop(cmd *commander.Command, args []string) error {
 		}
 	}
 
-	err = context.CollectionFactory().RemoteRepoCollection().Drop(repo)
+	err = collectionFactory.RemoteRepoCollection().Drop(repo)
 	if err != nil {
 		return fmt.Errorf("unable to drop: %s", err)
 	}

--- a/cmd/mirror_edit.go
+++ b/cmd/mirror_edit.go
@@ -16,7 +16,8 @@ func aptlyMirrorEdit(cmd *commander.Command, args []string) error {
 		return commander.ErrCommandError
 	}
 
-	repo, err := context.CollectionFactory().RemoteRepoCollection().ByName(args[0])
+	collectionFactory := context.NewCollectionFactory()
+	repo, err := collectionFactory.RemoteRepoCollection().ByName(args[0])
 	if err != nil {
 		return fmt.Errorf("unable to edit: %s", err)
 	}
@@ -72,7 +73,7 @@ func aptlyMirrorEdit(cmd *commander.Command, args []string) error {
 		}
 	}
 
-	err = context.CollectionFactory().RemoteRepoCollection().Update(repo)
+	err = collectionFactory.RemoteRepoCollection().Update(repo)
 	if err != nil {
 		return fmt.Errorf("unable to edit: %s", err)
 	}

--- a/cmd/mirror_list.go
+++ b/cmd/mirror_list.go
@@ -16,10 +16,11 @@ func aptlyMirrorList(cmd *commander.Command, args []string) error {
 	}
 
 	raw := cmd.Flag.Lookup("raw").Value.Get().(bool)
+	collectionFactory := context.NewCollectionFactory()
 
-	repos := make([]string, context.CollectionFactory().RemoteRepoCollection().Len())
+	repos := make([]string, collectionFactory.RemoteRepoCollection().Len())
 	i := 0
-	context.CollectionFactory().RemoteRepoCollection().ForEach(func(repo *deb.RemoteRepo) error {
+	collectionFactory.RemoteRepoCollection().ForEach(func(repo *deb.RemoteRepo) error {
 		if raw {
 			repos[i] = repo.Name
 		} else {

--- a/cmd/mirror_rename.go
+++ b/cmd/mirror_rename.go
@@ -20,7 +20,8 @@ func aptlyMirrorRename(cmd *commander.Command, args []string) error {
 
 	oldName, newName := args[0], args[1]
 
-	repo, err = context.CollectionFactory().RemoteRepoCollection().ByName(oldName)
+	collectionFactory := context.NewCollectionFactory()
+	repo, err = collectionFactory.RemoteRepoCollection().ByName(oldName)
 	if err != nil {
 		return fmt.Errorf("unable to rename: %s", err)
 	}
@@ -30,13 +31,13 @@ func aptlyMirrorRename(cmd *commander.Command, args []string) error {
 		return fmt.Errorf("unable to rename: %s", err)
 	}
 
-	_, err = context.CollectionFactory().RemoteRepoCollection().ByName(newName)
+	_, err = collectionFactory.RemoteRepoCollection().ByName(newName)
 	if err == nil {
 		return fmt.Errorf("unable to rename: mirror %s already exists", newName)
 	}
 
 	repo.Name = newName
-	err = context.CollectionFactory().RemoteRepoCollection().Update(repo)
+	err = collectionFactory.RemoteRepoCollection().Update(repo)
 	if err != nil {
 		return fmt.Errorf("unable to rename: %s", err)
 	}

--- a/cmd/mirror_show.go
+++ b/cmd/mirror_show.go
@@ -19,12 +19,13 @@ func aptlyMirrorShow(cmd *commander.Command, args []string) error {
 
 	name := args[0]
 
-	repo, err := context.CollectionFactory().RemoteRepoCollection().ByName(name)
+	collectionFactory := context.NewCollectionFactory()
+	repo, err := collectionFactory.RemoteRepoCollection().ByName(name)
 	if err != nil {
 		return fmt.Errorf("unable to show: %s", err)
 	}
 
-	err = context.CollectionFactory().RemoteRepoCollection().LoadComplete(repo)
+	err = collectionFactory.RemoteRepoCollection().LoadComplete(repo)
 	if err != nil {
 		return fmt.Errorf("unable to show: %s", err)
 	}
@@ -72,7 +73,7 @@ func aptlyMirrorShow(cmd *commander.Command, args []string) error {
 		if repo.LastDownloadDate.IsZero() {
 			fmt.Printf("Unable to show package list, mirror hasn't been downloaded yet.\n")
 		} else {
-			ListPackagesRefList(repo.RefList())
+			ListPackagesRefList(repo.RefList(), collectionFactory)
 		}
 	}
 

--- a/cmd/package_search.go
+++ b/cmd/package_search.go
@@ -29,7 +29,8 @@ func aptlyPackageSearch(cmd *commander.Command, args []string) error {
 		q = &deb.MatchAllQuery{}
 	}
 
-	result := q.Query(context.CollectionFactory().PackageCollection())
+	collectionFactory := context.NewCollectionFactory()
+	result := q.Query(collectionFactory.PackageCollection())
 	if result.Len() == 0 {
 		return fmt.Errorf("no results")
 	}

--- a/cmd/package_show.go
+++ b/cmd/package_show.go
@@ -12,9 +12,9 @@ import (
 	"github.com/smira/flag"
 )
 
-func printReferencesTo(p *deb.Package) (err error) {
-	err = context.CollectionFactory().RemoteRepoCollection().ForEach(func(repo *deb.RemoteRepo) error {
-		e := context.CollectionFactory().RemoteRepoCollection().LoadComplete(repo)
+func printReferencesTo(p *deb.Package, collectionFactory *deb.CollectionFactory) (err error) {
+	err = collectionFactory.RemoteRepoCollection().ForEach(func(repo *deb.RemoteRepo) error {
+		e := collectionFactory.RemoteRepoCollection().LoadComplete(repo)
 		if e != nil {
 			return e
 		}
@@ -29,8 +29,8 @@ func printReferencesTo(p *deb.Package) (err error) {
 		return err
 	}
 
-	err = context.CollectionFactory().LocalRepoCollection().ForEach(func(repo *deb.LocalRepo) error {
-		e := context.CollectionFactory().LocalRepoCollection().LoadComplete(repo)
+	err = collectionFactory.LocalRepoCollection().ForEach(func(repo *deb.LocalRepo) error {
+		e := collectionFactory.LocalRepoCollection().LoadComplete(repo)
 		if e != nil {
 			return e
 		}
@@ -45,8 +45,8 @@ func printReferencesTo(p *deb.Package) (err error) {
 		return err
 	}
 
-	err = context.CollectionFactory().SnapshotCollection().ForEach(func(snapshot *deb.Snapshot) error {
-		e := context.CollectionFactory().SnapshotCollection().LoadComplete(snapshot)
+	err = collectionFactory.SnapshotCollection().ForEach(func(snapshot *deb.Snapshot) error {
+		e := collectionFactory.SnapshotCollection().LoadComplete(snapshot)
 		if e != nil {
 			return e
 		}
@@ -76,7 +76,8 @@ func aptlyPackageShow(cmd *commander.Command, args []string) error {
 
 	w := bufio.NewWriter(os.Stdout)
 
-	result := q.Query(context.CollectionFactory().PackageCollection())
+	collectionFactory := context.NewCollectionFactory()
+	result := q.Query(collectionFactory.PackageCollection())
 
 	err = result.ForEach(func(p *deb.Package) error {
 		p.Stanza().WriteTo(w, p.IsSource, false)
@@ -104,7 +105,7 @@ func aptlyPackageShow(cmd *commander.Command, args []string) error {
 
 		if withReferences {
 			fmt.Printf("References to package:\n")
-			printReferencesTo(p)
+			printReferencesTo(p, collectionFactory)
 			fmt.Printf("\n")
 		}
 

--- a/cmd/publish_drop.go
+++ b/cmd/publish_drop.go
@@ -23,8 +23,9 @@ func aptlyPublishDrop(cmd *commander.Command, args []string) error {
 
 	storage, prefix := deb.ParsePrefix(param)
 
-	err = context.CollectionFactory().PublishedRepoCollection().Remove(context, storage, prefix, distribution,
-		context.CollectionFactory(), context.Progress(),
+	collectionFactory := context.NewCollectionFactory()
+	err = collectionFactory.PublishedRepoCollection().Remove(context, storage, prefix, distribution,
+		collectionFactory, context.Progress(),
 		context.Flags().Lookup("force-drop").Value.Get().(bool),
 		context.Flags().Lookup("skip-cleanup").Value.Get().(bool))
 	if err != nil {

--- a/cmd/publish_list.go
+++ b/cmd/publish_list.go
@@ -17,10 +17,11 @@ func aptlyPublishList(cmd *commander.Command, args []string) error {
 
 	raw := cmd.Flag.Lookup("raw").Value.Get().(bool)
 
-	published := make([]string, 0, context.CollectionFactory().PublishedRepoCollection().Len())
+	collectionFactory := context.NewCollectionFactory()
+	published := make([]string, 0, collectionFactory.PublishedRepoCollection().Len())
 
-	err = context.CollectionFactory().PublishedRepoCollection().ForEach(func(repo *deb.PublishedRepo) error {
-		e := context.CollectionFactory().PublishedRepoCollection().LoadComplete(repo, context.CollectionFactory())
+	err = collectionFactory.PublishedRepoCollection().ForEach(func(repo *deb.PublishedRepo) error {
+		e := collectionFactory.PublishedRepoCollection().LoadComplete(repo, collectionFactory)
 		if e != nil {
 			return e
 		}

--- a/cmd/publish_show.go
+++ b/cmd/publish_show.go
@@ -24,7 +24,8 @@ func aptlyPublishShow(cmd *commander.Command, args []string) error {
 
 	storage, prefix := deb.ParsePrefix(param)
 
-	repo, err := context.CollectionFactory().PublishedRepoCollection().ByStoragePrefixDistribution(storage, prefix, distribution)
+	collectionFactory := context.NewCollectionFactory()
+	repo, err := collectionFactory.PublishedRepoCollection().ByStoragePrefixDistribution(storage, prefix, distribution)
 	if err != nil {
 		return fmt.Errorf("unable to show: %s", err)
 	}
@@ -42,13 +43,13 @@ func aptlyPublishShow(cmd *commander.Command, args []string) error {
 	for component, sourceID := range repo.Sources {
 		var name string
 		if repo.SourceKind == deb.SourceSnapshot {
-			source, e := context.CollectionFactory().SnapshotCollection().ByUUID(sourceID)
+			source, e := collectionFactory.SnapshotCollection().ByUUID(sourceID)
 			if e != nil {
 				continue
 			}
 			name = source.Name
 		} else if repo.SourceKind == deb.SourceLocalRepo {
-			source, e := context.CollectionFactory().LocalRepoCollection().ByUUID(sourceID)
+			source, e := collectionFactory.LocalRepoCollection().ByUUID(sourceID)
 			if e != nil {
 				continue
 			}

--- a/cmd/publish_snapshot.go
+++ b/cmd/publish_snapshot.go
@@ -15,6 +15,7 @@ func aptlyPublishSnapshotOrRepo(cmd *commander.Command, args []string) error {
 	var err error
 
 	components := strings.Split(context.Flags().Lookup("component").Value.String(), ",")
+	collectionFactory := context.NewCollectionFactory()
 
 	if len(args) < len(components) || len(args) > len(components)+1 {
 		cmd.Usage()
@@ -43,12 +44,12 @@ func aptlyPublishSnapshotOrRepo(cmd *commander.Command, args []string) error {
 		)
 
 		for _, name := range args {
-			snapshot, err = context.CollectionFactory().SnapshotCollection().ByName(name)
+			snapshot, err = collectionFactory.SnapshotCollection().ByName(name)
 			if err != nil {
 				return fmt.Errorf("unable to publish: %s", err)
 			}
 
-			err = context.CollectionFactory().SnapshotCollection().LoadComplete(snapshot)
+			err = collectionFactory.SnapshotCollection().LoadComplete(snapshot)
 			if err != nil {
 				return fmt.Errorf("unable to publish: %s", err)
 			}
@@ -79,12 +80,12 @@ func aptlyPublishSnapshotOrRepo(cmd *commander.Command, args []string) error {
 		)
 
 		for _, name := range args {
-			localRepo, err = context.CollectionFactory().LocalRepoCollection().ByName(name)
+			localRepo, err = collectionFactory.LocalRepoCollection().ByName(name)
 			if err != nil {
 				return fmt.Errorf("unable to publish: %s", err)
 			}
 
-			err = context.CollectionFactory().LocalRepoCollection().LoadComplete(localRepo)
+			err = collectionFactory.LocalRepoCollection().LoadComplete(localRepo)
 			if err != nil {
 				return fmt.Errorf("unable to publish: %s", err)
 			}
@@ -116,7 +117,7 @@ func aptlyPublishSnapshotOrRepo(cmd *commander.Command, args []string) error {
 	notAutomatic := context.Flags().Lookup("notautomatic").Value.String()
 	butAutomaticUpgrades := context.Flags().Lookup("butautomaticupgrades").Value.String()
 
-	published, err := deb.NewPublishedRepo(storage, prefix, distribution, context.ArchitecturesList(), components, sources, context.CollectionFactory())
+	published, err := deb.NewPublishedRepo(storage, prefix, distribution, context.ArchitecturesList(), components, sources, collectionFactory)
 	if err != nil {
 		return fmt.Errorf("unable to publish: %s", err)
 	}
@@ -141,9 +142,9 @@ func aptlyPublishSnapshotOrRepo(cmd *commander.Command, args []string) error {
 		published.AcquireByHash = context.Flags().Lookup("acquire-by-hash").Value.Get().(bool)
 	}
 
-	duplicate := context.CollectionFactory().PublishedRepoCollection().CheckDuplicate(published)
+	duplicate := collectionFactory.PublishedRepoCollection().CheckDuplicate(published)
 	if duplicate != nil {
-		context.CollectionFactory().PublishedRepoCollection().LoadComplete(duplicate, context.CollectionFactory())
+		collectionFactory.PublishedRepoCollection().LoadComplete(duplicate, collectionFactory)
 		return fmt.Errorf("prefix/distribution already used by another published repo: %s", duplicate)
 	}
 
@@ -158,12 +159,12 @@ func aptlyPublishSnapshotOrRepo(cmd *commander.Command, args []string) error {
 			"the same package pool.\n")
 	}
 
-	err = published.Publish(context.PackagePool(), context, context.CollectionFactory(), signer, context.Progress(), forceOverwrite)
+	err = published.Publish(context.PackagePool(), context, collectionFactory, signer, context.Progress(), forceOverwrite)
 	if err != nil {
 		return fmt.Errorf("unable to publish: %s", err)
 	}
 
-	err = context.CollectionFactory().PublishedRepoCollection().Add(published)
+	err = collectionFactory.PublishedRepoCollection().Add(published)
 	if err != nil {
 		return fmt.Errorf("unable to save to DB: %s", err)
 	}

--- a/cmd/publish_switch.go
+++ b/cmd/publish_switch.go
@@ -39,7 +39,8 @@ func aptlyPublishSwitch(cmd *commander.Command, args []string) error {
 
 	var published *deb.PublishedRepo
 
-	published, err = context.CollectionFactory().PublishedRepoCollection().ByStoragePrefixDistribution(storage, prefix, distribution)
+	collectionFactory := context.NewCollectionFactory()
+	published, err = collectionFactory.PublishedRepoCollection().ByStoragePrefixDistribution(storage, prefix, distribution)
 	if err != nil {
 		return fmt.Errorf("unable to update: %s", err)
 	}
@@ -48,7 +49,7 @@ func aptlyPublishSwitch(cmd *commander.Command, args []string) error {
 		return fmt.Errorf("unable to update: not a snapshot publish")
 	}
 
-	err = context.CollectionFactory().PublishedRepoCollection().LoadComplete(published, context.CollectionFactory())
+	err = collectionFactory.PublishedRepoCollection().LoadComplete(published, collectionFactory)
 	if err != nil {
 		return fmt.Errorf("unable to update: %s", err)
 	}
@@ -67,12 +68,12 @@ func aptlyPublishSwitch(cmd *commander.Command, args []string) error {
 			return fmt.Errorf("unable to switch: component %s is not in published repository", component)
 		}
 
-		snapshot, err = context.CollectionFactory().SnapshotCollection().ByName(names[i])
+		snapshot, err = collectionFactory.SnapshotCollection().ByName(names[i])
 		if err != nil {
 			return fmt.Errorf("unable to switch: %s", err)
 		}
 
-		err = context.CollectionFactory().SnapshotCollection().LoadComplete(snapshot)
+		err = collectionFactory.SnapshotCollection().LoadComplete(snapshot)
 		if err != nil {
 			return fmt.Errorf("unable to switch: %s", err)
 		}
@@ -95,20 +96,20 @@ func aptlyPublishSwitch(cmd *commander.Command, args []string) error {
 		published.SkipContents = context.Flags().Lookup("skip-contents").Value.Get().(bool)
 	}
 
-	err = published.Publish(context.PackagePool(), context, context.CollectionFactory(), signer, context.Progress(), forceOverwrite)
+	err = published.Publish(context.PackagePool(), context, collectionFactory, signer, context.Progress(), forceOverwrite)
 	if err != nil {
 		return fmt.Errorf("unable to publish: %s", err)
 	}
 
-	err = context.CollectionFactory().PublishedRepoCollection().Update(published)
+	err = collectionFactory.PublishedRepoCollection().Update(published)
 	if err != nil {
 		return fmt.Errorf("unable to save to DB: %s", err)
 	}
 
 	skipCleanup := context.Flags().Lookup("skip-cleanup").Value.Get().(bool)
 	if !skipCleanup {
-		err = context.CollectionFactory().PublishedRepoCollection().CleanupPrefixComponentFiles(published.Prefix, components,
-			context.GetPublishedStorage(storage), context.CollectionFactory(), context.Progress())
+		err = collectionFactory.PublishedRepoCollection().CleanupPrefixComponentFiles(published.Prefix, components,
+			context.GetPublishedStorage(storage), collectionFactory, context.Progress())
 		if err != nil {
 			return fmt.Errorf("unable to update: %s", err)
 		}

--- a/cmd/publish_update.go
+++ b/cmd/publish_update.go
@@ -25,7 +25,8 @@ func aptlyPublishUpdate(cmd *commander.Command, args []string) error {
 
 	var published *deb.PublishedRepo
 
-	published, err = context.CollectionFactory().PublishedRepoCollection().ByStoragePrefixDistribution(storage, prefix, distribution)
+	collectionFactory := context.NewCollectionFactory()
+	published, err = collectionFactory.PublishedRepoCollection().ByStoragePrefixDistribution(storage, prefix, distribution)
 	if err != nil {
 		return fmt.Errorf("unable to update: %s", err)
 	}
@@ -34,7 +35,7 @@ func aptlyPublishUpdate(cmd *commander.Command, args []string) error {
 		return fmt.Errorf("unable to update: not a local repository publish")
 	}
 
-	err = context.CollectionFactory().PublishedRepoCollection().LoadComplete(published, context.CollectionFactory())
+	err = collectionFactory.PublishedRepoCollection().LoadComplete(published, collectionFactory)
 	if err != nil {
 		return fmt.Errorf("unable to update: %s", err)
 	}
@@ -59,20 +60,20 @@ func aptlyPublishUpdate(cmd *commander.Command, args []string) error {
 		published.SkipContents = context.Flags().Lookup("skip-contents").Value.Get().(bool)
 	}
 
-	err = published.Publish(context.PackagePool(), context, context.CollectionFactory(), signer, context.Progress(), forceOverwrite)
+	err = published.Publish(context.PackagePool(), context, collectionFactory, signer, context.Progress(), forceOverwrite)
 	if err != nil {
 		return fmt.Errorf("unable to publish: %s", err)
 	}
 
-	err = context.CollectionFactory().PublishedRepoCollection().Update(published)
+	err = collectionFactory.PublishedRepoCollection().Update(published)
 	if err != nil {
 		return fmt.Errorf("unable to save to DB: %s", err)
 	}
 
 	skipCleanup := context.Flags().Lookup("skip-cleanup").Value.Get().(bool)
 	if !skipCleanup {
-		err = context.CollectionFactory().PublishedRepoCollection().CleanupPrefixComponentFiles(published.Prefix, components,
-			context.GetPublishedStorage(storage), context.CollectionFactory(), context.Progress())
+		err = collectionFactory.PublishedRepoCollection().CleanupPrefixComponentFiles(published.Prefix, components,
+			context.GetPublishedStorage(storage), collectionFactory, context.Progress())
 		if err != nil {
 			return fmt.Errorf("unable to update: %s", err)
 		}

--- a/cmd/repo_add.go
+++ b/cmd/repo_add.go
@@ -22,19 +22,20 @@ func aptlyRepoAdd(cmd *commander.Command, args []string) error {
 
 	verifier := context.GetVerifier()
 
-	repo, err := context.CollectionFactory().LocalRepoCollection().ByName(name)
+	collectionFactory := context.NewCollectionFactory()
+	repo, err := collectionFactory.LocalRepoCollection().ByName(name)
 	if err != nil {
 		return fmt.Errorf("unable to add: %s", err)
 	}
 
-	err = context.CollectionFactory().LocalRepoCollection().LoadComplete(repo)
+	err = collectionFactory.LocalRepoCollection().LoadComplete(repo)
 	if err != nil {
 		return fmt.Errorf("unable to add: %s", err)
 	}
 
 	context.Progress().Printf("Loading packages...\n")
 
-	list, err := deb.NewPackageListFromRefList(repo.RefList(), context.CollectionFactory().PackageCollection(), context.Progress())
+	list, err := deb.NewPackageListFromRefList(repo.RefList(), collectionFactory.PackageCollection(), context.Progress())
 	if err != nil {
 		return fmt.Errorf("unable to load packages: %s", err)
 	}
@@ -48,8 +49,8 @@ func aptlyRepoAdd(cmd *commander.Command, args []string) error {
 	var processedFiles, failedFiles2 []string
 
 	processedFiles, failedFiles2, err = deb.ImportPackageFiles(list, packageFiles, forceReplace, verifier, context.PackagePool(),
-		context.CollectionFactory().PackageCollection(), &aptly.ConsoleResultReporter{Progress: context.Progress()}, nil,
-		context.CollectionFactory().ChecksumCollection())
+		collectionFactory.PackageCollection(), &aptly.ConsoleResultReporter{Progress: context.Progress()}, nil,
+		collectionFactory.ChecksumCollection())
 	failedFiles = append(failedFiles, failedFiles2...)
 	if err != nil {
 		return fmt.Errorf("unable to import package files: %s", err)
@@ -59,7 +60,7 @@ func aptlyRepoAdd(cmd *commander.Command, args []string) error {
 
 	repo.UpdateRefList(deb.NewPackageRefListFromPackageList(list))
 
-	err = context.CollectionFactory().LocalRepoCollection().Update(repo)
+	err = collectionFactory.LocalRepoCollection().Update(repo)
 	if err != nil {
 		return fmt.Errorf("unable to save: %s", err)
 	}

--- a/cmd/repo_create.go
+++ b/cmd/repo_create.go
@@ -27,15 +27,16 @@ func aptlyRepoCreate(cmd *commander.Command, args []string) error {
 		}
 	}
 
+	collectionFactory := context.NewCollectionFactory()
 	if len(args) == 4 {
 		var snapshot *deb.Snapshot
 
-		snapshot, err = context.CollectionFactory().SnapshotCollection().ByName(args[3])
+		snapshot, err = collectionFactory.SnapshotCollection().ByName(args[3])
 		if err != nil {
 			return fmt.Errorf("unable to load source snapshot: %s", err)
 		}
 
-		err = context.CollectionFactory().SnapshotCollection().LoadComplete(snapshot)
+		err = collectionFactory.SnapshotCollection().LoadComplete(snapshot)
 		if err != nil {
 			return fmt.Errorf("unable to load source snapshot: %s", err)
 		}
@@ -43,7 +44,7 @@ func aptlyRepoCreate(cmd *commander.Command, args []string) error {
 		repo.UpdateRefList(snapshot.RefList())
 	}
 
-	err = context.CollectionFactory().LocalRepoCollection().Add(repo)
+	err = collectionFactory.LocalRepoCollection().Add(repo)
 	if err != nil {
 		return fmt.Errorf("unable to add local repo: %s", err)
 	}

--- a/cmd/repo_drop.go
+++ b/cmd/repo_drop.go
@@ -15,17 +15,18 @@ func aptlyRepoDrop(cmd *commander.Command, args []string) error {
 	}
 
 	name := args[0]
+	collectionFactory := context.NewCollectionFactory()
 
-	repo, err := context.CollectionFactory().LocalRepoCollection().ByName(name)
+	repo, err := collectionFactory.LocalRepoCollection().ByName(name)
 	if err != nil {
 		return fmt.Errorf("unable to drop: %s", err)
 	}
 
-	published := context.CollectionFactory().PublishedRepoCollection().ByLocalRepo(repo)
+	published := collectionFactory.PublishedRepoCollection().ByLocalRepo(repo)
 	if len(published) > 0 {
 		fmt.Printf("Local repo `%s` is published currently:\n", repo.Name)
 		for _, repo := range published {
-			err = context.CollectionFactory().PublishedRepoCollection().LoadComplete(repo, context.CollectionFactory())
+			err = collectionFactory.PublishedRepoCollection().LoadComplete(repo, collectionFactory)
 			if err != nil {
 				return fmt.Errorf("unable to load published: %s", err)
 			}
@@ -37,7 +38,7 @@ func aptlyRepoDrop(cmd *commander.Command, args []string) error {
 
 	force := context.Flags().Lookup("force").Value.Get().(bool)
 	if !force {
-		snapshots := context.CollectionFactory().SnapshotCollection().ByLocalRepoSource(repo)
+		snapshots := collectionFactory.SnapshotCollection().ByLocalRepoSource(repo)
 
 		if len(snapshots) > 0 {
 			fmt.Printf("Local repo `%s` was used to create following snapshots:\n", repo.Name)
@@ -49,7 +50,7 @@ func aptlyRepoDrop(cmd *commander.Command, args []string) error {
 		}
 	}
 
-	err = context.CollectionFactory().LocalRepoCollection().Drop(repo)
+	err = collectionFactory.LocalRepoCollection().Drop(repo)
 	if err != nil {
 		return fmt.Errorf("unable to drop: %s", err)
 	}

--- a/cmd/repo_edit.go
+++ b/cmd/repo_edit.go
@@ -16,12 +16,13 @@ func aptlyRepoEdit(cmd *commander.Command, args []string) error {
 		return commander.ErrCommandError
 	}
 
-	repo, err := context.CollectionFactory().LocalRepoCollection().ByName(args[0])
+	collectionFactory := context.NewCollectionFactory()
+	repo, err := collectionFactory.LocalRepoCollection().ByName(args[0])
 	if err != nil {
 		return fmt.Errorf("unable to edit: %s", err)
 	}
 
-	err = context.CollectionFactory().LocalRepoCollection().LoadComplete(repo)
+	err = collectionFactory.LocalRepoCollection().LoadComplete(repo)
 	if err != nil {
 		return fmt.Errorf("unable to edit: %s", err)
 	}
@@ -52,7 +53,7 @@ func aptlyRepoEdit(cmd *commander.Command, args []string) error {
 		}
 	}
 
-	err = context.CollectionFactory().LocalRepoCollection().Update(repo)
+	err = collectionFactory.LocalRepoCollection().Update(repo)
 	if err != nil {
 		return fmt.Errorf("unable to edit: %s", err)
 	}

--- a/cmd/repo_include.go
+++ b/cmd/repo_include.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"text/template"
 
 	"github.com/aptly-dev/aptly/aptly"
 	"github.com/aptly-dev/aptly/deb"
@@ -33,6 +34,12 @@ func aptlyRepoInclude(cmd *commander.Command, args []string) error {
 	repoTemplateString := context.Flags().Lookup("repo").Value.Get().(string)
 	collectionFactory := context.NewCollectionFactory()
 
+	var repoTemplate *template.Template
+	repoTemplate, err = template.New("repo").Parse(repoTemplateString)
+	if err != nil {
+		return fmt.Errorf("error parsing -repo template: %s", err)
+	}
+
 	uploaders := (*deb.Uploaders)(nil)
 	uploadersFile := context.Flags().Lookup("uploaders-file").Value.Get().(string)
 	if uploadersFile != "" {
@@ -55,7 +62,7 @@ func aptlyRepoInclude(cmd *commander.Command, args []string) error {
 
 	changesFiles, failedFiles = deb.CollectChangesFiles(args, reporter)
 	_, failedFiles2, err = deb.ImportChangesFiles(
-		changesFiles, reporter, acceptUnsigned, ignoreSignatures, forceReplace, noRemoveFiles, verifier, repoTemplateString,
+		changesFiles, reporter, acceptUnsigned, ignoreSignatures, forceReplace, noRemoveFiles, verifier, repoTemplate,
 		context.Progress(), collectionFactory.LocalRepoCollection(), collectionFactory.PackageCollection(),
 		context.PackagePool(), collectionFactory.ChecksumCollection(),
 		uploaders, query.Parse)

--- a/cmd/repo_include.go
+++ b/cmd/repo_include.go
@@ -31,6 +31,7 @@ func aptlyRepoInclude(cmd *commander.Command, args []string) error {
 	ignoreSignatures := context.Flags().Lookup("ignore-signatures").Value.Get().(bool)
 	noRemoveFiles := context.Flags().Lookup("no-remove-files").Value.Get().(bool)
 	repoTemplateString := context.Flags().Lookup("repo").Value.Get().(string)
+	collectionFactory := context.NewCollectionFactory()
 
 	uploaders := (*deb.Uploaders)(nil)
 	uploadersFile := context.Flags().Lookup("uploaders-file").Value.Get().(string)
@@ -55,8 +56,8 @@ func aptlyRepoInclude(cmd *commander.Command, args []string) error {
 	changesFiles, failedFiles = deb.CollectChangesFiles(args, reporter)
 	_, failedFiles2, err = deb.ImportChangesFiles(
 		changesFiles, reporter, acceptUnsigned, ignoreSignatures, forceReplace, noRemoveFiles, verifier, repoTemplateString,
-		context.Progress(), context.CollectionFactory().LocalRepoCollection(), context.CollectionFactory().PackageCollection(),
-		context.PackagePool(), context.CollectionFactory().ChecksumCollection(),
+		context.Progress(), collectionFactory.LocalRepoCollection(), collectionFactory.PackageCollection(),
+		context.PackagePool(), collectionFactory.ChecksumCollection(),
 		uploaders, query.Parse)
 	failedFiles = append(failedFiles, failedFiles2...)
 

--- a/cmd/repo_list.go
+++ b/cmd/repo_list.go
@@ -17,13 +17,14 @@ func aptlyRepoList(cmd *commander.Command, args []string) error {
 
 	raw := cmd.Flag.Lookup("raw").Value.Get().(bool)
 
-	repos := make([]string, context.CollectionFactory().LocalRepoCollection().Len())
+	collectionFactory := context.NewCollectionFactory()
+	repos := make([]string, collectionFactory.LocalRepoCollection().Len())
 	i := 0
-	context.CollectionFactory().LocalRepoCollection().ForEach(func(repo *deb.LocalRepo) error {
+	collectionFactory.LocalRepoCollection().ForEach(func(repo *deb.LocalRepo) error {
 		if raw {
 			repos[i] = repo.Name
 		} else {
-			e := context.CollectionFactory().LocalRepoCollection().LoadComplete(repo)
+			e := collectionFactory.LocalRepoCollection().LoadComplete(repo)
 			if e != nil {
 				return e
 			}

--- a/cmd/repo_move.go
+++ b/cmd/repo_move.go
@@ -19,12 +19,13 @@ func aptlyRepoMoveCopyImport(cmd *commander.Command, args []string) error {
 
 	command := cmd.Name()
 
-	dstRepo, err := context.CollectionFactory().LocalRepoCollection().ByName(args[1])
+	collectionFactory := context.NewCollectionFactory()
+	dstRepo, err := collectionFactory.LocalRepoCollection().ByName(args[1])
 	if err != nil {
 		return fmt.Errorf("unable to %s: %s", command, err)
 	}
 
-	err = context.CollectionFactory().LocalRepoCollection().LoadComplete(dstRepo)
+	err = collectionFactory.LocalRepoCollection().LoadComplete(dstRepo)
 	if err != nil {
 		return fmt.Errorf("unable to %s: %s", command, err)
 	}
@@ -35,7 +36,7 @@ func aptlyRepoMoveCopyImport(cmd *commander.Command, args []string) error {
 	)
 
 	if command == "copy" || command == "move" { // nolint: goconst
-		srcRepo, err = context.CollectionFactory().LocalRepoCollection().ByName(args[0])
+		srcRepo, err = collectionFactory.LocalRepoCollection().ByName(args[0])
 		if err != nil {
 			return fmt.Errorf("unable to %s: %s", command, err)
 		}
@@ -44,7 +45,7 @@ func aptlyRepoMoveCopyImport(cmd *commander.Command, args []string) error {
 			return fmt.Errorf("unable to %s: source and destination are the same", command)
 		}
 
-		err = context.CollectionFactory().LocalRepoCollection().LoadComplete(srcRepo)
+		err = collectionFactory.LocalRepoCollection().LoadComplete(srcRepo)
 		if err != nil {
 			return fmt.Errorf("unable to %s: %s", command, err)
 		}
@@ -53,12 +54,12 @@ func aptlyRepoMoveCopyImport(cmd *commander.Command, args []string) error {
 	} else if command == "import" { // nolint: goconst
 		var srcRemoteRepo *deb.RemoteRepo
 
-		srcRemoteRepo, err = context.CollectionFactory().RemoteRepoCollection().ByName(args[0])
+		srcRemoteRepo, err = collectionFactory.RemoteRepoCollection().ByName(args[0])
 		if err != nil {
 			return fmt.Errorf("unable to %s: %s", command, err)
 		}
 
-		err = context.CollectionFactory().RemoteRepoCollection().LoadComplete(srcRemoteRepo)
+		err = collectionFactory.RemoteRepoCollection().LoadComplete(srcRemoteRepo)
 		if err != nil {
 			return fmt.Errorf("unable to %s: %s", command, err)
 		}
@@ -74,12 +75,12 @@ func aptlyRepoMoveCopyImport(cmd *commander.Command, args []string) error {
 
 	context.Progress().Printf("Loading packages...\n")
 
-	dstList, err := deb.NewPackageListFromRefList(dstRepo.RefList(), context.CollectionFactory().PackageCollection(), context.Progress())
+	dstList, err := deb.NewPackageListFromRefList(dstRepo.RefList(), collectionFactory.PackageCollection(), context.Progress())
 	if err != nil {
 		return fmt.Errorf("unable to load packages: %s", err)
 	}
 
-	srcList, err := deb.NewPackageListFromRefList(srcRefList, context.CollectionFactory().PackageCollection(), context.Progress())
+	srcList, err := deb.NewPackageListFromRefList(srcRefList, collectionFactory.PackageCollection(), context.Progress())
 	if err != nil {
 		return fmt.Errorf("unable to load packages: %s", err)
 	}
@@ -151,7 +152,7 @@ func aptlyRepoMoveCopyImport(cmd *commander.Command, args []string) error {
 	} else {
 		dstRepo.UpdateRefList(deb.NewPackageRefListFromPackageList(dstList))
 
-		err = context.CollectionFactory().LocalRepoCollection().Update(dstRepo)
+		err = collectionFactory.LocalRepoCollection().Update(dstRepo)
 		if err != nil {
 			return fmt.Errorf("unable to save: %s", err)
 		}
@@ -159,7 +160,7 @@ func aptlyRepoMoveCopyImport(cmd *commander.Command, args []string) error {
 		if command == "move" { // nolint: goconst
 			srcRepo.UpdateRefList(deb.NewPackageRefListFromPackageList(srcList))
 
-			err = context.CollectionFactory().LocalRepoCollection().Update(srcRepo)
+			err = collectionFactory.LocalRepoCollection().Update(srcRepo)
 			if err != nil {
 				return fmt.Errorf("unable to save: %s", err)
 			}

--- a/cmd/repo_remove.go
+++ b/cmd/repo_remove.go
@@ -18,19 +18,20 @@ func aptlyRepoRemove(cmd *commander.Command, args []string) error {
 
 	name := args[0]
 
-	repo, err := context.CollectionFactory().LocalRepoCollection().ByName(name)
+	collectionFactory := context.NewCollectionFactory()
+	repo, err := collectionFactory.LocalRepoCollection().ByName(name)
 	if err != nil {
 		return fmt.Errorf("unable to remove: %s", err)
 	}
 
-	err = context.CollectionFactory().LocalRepoCollection().LoadComplete(repo)
+	err = collectionFactory.LocalRepoCollection().LoadComplete(repo)
 	if err != nil {
 		return fmt.Errorf("unable to remove: %s", err)
 	}
 
 	context.Progress().Printf("Loading packages...\n")
 
-	list, err := deb.NewPackageListFromRefList(repo.RefList(), context.CollectionFactory().PackageCollection(), context.Progress())
+	list, err := deb.NewPackageListFromRefList(repo.RefList(), collectionFactory.PackageCollection(), context.Progress())
 	if err != nil {
 		return fmt.Errorf("unable to load packages: %s", err)
 	}
@@ -60,7 +61,7 @@ func aptlyRepoRemove(cmd *commander.Command, args []string) error {
 	} else {
 		repo.UpdateRefList(deb.NewPackageRefListFromPackageList(list))
 
-		err = context.CollectionFactory().LocalRepoCollection().Update(repo)
+		err = collectionFactory.LocalRepoCollection().Update(repo)
 		if err != nil {
 			return fmt.Errorf("unable to save: %s", err)
 		}

--- a/cmd/repo_rename.go
+++ b/cmd/repo_rename.go
@@ -20,18 +20,19 @@ func aptlyRepoRename(cmd *commander.Command, args []string) error {
 
 	oldName, newName := args[0], args[1]
 
-	repo, err = context.CollectionFactory().LocalRepoCollection().ByName(oldName)
+	collectionFactory := context.NewCollectionFactory()
+	repo, err = collectionFactory.LocalRepoCollection().ByName(oldName)
 	if err != nil {
 		return fmt.Errorf("unable to rename: %s", err)
 	}
 
-	_, err = context.CollectionFactory().LocalRepoCollection().ByName(newName)
+	_, err = collectionFactory.LocalRepoCollection().ByName(newName)
 	if err == nil {
 		return fmt.Errorf("unable to rename: local repo %s already exists", newName)
 	}
 
 	repo.Name = newName
-	err = context.CollectionFactory().LocalRepoCollection().Update(repo)
+	err = collectionFactory.LocalRepoCollection().Update(repo)
 	if err != nil {
 		return fmt.Errorf("unable to rename: %s", err)
 	}

--- a/cmd/repo_show.go
+++ b/cmd/repo_show.go
@@ -16,12 +16,13 @@ func aptlyRepoShow(cmd *commander.Command, args []string) error {
 
 	name := args[0]
 
-	repo, err := context.CollectionFactory().LocalRepoCollection().ByName(name)
+	collectionFactory := context.NewCollectionFactory()
+	repo, err := collectionFactory.LocalRepoCollection().ByName(name)
 	if err != nil {
 		return fmt.Errorf("unable to show: %s", err)
 	}
 
-	err = context.CollectionFactory().LocalRepoCollection().LoadComplete(repo)
+	err = collectionFactory.LocalRepoCollection().LoadComplete(repo)
 	if err != nil {
 		return fmt.Errorf("unable to show: %s", err)
 	}
@@ -37,7 +38,7 @@ func aptlyRepoShow(cmd *commander.Command, args []string) error {
 
 	withPackages := context.Flags().Lookup("with-packages").Value.Get().(bool)
 	if withPackages {
-		ListPackagesRefList(repo.RefList())
+		ListPackagesRefList(repo.RefList(), collectionFactory)
 	}
 
 	return err

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -34,7 +34,8 @@ func aptlyServe(cmd *commander.Command, args []string) error {
 		return err
 	}
 
-	if context.CollectionFactory().PublishedRepoCollection().Len() == 0 {
+	collectionFactory := context.NewCollectionFactory()
+	if collectionFactory.PublishedRepoCollection().Len() == 0 {
 		fmt.Printf("No published repositories, unable to serve.\n")
 		return nil
 	}
@@ -56,11 +57,11 @@ func aptlyServe(cmd *commander.Command, args []string) error {
 
 	fmt.Printf("Serving published repositories, recommended apt sources list:\n\n")
 
-	sources := make(sort.StringSlice, 0, context.CollectionFactory().PublishedRepoCollection().Len())
-	published := make(map[string]*deb.PublishedRepo, context.CollectionFactory().PublishedRepoCollection().Len())
+	sources := make(sort.StringSlice, 0, collectionFactory.PublishedRepoCollection().Len())
+	published := make(map[string]*deb.PublishedRepo, collectionFactory.PublishedRepoCollection().Len())
 
-	err = context.CollectionFactory().PublishedRepoCollection().ForEach(func(repo *deb.PublishedRepo) error {
-		e := context.CollectionFactory().PublishedRepoCollection().LoadComplete(repo, context.CollectionFactory())
+	err = collectionFactory.PublishedRepoCollection().ForEach(func(repo *deb.PublishedRepo) error {
+		e := collectionFactory.PublishedRepoCollection().LoadComplete(repo, collectionFactory)
 		if e != nil {
 			return e
 		}

--- a/cmd/snapshot_create.go
+++ b/cmd/snapshot_create.go
@@ -13,13 +13,14 @@ func aptlySnapshotCreate(cmd *commander.Command, args []string) error {
 		snapshot *deb.Snapshot
 	)
 
+	collectionFactory := context.NewCollectionFactory()
 	if len(args) == 4 && args[1] == "from" && args[2] == "mirror" { // nolint: goconst
 		// aptly snapshot create snap from mirror mirror
 		var repo *deb.RemoteRepo
 
 		repoName, snapshotName := args[3], args[0]
 
-		repo, err = context.CollectionFactory().RemoteRepoCollection().ByName(repoName)
+		repo, err = collectionFactory.RemoteRepoCollection().ByName(repoName)
 		if err != nil {
 			return fmt.Errorf("unable to create snapshot: %s", err)
 		}
@@ -29,7 +30,7 @@ func aptlySnapshotCreate(cmd *commander.Command, args []string) error {
 			return fmt.Errorf("unable to create snapshot: %s", err)
 		}
 
-		err = context.CollectionFactory().RemoteRepoCollection().LoadComplete(repo)
+		err = collectionFactory.RemoteRepoCollection().LoadComplete(repo)
 		if err != nil {
 			return fmt.Errorf("unable to create snapshot: %s", err)
 		}
@@ -44,12 +45,12 @@ func aptlySnapshotCreate(cmd *commander.Command, args []string) error {
 
 		localRepoName, snapshotName := args[3], args[0]
 
-		repo, err = context.CollectionFactory().LocalRepoCollection().ByName(localRepoName)
+		repo, err = collectionFactory.LocalRepoCollection().ByName(localRepoName)
 		if err != nil {
 			return fmt.Errorf("unable to create snapshot: %s", err)
 		}
 
-		err = context.CollectionFactory().LocalRepoCollection().LoadComplete(repo)
+		err = collectionFactory.LocalRepoCollection().LoadComplete(repo)
 		if err != nil {
 			return fmt.Errorf("unable to create snapshot: %s", err)
 		}
@@ -70,7 +71,7 @@ func aptlySnapshotCreate(cmd *commander.Command, args []string) error {
 		return commander.ErrCommandError
 	}
 
-	err = context.CollectionFactory().SnapshotCollection().Add(snapshot)
+	err = collectionFactory.SnapshotCollection().Add(snapshot)
 	if err != nil {
 		return fmt.Errorf("unable to add snapshot: %s", err)
 	}

--- a/cmd/snapshot_diff.go
+++ b/cmd/snapshot_diff.go
@@ -15,31 +15,32 @@ func aptlySnapshotDiff(cmd *commander.Command, args []string) error {
 	}
 
 	onlyMatching := context.Flags().Lookup("only-matching").Value.Get().(bool)
+	collectionFactory := context.NewCollectionFactory()
 
 	// Load <name-a> snapshot
-	snapshotA, err := context.CollectionFactory().SnapshotCollection().ByName(args[0])
+	snapshotA, err := collectionFactory.SnapshotCollection().ByName(args[0])
 	if err != nil {
 		return fmt.Errorf("unable to load snapshot A: %s", err)
 	}
 
-	err = context.CollectionFactory().SnapshotCollection().LoadComplete(snapshotA)
+	err = collectionFactory.SnapshotCollection().LoadComplete(snapshotA)
 	if err != nil {
 		return fmt.Errorf("unable to load snapshot A: %s", err)
 	}
 
 	// Load <name-b> snapshot
-	snapshotB, err := context.CollectionFactory().SnapshotCollection().ByName(args[1])
+	snapshotB, err := collectionFactory.SnapshotCollection().ByName(args[1])
 	if err != nil {
 		return fmt.Errorf("unable to load snapshot B: %s", err)
 	}
 
-	err = context.CollectionFactory().SnapshotCollection().LoadComplete(snapshotB)
+	err = collectionFactory.SnapshotCollection().LoadComplete(snapshotB)
 	if err != nil {
 		return fmt.Errorf("unable to load snapshot B: %s", err)
 	}
 
 	// Calculate diff
-	diff, err := snapshotA.RefList().Diff(snapshotB.RefList(), context.CollectionFactory().PackageCollection())
+	diff, err := snapshotA.RefList().Diff(snapshotB.RefList(), collectionFactory.PackageCollection())
 	if err != nil {
 		return fmt.Errorf("unable to calculate diff: %s", err)
 	}

--- a/cmd/snapshot_drop.go
+++ b/cmd/snapshot_drop.go
@@ -15,18 +15,19 @@ func aptlySnapshotDrop(cmd *commander.Command, args []string) error {
 	}
 
 	name := args[0]
+	collectionFactory := context.NewCollectionFactory()
 
-	snapshot, err := context.CollectionFactory().SnapshotCollection().ByName(name)
+	snapshot, err := collectionFactory.SnapshotCollection().ByName(name)
 	if err != nil {
 		return fmt.Errorf("unable to drop: %s", err)
 	}
 
-	published := context.CollectionFactory().PublishedRepoCollection().BySnapshot(snapshot)
+	published := collectionFactory.PublishedRepoCollection().BySnapshot(snapshot)
 
 	if len(published) > 0 {
 		fmt.Printf("Snapshot `%s` is published currently:\n", snapshot.Name)
 		for _, repo := range published {
-			err = context.CollectionFactory().PublishedRepoCollection().LoadComplete(repo, context.CollectionFactory())
+			err = collectionFactory.PublishedRepoCollection().LoadComplete(repo, collectionFactory)
 			if err != nil {
 				return fmt.Errorf("unable to load published: %s", err)
 			}
@@ -38,7 +39,7 @@ func aptlySnapshotDrop(cmd *commander.Command, args []string) error {
 
 	force := context.Flags().Lookup("force").Value.Get().(bool)
 	if !force {
-		snapshots := context.CollectionFactory().SnapshotCollection().BySnapshotSource(snapshot)
+		snapshots := collectionFactory.SnapshotCollection().BySnapshotSource(snapshot)
 		if len(snapshots) > 0 {
 			fmt.Printf("Snapshot `%s` was used as a source in following snapshots:\n", snapshot.Name)
 			for _, snap := range snapshots {
@@ -49,7 +50,7 @@ func aptlySnapshotDrop(cmd *commander.Command, args []string) error {
 		}
 	}
 
-	err = context.CollectionFactory().SnapshotCollection().Drop(snapshot)
+	err = collectionFactory.SnapshotCollection().Drop(snapshot)
 	if err != nil {
 		return fmt.Errorf("unable to drop: %s", err)
 	}

--- a/cmd/snapshot_filter.go
+++ b/cmd/snapshot_filter.go
@@ -19,21 +19,22 @@ func aptlySnapshotFilter(cmd *commander.Command, args []string) error {
 	}
 
 	withDeps := context.Flags().Lookup("with-deps").Value.Get().(bool)
+	collectionFactory := context.NewCollectionFactory()
 
 	// Load <source> snapshot
-	source, err := context.CollectionFactory().SnapshotCollection().ByName(args[0])
+	source, err := collectionFactory.SnapshotCollection().ByName(args[0])
 	if err != nil {
 		return fmt.Errorf("unable to filter: %s", err)
 	}
 
-	err = context.CollectionFactory().SnapshotCollection().LoadComplete(source)
+	err = collectionFactory.SnapshotCollection().LoadComplete(source)
 	if err != nil {
 		return fmt.Errorf("unable to filter: %s", err)
 	}
 
 	// Convert snapshot to package list
 	context.Progress().Printf("Loading packages (%d)...\n", source.RefList().Len())
-	packageList, err := deb.NewPackageListFromRefList(source.RefList(), context.CollectionFactory().PackageCollection(), context.Progress())
+	packageList, err := deb.NewPackageListFromRefList(source.RefList(), collectionFactory.PackageCollection(), context.Progress())
 	if err != nil {
 		return fmt.Errorf("unable to load packages: %s", err)
 	}
@@ -75,7 +76,7 @@ func aptlySnapshotFilter(cmd *commander.Command, args []string) error {
 	destination := deb.NewSnapshotFromPackageList(args[1], []*deb.Snapshot{source}, result,
 		fmt.Sprintf("Filtered '%s', query was: '%s'", source.Name, strings.Join(args[2:], " ")))
 
-	err = context.CollectionFactory().SnapshotCollection().Add(destination)
+	err = collectionFactory.SnapshotCollection().Add(destination)
 	if err != nil {
 		return fmt.Errorf("unable to create snapshot: %s", err)
 	}

--- a/cmd/snapshot_list.go
+++ b/cmd/snapshot_list.go
@@ -17,7 +17,8 @@ func aptlySnapshotList(cmd *commander.Command, args []string) error {
 	raw := cmd.Flag.Lookup("raw").Value.Get().(bool)
 	sortMethodString := cmd.Flag.Lookup("sort").Value.Get().(string)
 
-	collection := context.CollectionFactory().SnapshotCollection()
+	collectionFactory := context.NewCollectionFactory()
+	collection := collectionFactory.SnapshotCollection()
 
 	if raw {
 		collection.ForEachSorted(sortMethodString, func(snapshot *deb.Snapshot) error {

--- a/cmd/snapshot_merge.go
+++ b/cmd/snapshot_merge.go
@@ -15,15 +15,16 @@ func aptlySnapshotMerge(cmd *commander.Command, args []string) error {
 		return commander.ErrCommandError
 	}
 
+	collectionFactory := context.NewCollectionFactory()
 	sources := make([]*deb.Snapshot, len(args)-1)
 
 	for i := 0; i < len(args)-1; i++ {
-		sources[i], err = context.CollectionFactory().SnapshotCollection().ByName(args[i+1])
+		sources[i], err = collectionFactory.SnapshotCollection().ByName(args[i+1])
 		if err != nil {
 			return fmt.Errorf("unable to load snapshot: %s", err)
 		}
 
-		err = context.CollectionFactory().SnapshotCollection().LoadComplete(sources[i])
+		err = collectionFactory.SnapshotCollection().LoadComplete(sources[i])
 		if err != nil {
 			return fmt.Errorf("unable to load snapshot: %s", err)
 		}
@@ -56,7 +57,7 @@ func aptlySnapshotMerge(cmd *commander.Command, args []string) error {
 	destination := deb.NewSnapshotFromRefList(args[0], sources, result,
 		fmt.Sprintf("Merged from sources: %s", strings.Join(sourceDescription, ", ")))
 
-	err = context.CollectionFactory().SnapshotCollection().Add(destination)
+	err = collectionFactory.SnapshotCollection().Add(destination)
 	if err != nil {
 		return fmt.Errorf("unable to create snapshot: %s", err)
 	}

--- a/cmd/snapshot_pull.go
+++ b/cmd/snapshot_pull.go
@@ -21,25 +21,26 @@ func aptlySnapshotPull(cmd *commander.Command, args []string) error {
 	noDeps := context.Flags().Lookup("no-deps").Value.Get().(bool)
 	noRemove := context.Flags().Lookup("no-remove").Value.Get().(bool)
 	allMatches := context.Flags().Lookup("all-matches").Value.Get().(bool)
+	collectionFactory := context.NewCollectionFactory()
 
 	// Load <name> snapshot
-	snapshot, err := context.CollectionFactory().SnapshotCollection().ByName(args[0])
+	snapshot, err := collectionFactory.SnapshotCollection().ByName(args[0])
 	if err != nil {
 		return fmt.Errorf("unable to pull: %s", err)
 	}
 
-	err = context.CollectionFactory().SnapshotCollection().LoadComplete(snapshot)
+	err = collectionFactory.SnapshotCollection().LoadComplete(snapshot)
 	if err != nil {
 		return fmt.Errorf("unable to pull: %s", err)
 	}
 
 	// Load <source> snapshot
-	source, err := context.CollectionFactory().SnapshotCollection().ByName(args[1])
+	source, err := collectionFactory.SnapshotCollection().ByName(args[1])
 	if err != nil {
 		return fmt.Errorf("unable to pull: %s", err)
 	}
 
-	err = context.CollectionFactory().SnapshotCollection().LoadComplete(source)
+	err = collectionFactory.SnapshotCollection().LoadComplete(source)
 	if err != nil {
 		return fmt.Errorf("unable to pull: %s", err)
 	}
@@ -49,12 +50,12 @@ func aptlySnapshotPull(cmd *commander.Command, args []string) error {
 
 	// Convert snapshot to package list
 	context.Progress().Printf("Loading packages (%d)...\n", snapshot.RefList().Len()+source.RefList().Len())
-	packageList, err := deb.NewPackageListFromRefList(snapshot.RefList(), context.CollectionFactory().PackageCollection(), context.Progress())
+	packageList, err := deb.NewPackageListFromRefList(snapshot.RefList(), collectionFactory.PackageCollection(), context.Progress())
 	if err != nil {
 		return fmt.Errorf("unable to load packages: %s", err)
 	}
 
-	sourcePackageList, err := deb.NewPackageListFromRefList(source.RefList(), context.CollectionFactory().PackageCollection(), context.Progress())
+	sourcePackageList, err := deb.NewPackageListFromRefList(source.RefList(), collectionFactory.PackageCollection(), context.Progress())
 	if err != nil {
 		return fmt.Errorf("unable to load packages: %s", err)
 	}
@@ -137,7 +138,7 @@ func aptlySnapshotPull(cmd *commander.Command, args []string) error {
 		destination := deb.NewSnapshotFromPackageList(args[2], []*deb.Snapshot{snapshot, source}, packageList,
 			fmt.Sprintf("Pulled into '%s' with '%s' as source, pull request was: '%s'", snapshot.Name, source.Name, strings.Join(args[3:], " ")))
 
-		err = context.CollectionFactory().SnapshotCollection().Add(destination)
+		err = collectionFactory.SnapshotCollection().Add(destination)
 		if err != nil {
 			return fmt.Errorf("unable to create snapshot: %s", err)
 		}

--- a/cmd/snapshot_rename.go
+++ b/cmd/snapshot_rename.go
@@ -19,19 +19,20 @@ func aptlySnapshotRename(cmd *commander.Command, args []string) error {
 	}
 
 	oldName, newName := args[0], args[1]
+	collectionFactory := context.NewCollectionFactory()
 
-	snapshot, err = context.CollectionFactory().SnapshotCollection().ByName(oldName)
+	snapshot, err = collectionFactory.SnapshotCollection().ByName(oldName)
 	if err != nil {
 		return fmt.Errorf("unable to rename: %s", err)
 	}
 
-	_, err = context.CollectionFactory().SnapshotCollection().ByName(newName)
+	_, err = collectionFactory.SnapshotCollection().ByName(newName)
 	if err == nil {
 		return fmt.Errorf("unable to rename: snapshot %s already exists", newName)
 	}
 
 	snapshot.Name = newName
-	err = context.CollectionFactory().SnapshotCollection().Update(snapshot)
+	err = collectionFactory.SnapshotCollection().Update(snapshot)
 	if err != nil {
 		return fmt.Errorf("unable to rename: %s", err)
 	}

--- a/cmd/snapshot_search.go
+++ b/cmd/snapshot_search.go
@@ -23,17 +23,18 @@ func aptlySnapshotMirrorRepoSearch(cmd *commander.Command, args []string) error 
 
 	name := args[0]
 	command := cmd.Parent.Name()
+	collectionFactory := context.NewCollectionFactory()
 
 	var reflist *deb.PackageRefList
 
 	if command == "snapshot" { // nolint: goconst
 		var snapshot *deb.Snapshot
-		snapshot, err = context.CollectionFactory().SnapshotCollection().ByName(name)
+		snapshot, err = collectionFactory.SnapshotCollection().ByName(name)
 		if err != nil {
 			return fmt.Errorf("unable to search: %s", err)
 		}
 
-		err = context.CollectionFactory().SnapshotCollection().LoadComplete(snapshot)
+		err = collectionFactory.SnapshotCollection().LoadComplete(snapshot)
 		if err != nil {
 			return fmt.Errorf("unable to search: %s", err)
 		}
@@ -41,12 +42,12 @@ func aptlySnapshotMirrorRepoSearch(cmd *commander.Command, args []string) error 
 		reflist = snapshot.RefList()
 	} else if command == "mirror" {
 		var repo *deb.RemoteRepo
-		repo, err = context.CollectionFactory().RemoteRepoCollection().ByName(name)
+		repo, err = collectionFactory.RemoteRepoCollection().ByName(name)
 		if err != nil {
 			return fmt.Errorf("unable to search: %s", err)
 		}
 
-		err = context.CollectionFactory().RemoteRepoCollection().LoadComplete(repo)
+		err = collectionFactory.RemoteRepoCollection().LoadComplete(repo)
 		if err != nil {
 			return fmt.Errorf("unable to search: %s", err)
 		}
@@ -54,12 +55,12 @@ func aptlySnapshotMirrorRepoSearch(cmd *commander.Command, args []string) error 
 		reflist = repo.RefList()
 	} else if command == "repo" { // nolint: goconst
 		var repo *deb.LocalRepo
-		repo, err = context.CollectionFactory().LocalRepoCollection().ByName(name)
+		repo, err = collectionFactory.LocalRepoCollection().ByName(name)
 		if err != nil {
 			return fmt.Errorf("unable to search: %s", err)
 		}
 
-		err = context.CollectionFactory().LocalRepoCollection().LoadComplete(repo)
+		err = collectionFactory.LocalRepoCollection().LoadComplete(repo)
 		if err != nil {
 			return fmt.Errorf("unable to search: %s", err)
 		}
@@ -69,7 +70,7 @@ func aptlySnapshotMirrorRepoSearch(cmd *commander.Command, args []string) error 
 		panic("unknown command")
 	}
 
-	list, err := deb.NewPackageListFromRefList(reflist, context.CollectionFactory().PackageCollection(), context.Progress())
+	list, err := deb.NewPackageListFromRefList(reflist, collectionFactory.PackageCollection(), context.Progress())
 	if err != nil {
 		return fmt.Errorf("unable to search: %s", err)
 	}

--- a/cmd/snapshot_show.go
+++ b/cmd/snapshot_show.go
@@ -16,13 +16,14 @@ func aptlySnapshotShow(cmd *commander.Command, args []string) error {
 	}
 
 	name := args[0]
+	collectionFactory := context.NewCollectionFactory()
 
-	snapshot, err := context.CollectionFactory().SnapshotCollection().ByName(name)
+	snapshot, err := collectionFactory.SnapshotCollection().ByName(name)
 	if err != nil {
 		return fmt.Errorf("unable to show: %s", err)
 	}
 
-	err = context.CollectionFactory().SnapshotCollection().LoadComplete(snapshot)
+	err = collectionFactory.SnapshotCollection().LoadComplete(snapshot)
 	if err != nil {
 		return fmt.Errorf("unable to show: %s", err)
 	}
@@ -37,21 +38,21 @@ func aptlySnapshotShow(cmd *commander.Command, args []string) error {
 			var name string
 			if snapshot.SourceKind == deb.SourceSnapshot {
 				var source *deb.Snapshot
-				source, err = context.CollectionFactory().SnapshotCollection().ByUUID(sourceID)
+				source, err = collectionFactory.SnapshotCollection().ByUUID(sourceID)
 				if err != nil {
 					continue
 				}
 				name = source.Name
 			} else if snapshot.SourceKind == deb.SourceLocalRepo {
 				var source *deb.LocalRepo
-				source, err = context.CollectionFactory().LocalRepoCollection().ByUUID(sourceID)
+				source, err = collectionFactory.LocalRepoCollection().ByUUID(sourceID)
 				if err != nil {
 					continue
 				}
 				name = source.Name
 			} else if snapshot.SourceKind == deb.SourceRemoteRepo {
 				var source *deb.RemoteRepo
-				source, err = context.CollectionFactory().RemoteRepoCollection().ByUUID(sourceID)
+				source, err = collectionFactory.RemoteRepoCollection().ByUUID(sourceID)
 				if err != nil {
 					continue
 				}
@@ -66,7 +67,7 @@ func aptlySnapshotShow(cmd *commander.Command, args []string) error {
 
 	withPackages := context.Flags().Lookup("with-packages").Value.Get().(bool)
 	if withPackages {
-		ListPackagesRefList(snapshot.RefList())
+		ListPackagesRefList(snapshot.RefList(), collectionFactory)
 	}
 
 	return err

--- a/cmd/snapshot_verify.go
+++ b/cmd/snapshot_verify.go
@@ -16,13 +16,14 @@ func aptlySnapshotVerify(cmd *commander.Command, args []string) error {
 	}
 
 	snapshots := make([]*deb.Snapshot, len(args))
+	collectionFactory := context.NewCollectionFactory()
 	for i := range snapshots {
-		snapshots[i], err = context.CollectionFactory().SnapshotCollection().ByName(args[i])
+		snapshots[i], err = collectionFactory.SnapshotCollection().ByName(args[i])
 		if err != nil {
 			return fmt.Errorf("unable to verify: %s", err)
 		}
 
-		err = context.CollectionFactory().SnapshotCollection().LoadComplete(snapshots[i])
+		err = collectionFactory.SnapshotCollection().LoadComplete(snapshots[i])
 		if err != nil {
 			return fmt.Errorf("unable to verify: %s", err)
 		}
@@ -30,7 +31,7 @@ func aptlySnapshotVerify(cmd *commander.Command, args []string) error {
 
 	context.Progress().Printf("Loading packages...\n")
 
-	packageList, err := deb.NewPackageListFromRefList(snapshots[0].RefList(), context.CollectionFactory().PackageCollection(), context.Progress())
+	packageList, err := deb.NewPackageListFromRefList(snapshots[0].RefList(), collectionFactory.PackageCollection(), context.Progress())
 	if err != nil {
 		return fmt.Errorf("unable to load packages: %s", err)
 	}
@@ -43,7 +44,7 @@ func aptlySnapshotVerify(cmd *commander.Command, args []string) error {
 
 	var pL *deb.PackageList
 	for i := 1; i < len(snapshots); i++ {
-		pL, err = deb.NewPackageListFromRefList(snapshots[i].RefList(), context.CollectionFactory().PackageCollection(), context.Progress())
+		pL, err = deb.NewPackageListFromRefList(snapshots[i].RefList(), collectionFactory.PackageCollection(), context.Progress())
 		if err != nil {
 			return fmt.Errorf("unable to load packages: %s", err)
 		}

--- a/context/context.go
+++ b/context/context.go
@@ -42,7 +42,6 @@ type AptlyContext struct {
 	database          database.Storage
 	packagePool       aptly.PackagePool
 	publishedStorages map[string]aptly.PublishedStorage
-	collectionFactory *deb.CollectionFactory
 	dependencyOptions int
 	architecturesList []string
 	// Debug features
@@ -293,20 +292,16 @@ func (context *AptlyContext) ReOpenDatabase() error {
 	return err
 }
 
-// CollectionFactory builds factory producing all kinds of collections
-func (context *AptlyContext) CollectionFactory() *deb.CollectionFactory {
+// NewCollectionFactory builds factory producing all kinds of collections
+func (context *AptlyContext) NewCollectionFactory() *deb.CollectionFactory {
 	context.Lock()
 	defer context.Unlock()
 
-	if context.collectionFactory == nil {
-		db, err := context._database()
-		if err != nil {
-			Fatal(err)
-		}
-		context.collectionFactory = deb.NewCollectionFactory(db)
+	db, err := context._database()
+	if err != nil {
+		Fatal(err)
 	}
-
-	return context.collectionFactory
+	return deb.NewCollectionFactory(db)
 }
 
 // PackagePool returns instance of PackagePool

--- a/context/context.go
+++ b/context/context.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aptly-dev/aptly/pgp"
 	"github.com/aptly-dev/aptly/s3"
 	"github.com/aptly-dev/aptly/swift"
+	"github.com/aptly-dev/aptly/task"
 	"github.com/aptly-dev/aptly/utils"
 	"github.com/smira/commander"
 	"github.com/smira/flag"
@@ -39,6 +40,7 @@ type AptlyContext struct {
 
 	progress          aptly.Progress
 	downloader        aptly.Downloader
+	taskList          *task.List
 	database          database.Storage
 	packagePool       aptly.PackagePool
 	publishedStorages map[string]aptly.PublishedStorage
@@ -198,24 +200,49 @@ func (context *AptlyContext) _progress() aptly.Progress {
 	return context.progress
 }
 
+// NewDownloader returns instance of new downloader with given progress
+func (context *AptlyContext) NewDownloader(progress aptly.Progress) aptly.Downloader {
+	context.Lock()
+	defer context.Unlock()
+
+	return context.newDownloader(progress)
+}
+
+// NewDownloader returns instance of new downloader with given progress without locking
+// so it can be used for internal usage.
+func (context *AptlyContext) newDownloader(progress aptly.Progress) aptly.Downloader {
+	var downloadLimit int64
+	limitFlag := context.flags.Lookup("download-limit")
+	if limitFlag != nil {
+		downloadLimit = limitFlag.Value.Get().(int64)
+	}
+	if downloadLimit == 0 {
+		downloadLimit = context.config().DownloadLimit
+	}
+	return http.NewDownloader(downloadLimit*1024, progress)
+}
+
 // Downloader returns instance of current downloader
 func (context *AptlyContext) Downloader() aptly.Downloader {
 	context.Lock()
 	defer context.Unlock()
 
 	if context.downloader == nil {
-		var downloadLimit int64
-		limitFlag := context.flags.Lookup("download-limit")
-		if limitFlag != nil {
-			downloadLimit = limitFlag.Value.Get().(int64)
-		}
-		if downloadLimit == 0 {
-			downloadLimit = context.config().DownloadLimit
-		}
-		context.downloader = http.NewDownloader(downloadLimit*1024, context._progress())
+		context.downloader = context.newDownloader(context._progress())
 	}
 
 	return context.downloader
+}
+
+// TaskList returns instance of current task list
+func (context *AptlyContext) TaskList() *task.List {
+	context.Lock()
+	defer context.Unlock()
+
+	if context.taskList == nil {
+		context.taskList = task.NewList()
+	}
+	return context.taskList
 }
 
 // DBPath builds path to database

--- a/database/leveldb.go
+++ b/database/leveldb.go
@@ -35,6 +35,7 @@ type Storage interface {
 	Open() error
 	Close() error
 	StartBatch()
+	ResetBatch()
 	FinishBatch() error
 	CompactDB() error
 	Drop() error
@@ -240,6 +241,11 @@ func (l *levelDB) StartBatch() {
 		panic("batch already started")
 	}
 	l.batch = new(leveldb.Batch)
+}
+
+// ResetBatch reverts current batch
+func (l *levelDB) ResetBatch() {
+	l.batch = nil
 }
 
 // FinishBatch finalizes the batch, saving operations

--- a/database/leveldb.go
+++ b/database/leveldb.go
@@ -41,8 +41,8 @@ type Storage interface {
 }
 
 type levelDB struct {
-	path  string
-	db    *leveldb.DB
+	path string
+	db   *leveldb.DB
 }
 
 // Check interface

--- a/database/leveldb_test.go
+++ b/database/leveldb_test.go
@@ -176,9 +176,9 @@ func (s *LevelDBSuite) TestBatch(c *C) {
 	err := s.db.Put(key, value)
 	c.Assert(err, IsNil)
 
-	s.db.StartBatch()
-	s.db.Put(key2, value2)
-	s.db.Delete(key)
+	batch := s.db.StartBatch()
+	batch.Put(key2, value2)
+	batch.Delete(key)
 
 	v, err := s.db.Get(key)
 	c.Check(err, IsNil)
@@ -187,7 +187,7 @@ func (s *LevelDBSuite) TestBatch(c *C) {
 	_, err = s.db.Get(key2)
 	c.Check(err, ErrorMatches, "key not found")
 
-	err = s.db.FinishBatch()
+	err = s.db.FinishBatch(batch)
 	c.Check(err, IsNil)
 
 	v2, err := s.db.Get(key2)
@@ -196,11 +196,6 @@ func (s *LevelDBSuite) TestBatch(c *C) {
 
 	_, err = s.db.Get(key)
 	c.Check(err, ErrorMatches, "key not found")
-
-	c.Check(func() { s.db.FinishBatch() }, Panics, "no batch")
-
-	s.db.StartBatch()
-	c.Check(func() { s.db.StartBatch() }, Panics, "batch already started")
 }
 
 func (s *LevelDBSuite) TestCompactDB(c *C) {

--- a/deb/changes.go
+++ b/deb/changes.go
@@ -293,14 +293,9 @@ func CollectChangesFiles(locations []string, reporter aptly.ResultReporter) (cha
 
 // ImportChangesFiles imports referenced files in changes files into local repository
 func ImportChangesFiles(changesFiles []string, reporter aptly.ResultReporter, acceptUnsigned, ignoreSignatures, forceReplace, noRemoveFiles bool,
-	verifier pgp.Verifier, repoTemplateString string, progress aptly.Progress, localRepoCollection *LocalRepoCollection, packageCollection *PackageCollection,
+	verifier pgp.Verifier, repoTemplate *template.Template, progress aptly.Progress, localRepoCollection *LocalRepoCollection, packageCollection *PackageCollection,
 	pool aptly.PackagePool, checksumStorage aptly.ChecksumStorage, uploaders *Uploaders, parseQuery parseQuery) (processedFiles []string, failedFiles []string, err error) {
 
-	var repoTemplate *template.Template
-	repoTemplate, err = template.New("repo").Parse(repoTemplateString)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error parsing -repo template: %s", err)
-	}
 	for _, path := range changesFiles {
 		var changes *Changes
 

--- a/deb/changes_test.go
+++ b/deb/changes_test.go
@@ -3,6 +3,7 @@ package deb
 import (
 	"os"
 	"path/filepath"
+	"text/template"
 
 	"github.com/aptly-dev/aptly/aptly"
 	"github.com/aptly-dev/aptly/console"
@@ -122,7 +123,8 @@ func (s *ChangesSuite) TestImportChangesFiles(c *C) {
 	processedFiles, failedFiles, err := ImportChangesFiles(
 		append(changesFiles, "testdata/changes/notexistent.changes"),
 		s.Reporter, true, true, false, false, &NullVerifier{},
-		"test", s.progress, s.localRepoCollection, s.packageCollection, s.packagePool, s.checksumStorage,
+		template.Must(template.New("test").Parse("test")), s.progress,
+		s.localRepoCollection, s.packageCollection, s.packagePool, s.checksumStorage,
 		nil, nil)
 	c.Assert(err, IsNil)
 	c.Check(failedFiles, DeepEquals, append(expectedFailedFiles, "testdata/changes/notexistent.changes"))

--- a/deb/local.go
+++ b/deb/local.go
@@ -98,7 +98,7 @@ type LocalRepoCollection struct {
 // NewLocalRepoCollection loads LocalRepos from DB and makes up collection
 func NewLocalRepoCollection(db database.Storage) *LocalRepoCollection {
 	result := &LocalRepoCollection{
-		db:      db,
+		db: db,
 	}
 
 	blobs := db.FetchByPrefix([]byte("L"))

--- a/deb/local.go
+++ b/deb/local.go
@@ -135,6 +135,8 @@ func (collection *LocalRepoCollection) Add(repo *LocalRepo) error {
 
 // Update stores updated information about repo in DB
 func (collection *LocalRepoCollection) Update(repo *LocalRepo) error {
+	collection.db.StartBatch()
+	defer collection.db.ResetBatch()
 	err := collection.db.Put(repo.Key(), repo.Encode())
 	if err != nil {
 		return err
@@ -145,7 +147,7 @@ func (collection *LocalRepoCollection) Update(repo *LocalRepo) error {
 			return err
 		}
 	}
-	return nil
+	return collection.db.FinishBatch()
 }
 
 // LoadComplete loads additional information for local repo
@@ -217,10 +219,17 @@ func (collection *LocalRepoCollection) Drop(repo *LocalRepo) error {
 	collection.list[len(collection.list)-1], collection.list[repoPosition], collection.list =
 		nil, collection.list[len(collection.list)-1], collection.list[:len(collection.list)-1]
 
+	collection.db.StartBatch()
+	defer collection.db.ResetBatch()
 	err := collection.db.Delete(repo.Key())
 	if err != nil {
 		return err
 	}
 
-	return collection.db.Delete(repo.RefKey())
+	err = collection.db.Delete(repo.RefKey())
+	if err != nil {
+		return err
+	}
+
+	return collection.db.FinishBatch()
 }

--- a/deb/local.go
+++ b/deb/local.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"log"
-	"sync"
 
 	"github.com/aptly-dev/aptly/database"
 	"github.com/pborman/uuid"
@@ -92,7 +91,6 @@ func (repo *LocalRepo) RefKey() []byte {
 
 // LocalRepoCollection does listing, updating/adding/deleting of LocalRepos
 type LocalRepoCollection struct {
-	*sync.RWMutex
 	db   database.Storage
 	list []*LocalRepo
 }
@@ -100,7 +98,6 @@ type LocalRepoCollection struct {
 // NewLocalRepoCollection loads LocalRepos from DB and makes up collection
 func NewLocalRepoCollection(db database.Storage) *LocalRepoCollection {
 	result := &LocalRepoCollection{
-		RWMutex: &sync.RWMutex{},
 		db:      db,
 	}
 

--- a/deb/package_collection.go
+++ b/deb/package_collection.go
@@ -215,6 +215,9 @@ func (collection *PackageCollection) Update(p *Package) error {
 		return err
 	}
 
+	collection.db.StartBatch()
+	defer collection.db.ResetBatch()
+
 	err = collection.db.Put(p.Key(""), encodeBuffer.Bytes())
 	if err != nil {
 		return err
@@ -265,8 +268,7 @@ func (collection *PackageCollection) Update(p *Package) error {
 	}
 
 	p.collection = collection
-
-	return nil
+	return collection.db.FinishBatch()
 }
 
 // AllPackageRefs returns list of all packages as PackageRefList

--- a/deb/package_collection_test.go
+++ b/deb/package_collection_test.go
@@ -113,7 +113,9 @@ func (s *PackageCollectionSuite) TestDeleteByKey(c *C) {
 	_, err = s.db.Get(s.p.Key("xF"))
 	c.Check(err, IsNil)
 
-	err = s.collection.DeleteByKey(s.p.Key(""))
+	batch := s.db.StartBatch()
+	s.collection.DeleteByKey(s.p.Key(""), batch)
+	err = s.db.FinishBatch(batch)
 	c.Check(err, IsNil)
 
 	_, err = s.collection.ByKey(s.p.Key(""))

--- a/deb/publish.go
+++ b/deb/publish.go
@@ -604,8 +604,7 @@ func (p *PublishedRepo) Publish(packagePool aptly.PackagePool, publishedStorageP
 			// to push each path of the package into the database.
 			// We'll want this batched so as to avoid an excessive
 			// amount of write() calls.
-			tempDB.StartBatch()
-			defer tempDB.FinishBatch()
+			batch := tempDB.StartBatch()
 
 			for _, arch := range p.Architectures {
 				if pkg.MatchesArchitecture(arch) {
@@ -649,7 +648,7 @@ func (p *PublishedRepo) Publish(packagePool aptly.PackagePool, publishedStorageP
 			pkg.extra = nil
 			pkg.contents = nil
 
-			return nil
+			return tempDB.FinishBatch(batch)
 		})
 
 		if err != nil {
@@ -896,25 +895,17 @@ func (collection *PublishedRepoCollection) CheckDuplicate(repo *PublishedRepo) *
 }
 
 // Update stores updated information about repo in DB
-func (collection *PublishedRepoCollection) Update(repo *PublishedRepo) (err error) {
-	collection.db.StartBatch()
-	defer collection.db.ResetBatch()
-
-	err = collection.db.Put(repo.Key(), repo.Encode())
-	if err != nil {
-		return
-	}
+func (collection *PublishedRepoCollection) Update(repo *PublishedRepo) error {
+	batch := collection.db.StartBatch()
+	batch.Put(repo.Key(), repo.Encode())
 
 	if repo.SourceKind == SourceLocalRepo {
 		for component, item := range repo.sourceItems {
-			err = collection.db.Put(repo.RefKey(component), item.packageRefs.Encode())
-			if err != nil {
-				return
-			}
+			batch.Put(repo.RefKey(component), item.packageRefs.Encode())
 		}
 	}
-	err = collection.db.FinishBatch()
-	return
+
+	return collection.db.FinishBatch(batch)
 }
 
 // LoadComplete loads additional information for remote repo
@@ -1135,7 +1126,7 @@ func (collection *PublishedRepoCollection) CleanupPrefixComponentFiles(prefix st
 		}
 	}
 
-	return collection.db.FinishBatch()
+	return nil
 }
 
 // Remove removes published repository, cleaning up directories, files
@@ -1188,19 +1179,12 @@ func (collection *PublishedRepoCollection) Remove(publishedStorageProvider aptly
 		}
 	}
 
-	collection.db.StartBatch()
-	defer collection.db.ResetBatch()
-	err = collection.db.Delete(repo.Key())
-	if err != nil {
-		return err
-	}
+	batch := collection.db.StartBatch()
+	batch.Delete(repo.Key())
 
 	for _, component := range repo.Components() {
-		err = collection.db.Delete(repo.RefKey(component))
-		if err != nil {
-			return err
-		}
+		batch.Delete(repo.RefKey(component))
 	}
 
-	return nil
+	return collection.db.FinishBatch(batch)
 }

--- a/deb/publish.go
+++ b/deb/publish.go
@@ -897,6 +897,9 @@ func (collection *PublishedRepoCollection) CheckDuplicate(repo *PublishedRepo) *
 
 // Update stores updated information about repo in DB
 func (collection *PublishedRepoCollection) Update(repo *PublishedRepo) (err error) {
+	collection.db.StartBatch()
+	defer collection.db.ResetBatch()
+
 	err = collection.db.Put(repo.Key(), repo.Encode())
 	if err != nil {
 		return
@@ -910,6 +913,7 @@ func (collection *PublishedRepoCollection) Update(repo *PublishedRepo) (err erro
 			}
 		}
 	}
+	err = collection.db.FinishBatch()
 	return
 }
 
@@ -1131,7 +1135,7 @@ func (collection *PublishedRepoCollection) CleanupPrefixComponentFiles(prefix st
 		}
 	}
 
-	return nil
+	return collection.db.FinishBatch()
 }
 
 // Remove removes published repository, cleaning up directories, files
@@ -1184,6 +1188,8 @@ func (collection *PublishedRepoCollection) Remove(publishedStorageProvider aptly
 		}
 	}
 
+	collection.db.StartBatch()
+	defer collection.db.ResetBatch()
 	err = collection.db.Delete(repo.Key())
 	if err != nil {
 		return err

--- a/deb/publish.go
+++ b/deb/publish.go
@@ -850,7 +850,7 @@ type PublishedRepoCollection struct {
 // NewPublishedRepoCollection loads PublishedRepos from DB and makes up collection
 func NewPublishedRepoCollection(db database.Storage) *PublishedRepoCollection {
 	result := &PublishedRepoCollection{
-		db:      db,
+		db: db,
 	}
 
 	blobs := db.FetchByPrefix([]byte("U"))

--- a/deb/publish.go
+++ b/deb/publish.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/pborman/uuid"
@@ -845,7 +844,6 @@ func (p *PublishedRepo) RemoveFiles(publishedStorageProvider aptly.PublishedStor
 
 // PublishedRepoCollection does listing, updating/adding/deleting of PublishedRepos
 type PublishedRepoCollection struct {
-	*sync.RWMutex
 	db   database.Storage
 	list []*PublishedRepo
 }
@@ -853,7 +851,6 @@ type PublishedRepoCollection struct {
 // NewPublishedRepoCollection loads PublishedRepos from DB and makes up collection
 func NewPublishedRepoCollection(db database.Storage) *PublishedRepoCollection {
 	result := &PublishedRepoCollection{
-		RWMutex: &sync.RWMutex{},
 		db:      db,
 	}
 

--- a/deb/remote.go
+++ b/deb/remote.go
@@ -11,7 +11,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
@@ -653,7 +652,6 @@ func (repo *RemoteRepo) RefKey() []byte {
 
 // RemoteRepoCollection does listing, updating/adding/deleting of RemoteRepos
 type RemoteRepoCollection struct {
-	*sync.RWMutex
 	db   database.Storage
 	list []*RemoteRepo
 }
@@ -661,7 +659,6 @@ type RemoteRepoCollection struct {
 // NewRemoteRepoCollection loads RemoteRepos from DB and makes up collection
 func NewRemoteRepoCollection(db database.Storage) *RemoteRepoCollection {
 	result := &RemoteRepoCollection{
-		RWMutex: &sync.RWMutex{},
 		db:      db,
 	}
 

--- a/deb/remote.go
+++ b/deb/remote.go
@@ -667,7 +667,7 @@ type RemoteRepoCollection struct {
 // NewRemoteRepoCollection loads RemoteRepos from DB and makes up collection
 func NewRemoteRepoCollection(db database.Storage) *RemoteRepoCollection {
 	result := &RemoteRepoCollection{
-		db:      db,
+		db: db,
 	}
 
 	blobs := db.FetchByPrefix([]byte("R"))

--- a/deb/remote.go
+++ b/deb/remote.go
@@ -445,8 +445,10 @@ func (repo *RemoteRepo) DownloadPackageIndexes(progress aptly.Progress, d aptly.
 		}
 		defer packagesFile.Close()
 
-		stat, _ := packagesFile.Stat()
-		progress.InitBar(stat.Size(), true)
+		if progress != nil {
+			stat, _ := packagesFile.Stat()
+			progress.InitBar(stat.Size(), true)
+		}
 
 		sreader := NewControlFileReader(packagesReader)
 
@@ -459,8 +461,10 @@ func (repo *RemoteRepo) DownloadPackageIndexes(progress aptly.Progress, d aptly.
 				break
 			}
 
-			off, _ := packagesFile.Seek(0, 1)
-			progress.SetBar(int(off))
+			if progress != nil {
+				off, _ := packagesFile.Seek(0, 1)
+				progress.SetBar(int(off))
+			}
 
 			var p *Package
 
@@ -477,14 +481,18 @@ func (repo *RemoteRepo) DownloadPackageIndexes(progress aptly.Progress, d aptly.
 			err = repo.packageList.Add(p)
 			if err != nil {
 				if _, ok := err.(*PackageConflictError); ok {
-					progress.ColoredPrintf("@y[!]@| @!skipping package %s: duplicate in packages index@|", p)
+					if progress != nil {
+						progress.ColoredPrintf("@y[!]@| @!skipping package %s: duplicate in packages index@|", p)
+					}
 				} else {
 					return err
 				}
 			}
 		}
 
-		progress.ShutdownBar()
+		if progress != nil {
+			progress.ShutdownBar()
+		}
 	}
 
 	return nil

--- a/deb/snapshot.go
+++ b/deb/snapshot.go
@@ -119,6 +119,13 @@ func (s *Snapshot) Key() []byte {
 	return []byte("S" + s.UUID)
 }
 
+// ResourceKey is a unique identifier of the resource
+// this snapshot uses. Instead of uuid it uses name
+// which needs to be unique as well.
+func (s *Snapshot) ResourceKey() []byte {
+	return []byte("S" + s.Name)
+}
+
 // RefKey is a unique id for package reference list
 func (s *Snapshot) RefKey() []byte {
 	return []byte("E" + s.UUID)
@@ -178,7 +185,7 @@ type SnapshotCollection struct {
 // NewSnapshotCollection loads Snapshots from DB and makes up collection
 func NewSnapshotCollection(db database.Storage) *SnapshotCollection {
 	result := &SnapshotCollection{
-		db:      db,
+		db: db,
 	}
 
 	blobs := db.FetchByPrefix([]byte("S"))

--- a/deb/snapshot.go
+++ b/deb/snapshot.go
@@ -215,21 +215,14 @@ func (collection *SnapshotCollection) Add(snapshot *Snapshot) error {
 
 // Update stores updated information about repo in DB
 func (collection *SnapshotCollection) Update(snapshot *Snapshot) error {
-	collection.db.StartBatch()
-	defer collection.db.ResetBatch()
+	batch := collection.db.StartBatch()
 
-	err := collection.db.Put(snapshot.Key(), snapshot.Encode())
-	if err != nil {
-		return err
-	}
+	batch.Put(snapshot.Key(), snapshot.Encode())
 	if snapshot.packageRefs != nil {
-		err = collection.db.Put(snapshot.RefKey(), snapshot.packageRefs.Encode())
-		if err != nil {
-			return err
-		}
+		batch.Put(snapshot.RefKey(), snapshot.packageRefs.Encode())
 	}
 
-	return collection.db.FinishBatch()
+	return collection.db.FinishBatch(batch)
 }
 
 // LoadComplete loads additional information about snapshot
@@ -352,19 +345,10 @@ func (collection *SnapshotCollection) Drop(snapshot *Snapshot) error {
 	collection.list[len(collection.list)-1], collection.list[snapshotPosition], collection.list =
 		nil, collection.list[len(collection.list)-1], collection.list[:len(collection.list)-1]
 
-	collection.db.StartBatch()
-	defer collection.db.ResetBatch()
-	err := collection.db.Delete(snapshot.Key())
-	if err != nil {
-		return err
-	}
-
-	err = collection.db.Delete(snapshot.RefKey())
-	if err != nil {
-		return err
-	}
-
-	return collection.db.FinishBatch()
+	batch := collection.db.StartBatch()
+	batch.Delete(snapshot.Key())
+	batch.Delete(snapshot.RefKey())
+	return collection.db.FinishBatch(batch)
 }
 
 // Snapshot sorting methods

--- a/deb/snapshot.go
+++ b/deb/snapshot.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/aptly-dev/aptly/database"
@@ -172,7 +171,6 @@ func (s *Snapshot) Decode(input []byte) error {
 
 // SnapshotCollection does listing, updating/adding/deleting of Snapshots
 type SnapshotCollection struct {
-	*sync.RWMutex
 	db   database.Storage
 	list []*Snapshot
 }
@@ -180,7 +178,6 @@ type SnapshotCollection struct {
 // NewSnapshotCollection loads Snapshots from DB and makes up collection
 func NewSnapshotCollection(db database.Storage) *SnapshotCollection {
 	result := &SnapshotCollection{
-		RWMutex: &sync.RWMutex{},
 		db:      db,
 	}
 

--- a/http/download.go
+++ b/http/download.go
@@ -50,7 +50,7 @@ func NewDownloader(downLimit int64, progress aptly.Progress) aptly.Downloader {
 		},
 	}
 
-	if downLimit > 0 {
+	if downLimit > 0 && progress != nil {
 		downloader.aggWriter = flowrate.NewWriter(progress, downLimit)
 	} else {
 		downloader.aggWriter = progress
@@ -85,7 +85,9 @@ func retryableError(err error) bool {
 func (downloader *downloaderImpl) DownloadWithChecksum(ctx context.Context, url string, destination string,
 	expected *utils.ChecksumInfo, ignoreMismatch bool, maxTries int) error {
 
-	downloader.progress.Printf("Downloading %s...\n", url)
+	if downloader.progress != nil {
+		downloader.progress.Printf("Downloading %s...\n", url)
+	}
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -153,7 +155,11 @@ func (downloader *downloaderImpl) download(req *http.Request, url, destination s
 	defer outfile.Close()
 
 	checksummer := utils.NewChecksumWriter()
-	writers := []io.Writer{outfile, downloader.aggWriter}
+	writers := []io.Writer{outfile}
+
+	if downloader.progress != nil {
+		writers = append(writers, downloader.progress)
+	}
 
 	if expected != nil {
 		writers = append(writers, checksummer)

--- a/http/download.go
+++ b/http/download.go
@@ -190,7 +190,9 @@ func (downloader *downloaderImpl) download(req *http.Request, url, destination s
 
 		if err != nil {
 			if ignoreMismatch {
-				downloader.progress.Printf("WARNING: %s\n", err.Error())
+				if downloader.progress != nil {
+					downloader.progress.Printf("WARNING: %s\n", err.Error())
+				}
 			} else {
 				os.Remove(temppath)
 				return "", err

--- a/system/api_lib.py
+++ b/system/api_lib.py
@@ -47,6 +47,17 @@ class APITest(BaseTest):
             kwargs["headers"]["Content-Type"] = "application/json"
         return requests.post("http://%s%s" % (self.base_url, uri), *args, **kwargs)
 
+    def post_task(self, uri, *args, **kwargs):
+        resp = self.post(uri, *args, **kwargs)
+        if resp.status_code != 202:
+            return resp
+
+        _id = resp.json()['ID']
+        resp = self.get("/api/tasks/" + str(_id) + "/wait")
+        self.check_equal(resp.status_code, 200)
+
+        return self.get("/api/tasks/" + str(_id))
+
     def put(self, uri, *args, **kwargs):
         if "json" in kwargs:
             kwargs["data"] = json.dumps(kwargs.pop("json"))
@@ -55,6 +66,17 @@ class APITest(BaseTest):
             kwargs["headers"]["Content-Type"] = "application/json"
         return requests.put("http://%s%s" % (self.base_url, uri), *args, **kwargs)
 
+    def put_task(self, uri, *args, **kwargs):
+        resp = self.put(uri, *args, **kwargs)
+        if resp.status_code != 202:
+            return resp
+
+        _id = resp.json()['ID']
+        resp = self.get("/api/tasks/" + str(_id) + "/wait")
+        self.check_equal(resp.status_code, 200)
+
+        return self.get("/api/tasks/" + str(_id))
+
     def delete(self, uri, *args, **kwargs):
         if "json" in kwargs:
             kwargs["data"] = json.dumps(kwargs.pop("json"))
@@ -62,6 +84,17 @@ class APITest(BaseTest):
                 kwargs["headers"] = {}
             kwargs["headers"]["Content-Type"] = "application/json"
         return requests.delete("http://%s%s" % (self.base_url, uri), *args, **kwargs)
+
+    def delete_task(self, uri, *args, **kwargs):
+        resp = self.delete(uri, *args, **kwargs)
+        if resp.status_code != 202:
+            return resp
+
+        _id = resp.json()['ID']
+        resp = self.get("/api/tasks/" + str(_id) + "/wait")
+        self.check_equal(resp.status_code, 200)
+
+        return self.get("/api/tasks/" + str(_id))
 
     def upload(self, uri, *filenames, **kwargs):
         upload_name = kwargs.pop("upload_name", None)

--- a/system/t12_api/gpg.py
+++ b/system/t12_api/gpg.py
@@ -1,0 +1,53 @@
+import inspect
+import os
+import subprocess
+import tempfile
+
+from api_lib import APITest
+
+
+def check_gpgkey_exists(gpg_key, keyring):
+    subprocess.check_call([
+        "gpg", "--no-default-keyring",
+        "--keyring", keyring,
+        "--fingerprint", gpg_key,
+    ])
+
+
+class GPGAPITestAddKey(APITest):
+    """
+    POST /gpg/key
+    """
+    def check(self):
+        with tempfile.NamedTemporaryFile(suffix=".pub") as keyring:
+            gpgkeyid = "9E3E53F19C7DE460"
+            resp = self.post("/api/gpg/key", json={
+                "Keyserver": "keys.gnupg.net",
+                "Keyring": keyring.name,
+                "GpgKeyID": gpgkeyid
+            })
+
+            self.check_equal(resp.status_code, 200)
+            check_gpgkey_exists(gpgkeyid, keyring.name)
+
+
+class GPGAPITestAddKeyArmor(APITest):
+    """
+    POST /gpg/key
+    """
+    def check(self):
+        keyfile = os.path.join(os.path.dirname(inspect.getsourcefile(APITest)),
+                               "files") + "/launchpad.key"
+        gpgkeyid = "3B1F56C0"
+
+        with open(keyfile, 'r') as keyf:
+            gpgkeyarmor = keyf.read()
+
+        with tempfile.NamedTemporaryFile(suffix=".pub") as keyring:
+            resp = self.post("/api/gpg/key", json={
+                "Keyring": keyring.name,
+                "GpgKeyArmor": gpgkeyarmor
+            })
+
+            self.check_equal(resp.status_code, 200)
+            check_gpgkey_exists(gpgkeyid, keyring.name)

--- a/system/t12_api/graph.py
+++ b/system/t12_api/graph.py
@@ -44,4 +44,6 @@ class GraphAPITest(APITest):
 
         # remove the repos again
         for repo in tempRepos:
-            self.check_equal(self.delete("/api/repos/" + repo, params={"force": "1"}).status_code, 200)
+            self.check_equal(self.delete_task(
+                "/api/repos/" + repo, params={"force": "1"}).json()['State'], 2
+            )

--- a/system/t12_api/mirrors.py
+++ b/system/t12_api/mirrors.py
@@ -1,0 +1,116 @@
+from api_lib import APITest
+
+
+class MirrorsAPITestCreateShow(APITest):
+    """
+    POST /api/mirrors, GET /api/mirrors/:name/packages
+    """
+    def check(self):
+        mirror_name = self.random_name()
+        mirror_desc = {u'Name': mirror_name,
+                       u'ArchiveURL': 'http://security.debian.org/',
+                       u'Architectures': ['amd64'],
+                       u'Components': ['main'],
+                       u'Distribution': 'wheezy/updates'}
+
+        resp = self.post("/api/mirrors", json=mirror_desc)
+        self.check_equal(resp.status_code, 400)
+        self.check_equal({
+            'error': 'unable to fetch mirror: verification of detached signature failed: exit status 2',
+        }, resp.json())
+
+        mirror_desc[u'IgnoreSignatures'] = True
+        resp = self.post("/api/mirrors", json=mirror_desc)
+        self.check_equal(resp.status_code, 201)
+
+        resp = self.get("/api/mirrors/" + mirror_name)
+        self.check_equal(resp.status_code, 200)
+        self.check_subset({u'Name': mirror_name,
+                           u'ArchiveRoot': 'http://security.debian.org/',
+                           u'Architectures': ['amd64'],
+                           u'Components': ['main'],
+                           u'Distribution': 'wheezy/updates'}, resp.json())
+
+        resp = self.get("/api/mirrors/" + mirror_desc["Name"] + "/packages")
+        self.check_equal(resp.status_code, 404)
+
+
+class MirrorsAPITestCreateUpdate(APITest):
+    """
+    POST /api/mirrors, PUT /api/mirrors/:name, GET /api/mirrors/:name/packages
+    """
+    def check(self):
+        mirror_name = self.random_name()
+        mirror_desc = {u'Name': mirror_name,
+                       u'ArchiveURL': 'https://packagecloud.io/varnishcache/varnish30/debian/',
+                       u'Distribution': 'wheezy',
+                       u'Components': ['main']}
+
+        mirror_desc[u'IgnoreSignatures'] = True
+        resp = self.post("/api/mirrors", json=mirror_desc)
+        self.check_equal(resp.status_code, 201)
+
+        resp = self.get("/api/mirrors/" + mirror_name + "/packages")
+        self.check_equal(resp.status_code, 404)
+
+        mirror_desc["Name"] = self.random_name()
+        resp = self.put_task("/api/mirrors/" + mirror_name, json=mirror_desc)
+        self.check_equal(resp.json()["State"], 2)
+
+        _id = resp.json()['ID']
+        resp = self.get("/api/tasks/" + str(_id) + "/detail")
+        self.check_equal(resp.status_code, 200)
+        self.check_equal(resp.json()['RemainingDownloadSize'], 0)
+        self.check_equal(resp.json()['RemainingNumberOfPackages'], 0)
+
+        resp = self.get("/api/mirrors/" + mirror_desc["Name"])
+        self.check_equal(resp.status_code, 200)
+        self.check_subset({u'Name': mirror_desc["Name"],
+                           u'ArchiveRoot': 'https://packagecloud.io/varnishcache/varnish30/debian/',
+                           u'Distribution': 'wheezy'}, resp.json())
+
+        resp = self.get("/api/mirrors/" + mirror_desc["Name"] + "/packages")
+        self.check_equal(resp.status_code, 200)
+
+
+class MirrorsAPITestCreateDelete(APITest):
+    """
+    POST /api/mirrors, DELETE /api/mirrors/:name
+    """
+    def check(self):
+        mirror_name = self.random_name()
+        mirror_desc = {u'Name': mirror_name,
+                       u'ArchiveURL': 'https://packagecloud.io/varnishcache/varnish30/debian/',
+                       u'IgnoreSignatures': True,
+                       u'Distribution': 'wheezy',
+                       u'Components': ['main']}
+
+        resp = self.post("/api/mirrors", json=mirror_desc)
+        self.check_equal(resp.status_code, 201)
+
+        resp = self.delete_task("/api/mirrors/" + mirror_name)
+        self.check_equal(resp.json()['State'], 2)
+
+
+class MirrorsAPITestCreateList(APITest):
+    """
+    GET /api/mirrors, POST /api/mirrors, GET /api/mirrors
+    """
+    def check(self):
+        resp = self.get("/api/mirrors")
+        self.check_equal(resp.status_code, 200)
+        count = len(resp.json())
+
+        mirror_name = self.random_name()
+        mirror_desc = {u'Name': mirror_name,
+                       u'ArchiveURL': 'https://packagecloud.io/varnishcache/varnish30/debian/',
+                       u'IgnoreSignatures': True,
+                       u'Distribution': 'wheezy',
+                       u'Components': ['main']}
+
+        resp = self.post("/api/mirrors", json=mirror_desc)
+        self.check_equal(resp.status_code, 201)
+
+        resp = self.get("/api/mirrors")
+        self.check_equal(resp.status_code, 200)
+        self.check_equal(len(resp.json()), count + 1)

--- a/system/t12_api/packages.py
+++ b/system/t12_api/packages.py
@@ -15,8 +15,8 @@ class PackagesAPITestShow(APITest):
         self.check_equal(self.upload("/api/files/" + d,
                          "pyspi_0.6.1-1.3.dsc", "pyspi_0.6.1-1.3.diff.gz", "pyspi_0.6.1.orig.tar.gz").status_code, 200)
 
-        resp = self.post("/api/repos/" + repo_name + "/file/" + d)
-        self.check_equal(resp.status_code, 200)
+        resp = self.post_task("/api/repos/" + repo_name + "/file/" + d)
+        self.check_equal(resp.json()['State'], 2)
 
         # get information about package
         resp = self.get("/api/packages/" + urllib.quote('Psource pyspi 0.6.1-1.3 3a8b37cbd9a3559e'))

--- a/system/t12_api/publish.py
+++ b/system/t12_api/publish.py
@@ -25,16 +25,18 @@ class PublishAPITestRepo(APITest):
                                      "pyspi_0.6.1-1.3.diff.gz", "pyspi_0.6.1.orig.tar.gz",
                                      "pyspi-0.6.1-1.3.stripped.dsc").status_code, 200)
 
-        self.check_equal(self.post("/api/repos/" + repo_name + "/file/" + d).status_code, 200)
+        self.check_equal(self.post_task("/api/repos/" + repo_name + "/file/" + d).json()['State'], 2)
 
         # publishing under prefix, default distribution
         prefix = self.random_name()
-        resp = self.post("/api/publish/" + prefix,
-                         json={
-                             "SourceKind": "local",
-                             "Sources": [{"Name": repo_name}],
-                             "Signing": DefaultSigningOptions,
-                         })
+        resp = self.post_task(
+            "/api/publish/" + prefix,
+            json={
+                 "SourceKind": "local",
+                 "Sources": [{"Name": repo_name}],
+                 "Signing": DefaultSigningOptions,
+            }
+        )
         repo_expected = {
             'AcquireByHash': False,
             'Architectures': ['i386', 'source'],
@@ -49,8 +51,7 @@ class PublishAPITestRepo(APITest):
             'Sources': [{'Component': 'main', 'Name': repo_name}],
             'Storage': ''}
 
-        self.check_equal(resp.status_code, 201)
-        self.check_equal(resp.json(), repo_expected)
+        self.check_equal(resp.json()['State'], 2)
 
         all_repos = self.get("/api/publish")
         self.check_equal(all_repos.status_code, 200)
@@ -64,14 +65,17 @@ class PublishAPITestRepo(APITest):
 
         # publishing under root, custom distribution, architectures
         distribution = self.random_name()
-        resp = self.post("/api/publish/:.",
-                         json={
-                             "SourceKind": "local",
-                             "Sources": [{"Name": repo_name}],
-                             "Signing": DefaultSigningOptions,
-                             "Distribution": distribution,
-                             "Architectures": ["i386", "amd64"],
-                         })
+        resp = self.post_task(
+            "/api/publish/:.",
+            json={
+                 "SourceKind": "local",
+                 "Sources": [{"Name": repo_name}],
+                 "Signing": DefaultSigningOptions,
+                 "Distribution": distribution,
+                 "Architectures": ["i386", "amd64"],
+            }
+        )
+        self.check_equal(resp.json()['State'], 2)
         repo2_expected = {
             'AcquireByHash': False,
             'Architectures': ['amd64', 'i386'],
@@ -85,8 +89,9 @@ class PublishAPITestRepo(APITest):
             'SourceKind': 'local',
             'Sources': [{'Component': 'main', 'Name': repo_name}],
             'Storage': ''}
-        self.check_equal(resp.status_code, 201)
-        self.check_equal(resp.json(), repo2_expected)
+        all_repos = self.get("/api/publish")
+        self.check_equal(all_repos.status_code, 200)
+        self.check_in(repo_expected, all_repos.json())
 
         self.check_exists("public/dists/" + distribution + "/Release")
         self.check_exists("public/dists/" + distribution + "/main/binary-i386/Packages")
@@ -115,23 +120,25 @@ class PublishSnapshotAPITest(APITest):
         self.check_equal(self.upload("/api/files/" + d,
                          "libboost-program-options-dev_1.49.0.1_i386.deb").status_code, 200)
 
-        self.check_equal(self.post("/api/repos/" + repo_name + "/file/" + d).status_code, 200)
+        self.check_equal(self.post_task("/api/repos/" + repo_name + "/file/" + d).json()['State'], 2)
 
-        self.check_equal(self.post("/api/repos/" + repo_name + '/snapshots', json={'Name': snapshot_name}).status_code, 201)
+        self.check_equal(self.post_task("/api/repos/" + repo_name + '/snapshots', json={'Name': snapshot_name}).json()['State'], 2)
 
         prefix = self.random_name()
-        resp = self.post("/api/publish/" + prefix,
-                         json={
-                             "AcquireByHash": True,
-                             "SourceKind": "snapshot",
-                             "Sources": [{"Name": snapshot_name}],
-                             "Signing": DefaultSigningOptions,
-                             "Distribution": "squeeze",
-                             "NotAutomatic": "yes",
-                             "ButAutomaticUpgrades": "yes",
-                         })
-        self.check_equal(resp.status_code, 201)
-        self.check_equal(resp.json(), {
+        resp = self.post_task(
+            "/api/publish/" + prefix,
+            json={
+                "AcquireByHash": True,
+                "SourceKind": "snapshot",
+                "Sources": [{"Name": snapshot_name}],
+                "Signing": DefaultSigningOptions,
+                "Distribution": "squeeze",
+                "NotAutomatic": "yes",
+                "ButAutomaticUpgrades": "yes",
+            }
+        )
+        self.check_equal(resp.json()['State'], 2)
+        repo_expected = {
             'AcquireByHash': True,
             'Architectures': ['i386'],
             'Distribution': 'squeeze',
@@ -143,7 +150,10 @@ class PublishSnapshotAPITest(APITest):
             'SkipContents': False,
             'SourceKind': 'snapshot',
             'Sources': [{'Component': 'main', 'Name': snapshot_name}],
-            'Storage': ''})
+            'Storage': ''}
+        all_repos = self.get("/api/publish")
+        self.check_equal(all_repos.status_code, 200)
+        self.check_in(repo_expected, all_repos.json())
 
         self.check_exists("public/" + prefix + "/dists/squeeze/Release")
         self.check_exists("public/" + prefix + "/dists/squeeze/main/binary-i386/by-hash")
@@ -168,18 +178,20 @@ class PublishUpdateAPITestRepo(APITest):
                         "pyspi_0.6.1-1.3.dsc",
                         "pyspi_0.6.1-1.3.diff.gz", "pyspi_0.6.1.orig.tar.gz",
                         "pyspi-0.6.1-1.3.stripped.dsc").status_code, 200)
-        self.check_equal(self.post("/api/repos/" + repo_name + "/file/" + d).status_code, 200)
+        self.check_equal(self.post_task("/api/repos/" + repo_name + "/file/" + d).json()['State'], 2)
 
         prefix = self.random_name()
-        resp = self.post("/api/publish/" + prefix,
-                         json={
-                             "Architectures": ["i386", "source"],
-                             "SourceKind": "local",
-                             "Sources": [{"Name": repo_name}],
-                             "Signing": DefaultSigningOptions,
-                         })
+        resp = self.post_task(
+            "/api/publish/" + prefix,
+            json={
+                "Architectures": ["i386", "source"],
+                "SourceKind": "local",
+                "Sources": [{"Name": repo_name}],
+                "Signing": DefaultSigningOptions,
+            }
+        )
 
-        self.check_equal(resp.status_code, 201)
+        self.check_equal(resp.json()['State'], 2)
 
         self.check_not_exists("public/" + prefix + "/pool/main/b/boost-defaults/libboost-program-options-dev_1.49.0.1_i386.deb")
         self.check_exists("public/" + prefix + "/pool/main/p/pyspi/pyspi-0.6.1-1.3.stripped.dsc")
@@ -187,17 +199,20 @@ class PublishUpdateAPITestRepo(APITest):
         d = self.random_name()
         self.check_equal(self.upload("/api/files/" + d,
                          "libboost-program-options-dev_1.49.0.1_i386.deb").status_code, 200)
-        self.check_equal(self.post("/api/repos/" + repo_name + "/file/" + d).status_code, 200)
+        self.check_equal(self.post_task("/api/repos/" + repo_name + "/file/" + d).json()['State'], 2)
 
-        self.check_equal(self.delete("/api/repos/" + repo_name + "/packages/",
-                         json={"PackageRefs": ['Psource pyspi 0.6.1-1.4 f8f1daa806004e89']}).status_code, 200)
+        self.check_equal(self.delete_task("/api/repos/" + repo_name + "/packages/",
+                         json={"PackageRefs": ['Psource pyspi 0.6.1-1.4 f8f1daa806004e89']}).json()['State'], 2)
 
         # Update and switch AcquireByHash on.
-        resp = self.put("/api/publish/" + prefix + "/wheezy",
-                        json={
-                            "AcquireByHash": True,
-                            "Signing": DefaultSigningOptions,
-                        })
+        resp = self.put_task(
+            "/api/publish/" + prefix + "/wheezy",
+            json={
+                "AcquireByHash": True,
+                "Signing": DefaultSigningOptions,
+            }
+        )
+        self.check_equal(resp.json()['State'], 2)
         repo_expected = {
             'AcquireByHash': True,
             'Architectures': ['i386', 'source'],
@@ -212,15 +227,16 @@ class PublishUpdateAPITestRepo(APITest):
             'Sources': [{'Component': 'main', 'Name': repo_name}],
             'Storage': ''}
 
-        self.check_equal(resp.status_code, 200)
-        self.check_equal(resp.json(), repo_expected)
+        all_repos = self.get("/api/publish")
+        self.check_equal(all_repos.status_code, 200)
+        self.check_in(repo_expected, all_repos.json())
 
         self.check_exists("public/" + prefix + "/dists/wheezy/main/binary-i386/by-hash")
 
         self.check_exists("public/" + prefix + "/pool/main/b/boost-defaults/libboost-program-options-dev_1.49.0.1_i386.deb")
         self.check_not_exists("public/" + prefix + "/pool/main/p/pyspi/pyspi-0.6.1-1.3.stripped.dsc")
 
-        self.check_equal(self.delete("/api/publish/" + prefix + "/wheezy").status_code, 200)
+        self.check_equal(self.delete_task("/api/publish/" + prefix + "/wheezy").json()['State'], 2)
         self.check_not_exists("public/" + prefix + "dists/")
 
 
@@ -240,48 +256,49 @@ class PublishUpdateSkipCleanupAPITestRepo(APITest):
                         "pyspi_0.6.1-1.3.dsc",
                         "pyspi_0.6.1-1.3.diff.gz", "pyspi_0.6.1.orig.tar.gz",
                         "pyspi-0.6.1-1.3.stripped.dsc").status_code, 200)
-        self.check_equal(self.post("/api/repos/" + repo_name + "/file/" + d).status_code, 200)
+        self.check_equal(self.post_task("/api/repos/" + repo_name + "/file/" + d).json()['State'], 2)
 
         prefix = self.random_name()
-        resp = self.post("/api/publish/" + prefix,
-                         json={
-                             "Architectures": ["i386", "source"],
-                             "SourceKind": "local",
-                             "Sources": [{"Name": repo_name}],
-                             "Signing": DefaultSigningOptions,
-                         })
+        resp = self.post_task("/api/publish/" + prefix,
+                              json={
+                                  "Architectures": ["i386", "source"],
+                                  "SourceKind": "local",
+                                  "Sources": [{"Name": repo_name}],
+                                  "Signing": DefaultSigningOptions,
+                              })
 
-        self.check_equal(resp.status_code, 201)
+        self.check_equal(resp.json()['State'], 2)
 
         self.check_not_exists("public/" + prefix + "/pool/main/b/boost-defaults/libboost-program-options-dev_1.49.0.1_i386.deb")
         self.check_exists("public/" + prefix + "/pool/main/p/pyspi/pyspi-0.6.1-1.3.stripped.dsc")
 
         # Publish two repos, so that deleting one while skipping cleanup will
         # not delete the whole prefix.
-        resp = self.post("/api/publish/" + prefix,
-                         json={
-                             "Architectures": ["i386", "source"],
-                             "Distribution": "otherdist",
-                             "SourceKind": "local",
-                             "Sources": [{"Name": repo_name}],
-                             "Signing": DefaultSigningOptions,
-                         })
+        resp = self.post_task("/api/publish/" + prefix,
+                              json={
+                                  "Architectures": ["i386", "source"],
+                                  "Distribution": "otherdist",
+                                  "SourceKind": "local",
+                                  "Sources": [{"Name": repo_name}],
+                                  "Signing": DefaultSigningOptions,
+                              })
 
-        self.check_equal(resp.status_code, 201)
+        self.check_equal(resp.json()['State'], 2)
 
         d = self.random_name()
         self.check_equal(self.upload("/api/files/" + d,
                          "libboost-program-options-dev_1.49.0.1_i386.deb").status_code, 200)
-        self.check_equal(self.post("/api/repos/" + repo_name + "/file/" + d).status_code, 200)
+        self.check_equal(self.post_task("/api/repos/" + repo_name + "/file/" + d).json()['State'], 2)
 
-        self.check_equal(self.delete("/api/repos/" + repo_name + "/packages/",
-                         json={"PackageRefs": ['Psource pyspi 0.6.1-1.4 f8f1daa806004e89']}).status_code, 200)
+        self.check_equal(self.delete_task("/api/repos/" + repo_name + "/packages/",
+                         json={"PackageRefs": ['Psource pyspi 0.6.1-1.4 f8f1daa806004e89']}).json()['State'], 2)
 
-        resp = self.put("/api/publish/" + prefix + "/wheezy",
-                        json={
-                            "Signing": DefaultSigningOptions,
-                            "SkipCleanup": True,
-                        })
+        resp = self.put_task("/api/publish/" + prefix + "/wheezy",
+                             json={
+                                 "Signing": DefaultSigningOptions,
+                                 "SkipCleanup": True,
+                             })
+        self.check_equal(resp.json()['State'], 2)
         repo_expected = {
             'AcquireByHash': False,
             'Architectures': ['i386', 'source'],
@@ -296,13 +313,14 @@ class PublishUpdateSkipCleanupAPITestRepo(APITest):
             'Sources': [{'Component': 'main', 'Name': repo_name}],
             'Storage': ''}
 
-        self.check_equal(resp.status_code, 200)
-        self.check_equal(resp.json(), repo_expected)
+        all_repos = self.get("/api/publish")
+        self.check_equal(all_repos.status_code, 200)
+        self.check_in(repo_expected, all_repos.json())
 
         self.check_exists("public/" + prefix + "/pool/main/b/boost-defaults/libboost-program-options-dev_1.49.0.1_i386.deb")
         self.check_exists("public/" + prefix + "/pool/main/p/pyspi/pyspi-0.6.1-1.3.stripped.dsc")
 
-        self.check_equal(self.delete("/api/publish/" + prefix + "/wheezy", params={"SkipCleanup": "1"}).status_code, 200)
+        self.check_equal(self.delete_task("/api/publish/" + prefix + "/wheezy", params={"SkipCleanup": "1"}).json()['State'], 2)
         self.check_exists("public/" + prefix + "/pool/main/b/boost-defaults/libboost-program-options-dev_1.49.0.1_i386.deb")
         self.check_exists("public/" + prefix + "/pool/main/p/pyspi/pyspi-0.6.1-1.3.stripped.dsc")
 
@@ -323,21 +341,22 @@ class PublishSwitchAPITestRepo(APITest):
                         "pyspi_0.6.1-1.3.dsc",
                         "pyspi_0.6.1-1.3.diff.gz", "pyspi_0.6.1.orig.tar.gz",
                         "pyspi-0.6.1-1.3.stripped.dsc").status_code, 200)
-        self.check_equal(self.post("/api/repos/" + repo_name + "/file/" + d).status_code, 200)
+        self.check_equal(self.post_task("/api/repos/" + repo_name + "/file/" + d).json()['State'], 2)
 
         snapshot1_name = self.random_name()
-        self.check_equal(self.post("/api/repos/" + repo_name + '/snapshots', json={'Name': snapshot1_name}).status_code, 201)
+        self.check_equal(self.post_task("/api/repos/" + repo_name + '/snapshots', json={'Name': snapshot1_name}).json()['State'], 2)
 
         prefix = self.random_name()
-        resp = self.post("/api/publish/" + prefix,
-                         json={
-                             "Architectures": ["i386", "source"],
-                             "SourceKind": "snapshot",
-                             "Sources": [{"Name": snapshot1_name}],
-                             "Signing": DefaultSigningOptions,
-                         })
+        resp = self.post_task(
+            "/api/publish/" + prefix,
+            json={
+                "Architectures": ["i386", "source"],
+                "SourceKind": "snapshot",
+                "Sources": [{"Name": snapshot1_name}],
+                "Signing": DefaultSigningOptions,
+            })
 
-        self.check_equal(resp.status_code, 201)
+        self.check_equal(resp.json()['State'], 2)
         repo_expected = {
             'AcquireByHash': False,
             'Architectures': ['i386', 'source'],
@@ -351,7 +370,9 @@ class PublishSwitchAPITestRepo(APITest):
             'SourceKind': 'snapshot',
             'Sources': [{'Component': 'main', 'Name': snapshot1_name}],
             'Storage': ''}
-        self.check_equal(resp.json(), repo_expected)
+        all_repos = self.get("/api/publish")
+        self.check_equal(all_repos.status_code, 200)
+        self.check_in(repo_expected, all_repos.json())
 
         self.check_not_exists("public/" + prefix + "/pool/main/b/boost-defaults/libboost-program-options-dev_1.49.0.1_i386.deb")
         self.check_exists("public/" + prefix + "/pool/main/p/pyspi/pyspi-0.6.1-1.3.stripped.dsc")
@@ -359,20 +380,22 @@ class PublishSwitchAPITestRepo(APITest):
         d = self.random_name()
         self.check_equal(self.upload("/api/files/" + d,
                          "libboost-program-options-dev_1.49.0.1_i386.deb").status_code, 200)
-        self.check_equal(self.post("/api/repos/" + repo_name + "/file/" + d).status_code, 200)
+        self.check_equal(self.post_task("/api/repos/" + repo_name + "/file/" + d).json()['State'], 2)
 
-        self.check_equal(self.delete("/api/repos/" + repo_name + "/packages/",
-                         json={"PackageRefs": ['Psource pyspi 0.6.1-1.4 f8f1daa806004e89']}).status_code, 200)
+        self.check_equal(self.delete_task("/api/repos/" + repo_name + "/packages/",
+                         json={"PackageRefs": ['Psource pyspi 0.6.1-1.4 f8f1daa806004e89']}).json()['State'], 2)
 
         snapshot2_name = self.random_name()
-        self.check_equal(self.post("/api/repos/" + repo_name + '/snapshots', json={'Name': snapshot2_name}).status_code, 201)
+        self.check_equal(self.post_task("/api/repos/" + repo_name + '/snapshots', json={'Name': snapshot2_name}).json()['State'], 2)
 
-        resp = self.put("/api/publish/" + prefix + "/wheezy",
-                        json={
-                            "Snapshots": [{"Component": "main", "Name": snapshot2_name}],
-                            "Signing": DefaultSigningOptions,
-                            "SkipContents": True,
-                        })
+        resp = self.put_task(
+            "/api/publish/" + prefix + "/wheezy",
+            json={
+                "Snapshots": [{"Component": "main", "Name": snapshot2_name}],
+                "Signing": DefaultSigningOptions,
+                "SkipContents": True,
+            })
+        self.check_equal(resp.json()['State'], 2)
         repo_expected = {
             'AcquireByHash': False,
             'Architectures': ['i386', 'source'],
@@ -387,13 +410,14 @@ class PublishSwitchAPITestRepo(APITest):
             'Sources': [{'Component': 'main', 'Name': snapshot2_name}],
             'Storage': ''}
 
-        self.check_equal(resp.status_code, 200)
-        self.check_equal(resp.json(), repo_expected)
+        all_repos = self.get("/api/publish")
+        self.check_equal(all_repos.status_code, 200)
+        self.check_in(repo_expected, all_repos.json())
 
         self.check_exists("public/" + prefix + "/pool/main/b/boost-defaults/libboost-program-options-dev_1.49.0.1_i386.deb")
         self.check_not_exists("public/" + prefix + "/pool/main/p/pyspi/pyspi-0.6.1-1.3.stripped.dsc")
 
-        self.check_equal(self.delete("/api/publish/" + prefix + "/wheezy").status_code, 200)
+        self.check_equal(self.delete_task("/api/publish/" + prefix + "/wheezy").json()['State'], 2)
         self.check_not_exists("public/" + prefix + "dists/")
 
 
@@ -413,21 +437,21 @@ class PublishSwitchAPISkipCleanupTestRepo(APITest):
                         "pyspi_0.6.1-1.3.dsc",
                         "pyspi_0.6.1-1.3.diff.gz", "pyspi_0.6.1.orig.tar.gz",
                         "pyspi-0.6.1-1.3.stripped.dsc").status_code, 200)
-        self.check_equal(self.post("/api/repos/" + repo_name + "/file/" + d).status_code, 200)
+        self.check_equal(self.post_task("/api/repos/" + repo_name + "/file/" + d).json()['State'], 2)
 
         snapshot1_name = self.random_name()
-        self.check_equal(self.post("/api/repos/" + repo_name + '/snapshots', json={'Name': snapshot1_name}).status_code, 201)
+        self.check_equal(self.post_task("/api/repos/" + repo_name + '/snapshots', json={'Name': snapshot1_name}).json()['State'], 2)
 
         prefix = self.random_name()
-        resp = self.post("/api/publish/" + prefix,
-                         json={
-                             "Architectures": ["i386", "source"],
-                             "SourceKind": "snapshot",
-                             "Sources": [{"Name": snapshot1_name}],
-                             "Signing": DefaultSigningOptions,
-                         })
+        resp = self.post_task("/api/publish/" + prefix,
+                              json={
+                                  "Architectures": ["i386", "source"],
+                                  "SourceKind": "snapshot",
+                                  "Sources": [{"Name": snapshot1_name}],
+                                  "Signing": DefaultSigningOptions,
+                              })
 
-        self.check_equal(resp.status_code, 201)
+        self.check_equal(resp.json()['State'], 2)
         repo_expected = {
             'AcquireByHash': False,
             'Architectures': ['i386', 'source'],
@@ -441,23 +465,25 @@ class PublishSwitchAPISkipCleanupTestRepo(APITest):
             'SourceKind': 'snapshot',
             'Sources': [{'Component': 'main', 'Name': snapshot1_name}],
             'Storage': ''}
-        self.check_equal(resp.json(), repo_expected)
+        all_repos = self.get("/api/publish")
+        self.check_equal(all_repos.status_code, 200)
+        self.check_in(repo_expected, all_repos.json())
 
         self.check_not_exists("public/" + prefix + "/pool/main/b/boost-defaults/libboost-program-options-dev_1.49.0.1_i386.deb")
         self.check_exists("public/" + prefix + "/pool/main/p/pyspi/pyspi-0.6.1-1.3.stripped.dsc")
 
         # Publish two snapshots, so that deleting one while skipping cleanup will
         # not delete the whole prefix.
-        resp = self.post("/api/publish/" + prefix,
-                         json={
-                             "Architectures": ["i386", "source"],
-                             "Distribution": "otherdist",
-                             "SourceKind": "snapshot",
-                             "Sources": [{"Name": snapshot1_name}],
-                             "Signing": DefaultSigningOptions,
-                         })
+        resp = self.post_task("/api/publish/" + prefix,
+                              json={
+                                  "Architectures": ["i386", "source"],
+                                  "Distribution": "otherdist",
+                                  "SourceKind": "snapshot",
+                                  "Sources": [{"Name": snapshot1_name}],
+                                  "Signing": DefaultSigningOptions,
+                              })
 
-        self.check_equal(resp.status_code, 201)
+        self.check_equal(resp.json()['State'], 2)
         repo_expected = {
             'AcquireByHash': False,
             'Architectures': ['i386', 'source'],
@@ -471,26 +497,29 @@ class PublishSwitchAPISkipCleanupTestRepo(APITest):
             'SourceKind': 'snapshot',
             'Sources': [{'Component': 'main', 'Name': snapshot1_name}],
             'Storage': ''}
-        self.check_equal(resp.json(), repo_expected)
+        all_repos = self.get("/api/publish")
+        self.check_equal(all_repos.status_code, 200)
+        self.check_in(repo_expected, all_repos.json())
 
         d = self.random_name()
         self.check_equal(self.upload("/api/files/" + d,
                          "libboost-program-options-dev_1.49.0.1_i386.deb").status_code, 200)
-        self.check_equal(self.post("/api/repos/" + repo_name + "/file/" + d).status_code, 200)
+        self.check_equal(self.post_task("/api/repos/" + repo_name + "/file/" + d).json()['State'], 2)
 
-        self.check_equal(self.delete("/api/repos/" + repo_name + "/packages/",
-                         json={"PackageRefs": ['Psource pyspi 0.6.1-1.4 f8f1daa806004e89']}).status_code, 200)
+        self.check_equal(self.delete_task("/api/repos/" + repo_name + "/packages/",
+                         json={"PackageRefs": ['Psource pyspi 0.6.1-1.4 f8f1daa806004e89']}).json()['State'], 2)
 
         snapshot2_name = self.random_name()
-        self.check_equal(self.post("/api/repos/" + repo_name + '/snapshots', json={'Name': snapshot2_name}).status_code, 201)
+        self.check_equal(self.post_task("/api/repos/" + repo_name + '/snapshots', json={'Name': snapshot2_name}).json()['State'], 2)
 
-        resp = self.put("/api/publish/" + prefix + "/wheezy",
-                        json={
-                            "Snapshots": [{"Component": "main", "Name": snapshot2_name}],
-                            "Signing": DefaultSigningOptions,
-                            "SkipCleanup": True,
-                            "SkipContents": True,
-                        })
+        resp = self.put_task("/api/publish/" + prefix + "/wheezy",
+                             json={
+                                 "Snapshots": [{"Component": "main", "Name": snapshot2_name}],
+                                 "Signing": DefaultSigningOptions,
+                                 "SkipCleanup": True,
+                                 "SkipContents": True,
+                             })
+        self.check_equal(resp.json()['State'], 2)
         repo_expected = {
             'AcquireByHash': False,
             'Architectures': ['i386', 'source'],
@@ -505,12 +534,13 @@ class PublishSwitchAPISkipCleanupTestRepo(APITest):
             'Sources': [{'Component': 'main', 'Name': snapshot2_name}],
             'Storage': ''}
 
-        self.check_equal(resp.status_code, 200)
-        self.check_equal(resp.json(), repo_expected)
+        all_repos = self.get("/api/publish")
+        self.check_equal(all_repos.status_code, 200)
+        self.check_in(repo_expected, all_repos.json())
 
         self.check_exists("public/" + prefix + "/pool/main/b/boost-defaults/libboost-program-options-dev_1.49.0.1_i386.deb")
         self.check_exists("public/" + prefix + "/pool/main/p/pyspi/pyspi-0.6.1-1.3.stripped.dsc")
 
-        self.check_equal(self.delete("/api/publish/" + prefix + "/wheezy", params={"SkipCleanup": "1"}).status_code, 200)
+        self.check_equal(self.delete_task("/api/publish/" + prefix + "/wheezy", params={"SkipCleanup": "1"}).json()['State'], 2)
         self.check_exists("public/" + prefix + "/pool/main/b/boost-defaults/libboost-program-options-dev_1.49.0.1_i386.deb")
         self.check_exists("public/" + prefix + "/pool/main/p/pyspi/pyspi-0.6.1-1.3.stripped.dsc")

--- a/system/t12_api/snapshots.py
+++ b/system/t12_api/snapshots.py
@@ -12,9 +12,8 @@ class SnapshotsAPITestCreateShowEmpty(APITest):
                          u'Name': snapshot_name}
 
         # create empty snapshot
-        resp = self.post("/api/snapshots", json=snapshot_desc)
-        self.check_subset(snapshot_desc, resp.json())
-        self.check_equal(resp.status_code, 201)
+        resp = self.post_task("/api/snapshots", json=snapshot_desc)
+        self.check_equal(resp.json()['State'], 2)
 
         self.check_subset(snapshot_desc, self.get("/api/snapshots/" + snapshot_name).json())
         self.check_equal(self.get("/api/snapshots/" + snapshot_name).status_code, 200)
@@ -26,8 +25,8 @@ class SnapshotsAPITestCreateShowEmpty(APITest):
         self.check_equal(self.get("/api/snapshots/" + self.random_name()).status_code, 404)
 
         # create snapshot with duplicate name
-        resp = self.post("/api/snapshots", json=snapshot_desc)
-        self.check_equal(resp.status_code, 400)
+        resp = self.post_task("/api/snapshots", json=snapshot_desc)
+        self.check_equal(resp.json()['State'], 3)
 
 
 class SnapshotsAPITestCreateFromRefs(APITest):
@@ -47,9 +46,11 @@ class SnapshotsAPITestCreateFromRefs(APITest):
 
         # create empty snapshot
         empty_snapshot_name = self.random_name()
-        resp = self.post("/api/snapshots", json={"Name": empty_snapshot_name})
-        self.check_equal(resp.status_code, 201)
-        self.check_equal(resp.json()['Description'], 'Created as empty')
+        resp = self.post_task("/api/snapshots", json={"Name": empty_snapshot_name})
+        self.check_equal(resp.json()['State'], 2)
+        self.check_equal(
+            self.get("/api/snapshots/" + empty_snapshot_name).json()['Description'], "Created as empty"
+        )
 
         # create and upload package to repo to register package in DB
         repo_name = self.random_name()
@@ -57,16 +58,18 @@ class SnapshotsAPITestCreateFromRefs(APITest):
         d = self.random_name()
         self.check_equal(self.upload("/api/files/" + d,
                          "libboost-program-options-dev_1.49.0.1_i386.deb").status_code, 200)
-        self.check_equal(self.post("/api/repos/" + repo_name + "/file/" + d).status_code, 200)
+        self.check_equal(self.post_task("/api/repos/" + repo_name + "/file/" + d).json()['State'], 2)
 
         # create snapshot with empty snapshot as source and package
         snapshot = snapshot_desc.copy()
         snapshot['PackageRefs'] = ["Pi386 libboost-program-options-dev 1.49.0.1 918d2f433384e378"]
         snapshot['SourceSnapshots'] = [empty_snapshot_name]
-        resp = self.post("/api/snapshots", json=snapshot)
-        self.check_equal(resp.status_code, 201)
+        resp = self.post_task("/api/snapshots", json=snapshot)
+        self.check_equal(resp.json()['State'], 2)
         snapshot.pop('SourceSnapshots')
         snapshot.pop('PackageRefs')
+        resp = self.get("/api/snapshots/" + snapshot_name)
+        self.check_equal(resp.status_code, 200)
         self.check_subset(snapshot, resp.json())
 
         self.check_subset(snapshot, self.get("/api/snapshots/" + snapshot_name).json())
@@ -75,10 +78,10 @@ class SnapshotsAPITestCreateFromRefs(APITest):
         self.check_equal(resp.json(), ["Pi386 libboost-program-options-dev 1.49.0.1 918d2f433384e378"])
 
         # create snapshot with unreferenced package
-        resp = self.post("/api/snapshots", json={
+        resp = self.post_task("/api/snapshots", json={
             "Name": self.random_name(),
             "PackageRefs": ["Pi386 libboost-program-options-dev 1.49.0.1 918d2f433384e378", "Pamd64 no-such-package 1.2 91"]})
-        self.check_equal(resp.status_code, 404)
+        self.check_equal(resp.json()['State'], 3)
 
         # list snapshots
         resp = self.get("/api/snapshots", params={"sort": "time"})
@@ -96,8 +99,8 @@ class SnapshotsAPITestCreateFromRepo(APITest):
         snapshot_name = self.random_name()
         self.check_equal(self.post("/api/repos", json={"Name": repo_name}).status_code, 201)
 
-        resp = self.post("/api/repos/" + repo_name + '/snapshots', json={'Name': snapshot_name})
-        self.check_equal(resp.status_code, 201)
+        resp = self.post_task("/api/repos/" + repo_name + '/snapshots', json={'Name': snapshot_name})
+        self.check_equal(resp.json()['State'], 2)
         self.check_equal([],
                          self.get("/api/snapshots/" + snapshot_name + "/packages", params={"format": "details"}).json())
 
@@ -106,10 +109,10 @@ class SnapshotsAPITestCreateFromRepo(APITest):
         self.check_equal(self.upload("/api/files/" + d,
                          "libboost-program-options-dev_1.49.0.1_i386.deb").status_code, 200)
 
-        self.check_equal(self.post("/api/repos/" + repo_name + "/file/" + d).status_code, 200)
+        self.check_equal(self.post_task("/api/repos/" + repo_name + "/file/" + d).json()['State'], 2)
 
-        resp = self.post("/api/repos/" + repo_name + '/snapshots', json={'Name': snapshot_name})
-        self.check_equal(resp.status_code, 201)
+        resp = self.post_task("/api/repos/" + repo_name + '/snapshots', json={'Name': snapshot_name})
+        self.check_equal(resp.json()['State'], 2)
         self.check_equal(self.get("/api/snapshots/" + snapshot_name).status_code, 200)
 
         self.check_subset({u'Architecture': 'i386',
@@ -126,8 +129,8 @@ class SnapshotsAPITestCreateFromRepo(APITest):
                                    params={"format": "details", "q": "Version (> 0.6.1-1.4)"}).json()[0])
 
         # duplicate snapshot name
-        resp = self.post("/api/repos/" + repo_name + '/snapshots', json={'Name': snapshot_name})
-        self.check_equal(resp.status_code, 400)
+        resp = self.post_task("/api/repos/" + repo_name + '/snapshots', json={'Name': snapshot_name})
+        self.check_equal(resp.json()['State'], 3)
 
 
 class SnapshotsAPITestCreateUpdate(APITest):
@@ -139,13 +142,13 @@ class SnapshotsAPITestCreateUpdate(APITest):
         snapshot_desc = {u'Description': u'fun snapshot',
                          u'Name': snapshot_name}
 
-        resp = self.post("/api/snapshots", json=snapshot_desc)
-        self.check_equal(resp.status_code, 201)
+        resp = self.post_task("/api/snapshots", json=snapshot_desc)
+        self.check_equal(resp.json()['State'], 2)
 
         new_snapshot_name = self.random_name()
-        resp = self.put("/api/snapshots/" + snapshot_name, json={'Name': new_snapshot_name,
-                                                                 'Description': 'New description'})
-        self.check_equal(resp.status_code, 200)
+        resp = self.put_task("/api/snapshots/" + snapshot_name, json={'Name': new_snapshot_name,
+                                                                      'Description': 'New description'})
+        self.check_equal(resp.json()['State'], 2)
 
         resp = self.get("/api/snapshots/" + new_snapshot_name)
         self.check_equal(resp.status_code, 200)
@@ -153,9 +156,9 @@ class SnapshotsAPITestCreateUpdate(APITest):
                            "Description": "New description"}, resp.json())
 
         # duplicate name
-        resp = self.put("/api/snapshots/" + new_snapshot_name, json={'Name': new_snapshot_name,
-                                                                     'Description': 'New description'})
-        self.check_equal(resp.status_code, 409)
+        resp = self.put_task("/api/snapshots/" + new_snapshot_name, json={'Name': new_snapshot_name,
+                                                                          'Description': 'New description'})
+        self.check_equal(resp.json()['State'], 3)
 
         # missing snapshot
         resp = self.put("/api/snapshots/" + snapshot_name, json={})
@@ -172,36 +175,42 @@ class SnapshotsAPITestCreateDelete(APITest):
                          u'Name': snapshot_name}
 
         # deleting unreferenced snapshot
-        resp = self.post("/api/snapshots", json=snapshot_desc)
-        self.check_equal(resp.status_code, 201)
+        resp = self.post_task("/api/snapshots", json=snapshot_desc)
+        self.check_equal(resp.json()['State'], 2)
 
-        self.check_equal(self.delete("/api/snapshots/" + snapshot_name).status_code, 200)
+        self.check_equal(self.delete_task("/api/snapshots/" + snapshot_name).json()['State'], 2)
 
         self.check_equal(self.get("/api/snapshots/" + snapshot_name).status_code, 404)
 
         # deleting referenced snapshot
         snap1, snap2 = self.random_name(), self.random_name()
-        self.check_equal(self.post("/api/snapshots", json={"Name": snap1}).status_code, 201)
-        self.check_equal(self.post("/api/snapshots", json={"Name": snap2, "SourceSnapshots": [snap1]}).status_code, 201)
+        self.check_equal(self.post_task("/api/snapshots", json={"Name": snap1}).json()['State'], 2)
+        self.check_equal(
+            self.post_task(
+                "/api/snapshots", json={"Name": snap2, "SourceSnapshots": [snap1]}
+            ).json()['State'], 2
+        )
 
-        self.check_equal(self.delete("/api/snapshots/" + snap1).status_code, 409)
+        self.check_equal(self.delete_task("/api/snapshots/" + snap1).json()['State'], 3)
         self.check_equal(self.get("/api/snapshots/" + snap1).status_code, 200)
-        self.check_equal(self.delete("/api/snapshots/" + snap1, params={"force": "1"}).status_code, 200)
+        self.check_equal(self.delete_task("/api/snapshots/" + snap1, params={"force": "1"}).json()['State'], 2)
         self.check_equal(self.get("/api/snapshots/" + snap1).status_code, 404)
 
         # deleting published snapshot
-        resp = self.post("/api/publish",
-                         json={
-                             "SourceKind": "snapshot",
-                             "Distribution": "trusty",
-                             "Architectures": ["i386"],
-                             "Sources": [{"Name": snap2}],
-                             "Signing": DefaultSigningOptions,
-                         })
-        self.check_equal(resp.status_code, 201)
+        resp = self.post_task(
+            "/api/publish",
+            json={
+                 "SourceKind": "snapshot",
+                 "Distribution": "trusty",
+                 "Architectures": ["i386"],
+                 "Sources": [{"Name": snap2}],
+                 "Signing": DefaultSigningOptions,
+             }
+        )
+        self.check_equal(resp.json()['State'], 2)
 
-        self.check_equal(self.delete("/api/snapshots/" + snap2).status_code, 409)
-        self.check_equal(self.delete("/api/snapshots/" + snap2, params={"force": "1"}).status_code, 409)
+        self.check_equal(self.delete_task("/api/snapshots/" + snap2).json()['State'], 3)
+        self.check_equal(self.delete_task("/api/snapshots/" + snap2, params={"force": "1"}).json()['State'], 3)
 
 
 class SnapshotsAPITestSearch(APITest):
@@ -218,10 +227,10 @@ class SnapshotsAPITestSearch(APITest):
         self.check_equal(self.upload("/api/files/" + d,
                          "libboost-program-options-dev_1.49.0.1_i386.deb").status_code, 200)
 
-        self.check_equal(self.post("/api/repos/" + repo_name + "/file/" + d).status_code, 200)
+        self.check_equal(self.post_task("/api/repos/" + repo_name + "/file/" + d).json()['State'], 2)
 
-        resp = self.post("/api/repos/" + repo_name + '/snapshots', json={'Name': snapshot_name})
-        self.check_equal(resp.status_code, 201)
+        resp = self.post_task("/api/repos/" + repo_name + '/snapshots', json={'Name': snapshot_name})
+        self.check_equal(resp.json()['State'], 2)
 
         resp = self.get("/api/snapshots/" + snapshot_name + "/packages",
                         params={"q": "libboost-program-options-dev", "format": "details"})
@@ -252,13 +261,13 @@ class SnapshotsAPITestDiff(APITest):
         self.check_equal(self.upload("/api/files/" + d,
                          "libboost-program-options-dev_1.49.0.1_i386.deb").status_code, 200)
 
-        self.check_equal(self.post("/api/repos/" + repo_name + "/file/" + d).status_code, 200)
+        self.check_equal(self.post_task("/api/repos/" + repo_name + "/file/" + d).json()['State'], 2)
 
-        resp = self.post("/api/repos/" + repo_name + '/snapshots', json={'Name': snapshots[0]})
-        self.check_equal(resp.status_code, 201)
+        resp = self.post_task("/api/repos/" + repo_name + '/snapshots', json={'Name': snapshots[0]})
+        self.check_equal(resp.json()['State'], 2)
 
-        resp = self.post("/api/snapshots", json={'Name': snapshots[1]})
-        self.check_equal(resp.status_code, 201)
+        resp = self.post_task("/api/snapshots", json={'Name': snapshots[1]})
+        self.check_equal(resp.json()['State'], 2)
 
         resp = self.get("/api/snapshots/" + snapshots[0] + "/diff/" + snapshots[1])
         self.check_equal(resp.status_code, 200)

--- a/system/t12_api/tasks.py
+++ b/system/t12_api/tasks.py
@@ -1,0 +1,106 @@
+from api_lib import APITest
+from publish import DefaultSigningOptions
+
+
+class TaskAPITestParallelTasks(APITest):
+    """
+    GET /api/tasks, GET /api/tasks/:id/wait, GET /api/tasks-wait
+    """
+    def _create_mirror(self, dist):
+        mirror_name = self.random_name()
+        mirror_desc = {u'Name': mirror_name,
+                       u'ArchiveURL': 'https://packagecloud.io/varnishcache/varnish30/debian/',
+                       u'Distribution': dist,
+                       u'Components': ['main']}
+        mirror_desc[u'IgnoreSignatures'] = True
+        resp = self.post("/api/mirrors", json=mirror_desc)
+        self.check_equal(resp.status_code, 201)
+        resp = self.put("/api/mirrors/" + mirror_name, json=mirror_desc)
+        self.check_equal(resp.status_code, 202)
+
+        # check that two mirror updates cannot run at the same time
+        resp2 = self.put("/api/mirrors/" + mirror_name, json=mirror_desc)
+        self.check_equal(resp2.status_code, 409)
+
+        return resp.json()['ID'], mirror_name
+
+    def _create_repo(self):
+        repo_name = self.random_name()
+        distribution = self.random_name()
+
+        self.check_equal(self.post("/api/repos",
+                         json={
+                             "Name": repo_name,
+                             "Comment": "fun repo",
+                             "DefaultDistribution": distribution
+                         }).status_code, 201)
+        d = self.random_name()
+        self.check_equal(
+            self.upload("/api/files/" + d, "pyspi_0.6.1-1.3.dsc",
+                        "pyspi_0.6.1-1.3.diff.gz",
+                        "pyspi_0.6.1.orig.tar.gz").status_code, 200)
+
+        resp = self.post("/api/repos/" + repo_name + "/file/" + d)
+        self.check_equal(resp.status_code, 202)
+
+        return resp.json()['ID'], repo_name
+
+    def _wait_for_task(self, task_id):
+        uri = "/api/tasks/%d/wait" % int(task_id)
+        resp = self.get(uri)
+        self.check_equal(resp.status_code, 200)
+        self.check_equal(resp.json()['State'], 2)
+
+    def _wait_for_all_tasks(self):
+        resp = self.get("/api/tasks-wait")
+        self.check_equal(resp.status_code, 200)
+
+    def _snapshot(self, res_type, name):
+        uri = "/api/%s/%s/snapshots" % (res_type, name)
+        resp = self.post(uri, json={"Name": name})
+        self.check_equal(resp.status_code, 202)
+
+        return resp.json()['ID']
+
+    def _publish(self, source_kind, name):
+        resp = self.post("/api/publish",
+                         json={
+                             "SourceKind": source_kind,
+                             "Sources": [{"Name": name}],
+                             "Signing": DefaultSigningOptions,
+                         })
+        self.check_equal(resp.status_code, 202)
+        return resp.json()['ID']
+
+    def check(self):
+        publish_task_ids = []
+        mirror_task_list = []
+        for mirror_dist in ['squeeze', 'jessie']:
+            mirror_task_id, mirror_name = self._create_mirror(mirror_dist)
+            mirror_task_list.append((mirror_task_id, mirror_name))
+        repo_task_id, repo_name = self._create_repo()
+
+        self._wait_for_task(repo_task_id)
+
+        resp = self.delete("/api/tasks/%d" % repo_task_id)
+        self.check_equal(resp.status_code, 200)
+        resp = self.get("/api/tasks/%d" % repo_task_id)
+        self.check_equal(resp.status_code, 404)
+
+        repo_snap_task_id = self._snapshot('repos', repo_name)
+        self._wait_for_task(repo_snap_task_id)
+        publish_task_ids.append(self._publish('snapshot', repo_name))
+
+        for mirror_task_id, mirror_name in mirror_task_list:
+            self._wait_for_task(mirror_task_id)
+            mirror_snap_task_id = self._snapshot('mirrors', mirror_name)
+
+            self._wait_for_task(mirror_snap_task_id)
+            publish_task_ids.append(self._publish('snapshot', mirror_name))
+
+        self._wait_for_all_tasks()
+
+        for publish_task_id in publish_task_ids:
+            resp = self.get("/api/tasks/%d" % publish_task_id)
+            self.check_equal(resp.status_code, 200)
+            self.check_equal(resp.json()['State'], 2)

--- a/task/list.go
+++ b/task/list.go
@@ -1,0 +1,195 @@
+package task
+
+import (
+	"fmt"
+	"sync"
+)
+
+// List is handling list of processes and makes sure
+// only one process is executed at the time
+type List struct {
+	*sync.Mutex
+	tasks   []*Task
+	wgTasks map[int]*sync.WaitGroup
+	wg      *sync.WaitGroup
+	// resources currently used by running tasks
+	usedResources *ResourcesSet
+	idCounter     int
+}
+
+// NewList creates empty task list
+func NewList() *List {
+	list := &List{
+		Mutex:         &sync.Mutex{},
+		tasks:         make([]*Task, 0),
+		wgTasks:       make(map[int]*sync.WaitGroup),
+		wg:            &sync.WaitGroup{},
+		usedResources: NewResourcesSet(),
+	}
+	return list
+}
+
+// GetTasks gets complete list of tasks
+func (list *List) GetTasks() []Task {
+	var tasks []Task
+	list.Lock()
+	for _, task := range list.tasks {
+		tasks = append(tasks, *task)
+	}
+
+	list.Unlock()
+	return tasks
+}
+
+// DeleteTaskByID deletes given task from list. Only finished
+// tasks can be deleted.
+func (list *List) DeleteTaskByID(ID int) (Task, error) {
+	list.Lock()
+	defer list.Unlock()
+
+	tasks := list.tasks
+	for i, task := range tasks {
+		if task.ID == ID {
+			if task.State == SUCCEEDED || task.State == FAILED {
+				list.tasks = append(tasks[:i], tasks[i+1:]...)
+				return *task, nil
+			}
+
+			return *task, fmt.Errorf("Task with id %v is still running", ID)
+		}
+	}
+
+	return Task{}, fmt.Errorf("Could not find task with id %v", ID)
+}
+
+// GetTaskByID returns task with given id
+func (list *List) GetTaskByID(ID int) (Task, error) {
+	list.Lock()
+	tasks := list.tasks
+	list.Unlock()
+
+	for _, task := range tasks {
+		if task.ID == ID {
+			return *task, nil
+		}
+	}
+
+	return Task{}, fmt.Errorf("Could not find task with id %v", ID)
+}
+
+// GetTaskOutputByID returns standard output of task with given id
+func (list *List) GetTaskOutputByID(ID int) (string, error) {
+	task, err := list.GetTaskByID(ID)
+
+	if err != nil {
+		return "", err
+	}
+
+	return task.output.String(), nil
+}
+
+// GetTaskDetailByID returns detail of task with given id
+func (list *List) GetTaskDetailByID(ID int) (interface{}, error) {
+	task, err := list.GetTaskByID(ID)
+
+	if err != nil {
+		return nil, err
+	}
+
+	detail := task.detail.Load()
+	if detail == nil {
+		return struct{}{}, nil
+	}
+
+	return detail, nil
+}
+
+// RunTaskInBackground creates task and runs it in background. It won't be run and an error
+// returned if there are running tasks which are using needed resources already.
+func (list *List) RunTaskInBackground(name string, resources []string, process Process) (Task, *ResourceConflictError) {
+	list.Lock()
+	defer list.Unlock()
+
+	tasks := list.usedResources.UsedBy(resources)
+	if len(tasks) > 0 {
+		conflictError := &ResourceConflictError{
+			Tasks:   tasks,
+			Message: "Needed resources are used by other tasks.",
+		}
+		return Task{}, conflictError
+	}
+
+	list.idCounter++
+	wgTask := &sync.WaitGroup{}
+	task := NewTask(process, name, list.idCounter)
+
+	list.tasks = append(list.tasks, task)
+	list.wgTasks[task.ID] = wgTask
+	list.usedResources.MarkInUse(resources, task)
+
+	list.wg.Add(1)
+	wgTask.Add(1)
+
+	go func() {
+
+		list.Lock()
+		{
+			task.State = RUNNING
+		}
+		list.Unlock()
+
+		err := process(task.output, task.detail)
+
+		list.Lock()
+		{
+			if err != nil {
+				task.output.Printf("Task failed with error: %v", err)
+				task.State = FAILED
+			} else {
+				task.output.Print("Task succeeded")
+				task.State = SUCCEEDED
+			}
+
+			list.usedResources.Free(resources)
+
+			wgTask.Done()
+			list.wg.Done()
+		}
+		list.Unlock()
+	}()
+
+	return *task, nil
+}
+
+// Clear removes finished tasks from list
+func (list *List) Clear() {
+	list.Lock()
+
+	var tasks []*Task
+	for _, task := range list.tasks {
+		if task.State == IDLE || task.State == RUNNING {
+			tasks = append(tasks, task)
+		}
+	}
+	list.tasks = tasks
+
+	list.Unlock()
+}
+
+// Wait waits till all tasks are processed
+func (list *List) Wait() {
+	list.wg.Wait()
+}
+
+// WaitForTaskByID waits for task with given id to be processed
+func (list *List) WaitForTaskByID(ID int) (Task, error) {
+	list.Lock()
+	wgTask, ok := list.wgTasks[ID]
+	list.Unlock()
+	if !ok {
+		return Task{}, fmt.Errorf("Could not find task with id %v", ID)
+	}
+
+	wgTask.Wait()
+	return list.GetTaskByID(ID)
+}

--- a/task/list_test.go
+++ b/task/list_test.go
@@ -1,0 +1,51 @@
+package task
+
+import (
+	"errors"
+
+	// need to import as check as otherwise List is redeclared
+	check "gopkg.in/check.v1"
+)
+
+type ListSuite struct{}
+
+var _ = check.Suite(&ListSuite{})
+
+func (s *ListSuite) TestList(c *check.C) {
+	list := NewList()
+	c.Assert(len(list.GetTasks()), check.Equals, 0)
+
+	task, err := list.RunTaskInBackground("Successful task", nil, func(out *Output, detail *Detail) error {
+		return nil
+	})
+	c.Assert(err, check.IsNil)
+	list.WaitForTaskByID(task.ID)
+
+	tasks := list.GetTasks()
+	c.Assert(len(tasks), check.Equals, 1)
+	task, _ = list.GetTaskByID(task.ID)
+	c.Check(task.State, check.Equals, SUCCEEDED)
+	output, _ := list.GetTaskOutputByID(task.ID)
+	c.Check(output, check.Equals, "Task succeeded")
+	detail, _ := list.GetTaskDetailByID(task.ID)
+	c.Check(detail, check.Equals, struct{}{})
+
+	task, err = list.RunTaskInBackground("Faulty task", nil, func(out *Output, detail *Detail) error {
+		detail.Store("Details")
+		out.WriteString("Test Progress\n")
+		return errors.New("Task failed")
+	})
+	c.Assert(err, check.IsNil)
+	list.WaitForTaskByID(task.ID)
+
+	tasks = list.GetTasks()
+	c.Assert(len(tasks), check.Equals, 2)
+	task, _ = list.GetTaskByID(task.ID)
+	c.Check(task.State, check.Equals, FAILED)
+	output, _ = list.GetTaskOutputByID(task.ID)
+	c.Check(output, check.Equals, "Test Progress\nTask failed with error: Task failed")
+	detail, _ = list.GetTaskDetailByID(task.ID)
+	c.Check(detail, check.Equals, "Details")
+	_, deleteErr := list.DeleteTaskByID(task.ID)
+	c.Check(deleteErr, check.IsNil)
+}

--- a/task/output.go
+++ b/task/output.go
@@ -1,0 +1,95 @@
+package task
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+)
+
+// Output represents a safe standard output of task
+// which is compatbile to AptlyProgress.
+type Output struct {
+	mu     *sync.Mutex
+	output *bytes.Buffer
+}
+
+// NewOutput creates new output
+func NewOutput() *Output {
+	return &Output{mu: &sync.Mutex{}, output: &bytes.Buffer{}}
+}
+
+func (t *Output) String() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	return t.output.String()
+}
+
+// Write is used to determine how many bytes have been written
+// not needed in our case.
+func (t *Output) Write(p []byte) (n int, err error) {
+	return len(p), err
+}
+
+// WriteString writes string to output
+func (t *Output) WriteString(s string) (n int, err error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.output.WriteString(s)
+}
+
+// Start is needed for progress compatibility
+func (t *Output) Start() {
+	// Not implemented
+}
+
+// Shutdown is needed for progress compatibility
+func (t *Output) Shutdown() {
+	// Not implemented
+}
+
+// Flush is needed for progress compatibility
+func (t *Output) Flush() {
+	// Not implemented
+}
+
+// InitBar is needed for progress compatibility
+func (t *Output) InitBar(count int64, isBytes bool) {
+	// Not implemented
+}
+
+// ShutdownBar is needed for progress compatibility
+func (t *Output) ShutdownBar() {
+	// Not implemented
+}
+
+// AddBar is needed for progress compatibility
+func (t *Output) AddBar(count int) {
+	// Not implemented
+}
+
+// SetBar sets current position for progress bar
+func (t *Output) SetBar(count int) {
+	// Not implemented
+}
+
+// Printf does printf in a safe manner
+func (t *Output) Printf(msg string, a ...interface{}) {
+	t.WriteString(fmt.Sprintf(msg, a...))
+}
+
+// Print does printf in a safe manner
+func (t *Output) Print(msg string) {
+	t.WriteString(msg)
+}
+
+// ColoredPrintf does printf in a safe manner + newline
+// currently are no colors supported.
+func (t *Output) ColoredPrintf(msg string, a ...interface{}) {
+	t.WriteString(fmt.Sprintf(msg+"\n", a...))
+}
+
+// PrintfStdErr does printf but in safe manner to output
+func (t *Output) PrintfStdErr(msg string, a ...interface{}) {
+	t.WriteString(msg)
+}

--- a/task/resources.go
+++ b/task/resources.go
@@ -1,0 +1,93 @@
+package task
+
+import (
+	"strings"
+)
+
+// AllLocalReposResourcesKey to be used as resource key when all local repos are needed
+const AllLocalReposResourcesKey = "__alllocalrepos__"
+
+// ResourceConflictError represents a list tasks
+// using conflicitng resources
+type ResourceConflictError struct {
+	Tasks   []Task
+	Message string
+}
+
+func (e *ResourceConflictError) Error() string {
+	return e.Message
+}
+
+// ResourcesSet represents a set of task resources.
+// A resource is represented by its unique key
+type ResourcesSet struct {
+	set map[string]*Task
+}
+
+// NewResourcesSet creates new instance of resources set
+func NewResourcesSet() *ResourcesSet {
+	return &ResourcesSet{make(map[string]*Task)}
+}
+
+// MarkInUse given resources as used by given task
+func (r *ResourcesSet) MarkInUse(resources []string, task *Task) {
+	for _, resource := range resources {
+		r.set[resource] = task
+	}
+}
+
+// UsedBy checks whether one of given resources
+// is used by a task and if yes returns slice of such task
+func (r *ResourcesSet) UsedBy(resources []string) []Task {
+	var tasks []Task
+	var task *Task
+	var found bool
+
+	for _, resource := range resources {
+
+		if resource == AllLocalReposResourcesKey {
+			for taskResource, task := range r.set {
+				if strings.HasPrefix(taskResource, "L") {
+					tasks = appendTask(tasks, task)
+				}
+			}
+		}
+
+		task, found = r.set[resource]
+		if found {
+			tasks = appendTask(tasks, task)
+		}
+	}
+
+	task, found = r.set[AllLocalReposResourcesKey]
+	if found {
+		tasks = appendTask(tasks, task)
+	}
+
+	return tasks
+}
+
+// appendTask only appends task to tasks slice if not already
+// on slice
+func appendTask(tasks []Task, task *Task) []Task {
+	needsAppending := true
+	for _, givenTask := range tasks {
+		if givenTask.ID == task.ID {
+			needsAppending = false
+			break
+		}
+	}
+
+	if needsAppending {
+		return append(tasks, *task)
+	}
+
+	return tasks
+}
+
+// Free removes given resources from dependency set
+func (r *ResourcesSet) Free(resources []string) {
+	for _, resource := range resources {
+		delete(r.set, resource)
+	}
+}

--- a/task/task.go
+++ b/task/task.go
@@ -1,0 +1,50 @@
+package task
+
+import (
+	"sync/atomic"
+)
+
+// State task is in
+type State int
+
+// Detail represents custom task details
+type Detail struct {
+	atomic.Value
+}
+
+// Process is a function implementing the actual task logic
+type Process func(out *Output, detail *Detail) error
+
+const (
+	// IDLE when task is waiting
+	IDLE State = iota
+	// RUNNING when task is running
+	RUNNING
+	// SUCCEEDED when task is successfully finished
+	SUCCEEDED
+	// FAILED when task failed
+	FAILED
+)
+
+// Task represents as task in a queue encapsulates process code
+type Task struct {
+	output  *Output
+	detail  *Detail
+	process Process
+	Name    string
+	ID      int
+	State   State
+}
+
+// NewTask creates new task
+func NewTask(process Process, name string, ID int) *Task {
+	task := &Task{
+		output:  NewOutput(),
+		detail:  &Detail{},
+		process: process,
+		Name:    name,
+		ID:      ID,
+		State:   IDLE,
+	}
+	return task
+}

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -1,0 +1,12 @@
+package task
+
+import (
+	"testing"
+
+	check "gopkg.in/check.v1"
+)
+
+// Launch gocheck tests
+func Test(t *testing.T) {
+	check.TestingT(t)
+}


### PR DESCRIPTION
This introduces an async mirror api based on work made in #166 it additionally provides GPG end point to add additional keys. Otherwise won't it be possible to update new mirrors only through the API without using command line.

This mirror api is based on the concept of the task api introduced in PR #459. Hence, #459 needs to be agreed upon and merged first, before this PR can be processed.

For now to easier verify changes have a look directly at commits https://github.com/sliverc/aptly/commit/100edad3adf579ef55f12950992b50edb9762524 and https://github.com/sliverc/aptly/commit/611824ee1be8466244843034200e4807ff37f56a

As this is a lengthy PR once its core concept is agreed upon I will be happy to update the documentation as well.

## Checklist

- [x] unit-test added (if change is algorithm)
- [x] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [x] author name in `AUTHORS`