### PR TITLE
Filter between mirrors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -64,3 +64,4 @@ List of contributors, in chronological order:
 * Golf Hu (https://github.com/hudeng-go)
 * Cookie Fei (https://github.com/wuhuang26)
 * Andrey Loukhnov (https://github.com/aol-nnov)
+* Malte Swart (https://github.com/mswart)

--- a/api/api.go
+++ b/api/api.go
@@ -228,7 +228,7 @@ func showPackages(c *gin.Context, reflist *deb.PackageRefList, collectionFactory
 		list.PrepareIndex()
 
 		list, err = list.Filter([]deb.PackageQuery{q}, withDeps,
-			nil, context.DependencyOptions(), architecturesList)
+			nil, nil, context.DependencyOptions(), architecturesList)
 		if err != nil {
 			AbortWithJSONError(c, 500, fmt.Errorf("unable to search: %s", err))
 			return

--- a/api/api.go
+++ b/api/api.go
@@ -244,7 +244,7 @@ func showPackages(c *gin.Context, reflist *deb.PackageRefList, collectionFactory
 				fmt.Println("filter packages by version, query string parse err: ", err)
 				c.AbortWithError(500, fmt.Errorf("unable to parse %s maximum version query string: %s", p.Name, err))
 			} else {
-				tmpList, err := list.Filter([]deb.PackageQuery{versionQ}, false,
+				tmpList, err := list.Filter([]deb.PackageQuery{versionQ}, false, nil,
 					nil, 0, []string{})
 
 				if err == nil {

--- a/api/mirror.go
+++ b/api/mirror.go
@@ -306,7 +306,7 @@ func apiMirrorsPackages(c *gin.Context) {
 
 		list.PrepareIndex()
 
-		list, err = list.Filter([]deb.PackageQuery{q}, withDeps,
+		list, err = list.Filter([]deb.PackageQuery{q}, withDeps, nil,
 			nil, context.DependencyOptions(), architecturesList)
 		if err != nil {
 			AbortWithJSONError(c, 500, fmt.Errorf("unable to search: %s", err))
@@ -468,7 +468,7 @@ func apiMirrorsUpdate(c *gin.Context) {
 				return &task.ProcessReturnValue{Code: http.StatusInternalServerError, Value: nil}, fmt.Errorf("unable to update: %s", err)
 			}
 
-			_, _, err = remote.ApplyFilter(context.DependencyOptions(), filterQuery, out)
+			_, _, err = remote.ApplyFilter(context.DependencyOptions(), filterQuery, nil, out)
 			if err != nil {
 				return &task.ProcessReturnValue{Code: http.StatusInternalServerError, Value: nil}, fmt.Errorf("unable to update: %s", err)
 			}

--- a/api/repos.go
+++ b/api/repos.go
@@ -586,7 +586,7 @@ func apiReposCopyPackage(c *gin.Context) {
 			return &task.ProcessReturnValue{Code: http.StatusUnprocessableEntity, Value: nil}, fmt.Errorf("unable to parse query '%s': %s", fileName, err)
 		}
 
-		toProcess, err := srcList.FilterWithProgress(queries, jsonBody.WithDeps, dstList, context.DependencyOptions(), architecturesList, context.Progress())
+		toProcess, err := srcList.FilterWithProgress(queries, jsonBody.WithDeps, dstList, nil, context.DependencyOptions(), architecturesList, context.Progress())
 		if err != nil {
 			return &task.ProcessReturnValue{Code: http.StatusInternalServerError, Value: nil}, fmt.Errorf("filter error: %s", err)
 		}

--- a/api/snapshot.go
+++ b/api/snapshot.go
@@ -636,7 +636,7 @@ func apiSnapshotsPull(c *gin.Context) {
 		}
 
 		// Filter with dependencies as requested
-		destinationPackageList, err := sourcePackageList.FilterWithProgress(queries, !noDeps, toPackageList, context.DependencyOptions(), architecturesList, context.Progress())
+		destinationPackageList, err := sourcePackageList.FilterWithProgress(queries, !noDeps, toPackageList, nil, context.DependencyOptions(), architecturesList, context.Progress())
 		if err != nil {
 			return &task.ProcessReturnValue{Code: http.StatusInternalServerError, Value: nil}, err
 		}

--- a/cmd/mirror_create.go
+++ b/cmd/mirror_create.go
@@ -51,6 +51,15 @@ func aptlyMirrorCreate(cmd *commander.Command, args []string) error {
 	repo.SkipComponentCheck = context.Flags().Lookup("force-components").Value.Get().(bool)
 	repo.SkipArchitectureCheck = context.Flags().Lookup("force-architectures").Value.Get().(bool)
 
+	extraDepsFromMirrors := context.Flags().Lookup("deps-from-mirrors").Value.String()
+	if extraDepsFromMirrors != "" {
+		repo.DepsFromMirrors = strings.Split(extraDepsFromMirrors, ",")
+	}
+	extraDepsFromRepos := context.Flags().Lookup("deps-from-repos").Value.String()
+	if extraDepsFromRepos != "" {
+		repo.DepsFromRepos = strings.Split(extraDepsFromRepos, ",")
+	}
+
 	if repo.Filter != "" {
 		_, err = query.Parse(repo.Filter)
 		if err != nil {
@@ -109,6 +118,8 @@ Example:
 	cmd.Flag.Bool("force-architectures", false, "(only with architecture list) skip check that requested architectures are listed in Release file")
 	cmd.Flag.Int("max-tries", 1, "max download tries till process fails with download error")
 	cmd.Flag.Var(&keyRingsFlag{}, "keyring", "gpg keyring to use when verifying Release file (could be specified multiple times)")
+	cmd.Flag.String("deps-from-mirrors", "", "list of mirrors thats packages's dependencies should be fulfilled (comma-separated), default to none")
+	cmd.Flag.String("deps-from-repos", "", "list of repositories thats packages's dependencies should be fulfilled (comma-separated), default to none")
 
 	return cmd
 }

--- a/cmd/mirror_edit.go
+++ b/cmd/mirror_edit.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/aptly-dev/aptly/pgp"
 	"github.com/aptly-dev/aptly/query"
@@ -46,6 +47,20 @@ func aptlyMirrorEdit(cmd *commander.Command, args []string) error {
 			fetchMirror = true
 		case "ignore-signatures":
 			ignoreSignatures = true
+		case "deps-from-repos":
+			repoNames := flag.Value.String()
+			if repoNames != "" {
+				repo.DepsFromRepos = strings.Split(repoNames, ",")
+			} else {
+				repo.DepsFromRepos = make([]string, 0)
+			}
+		case "deps-from-mirrors":
+			mirrorNames := flag.Value.String()
+			if mirrorNames != "" {
+				repo.DepsFromMirrors = strings.Split(mirrorNames, ",")
+			} else {
+				repo.DepsFromMirrors = make([]string, 0)
+			}
 		}
 	})
 
@@ -111,6 +126,8 @@ Example:
 	cmd.Flag.Bool("with-sources", false, "download source packages in addition to binary packages")
 	cmd.Flag.Bool("with-udebs", false, "download .udeb packages (Debian installer support)")
 	cmd.Flag.Var(&keyRingsFlag{}, "keyring", "gpg keyring to use when verifying Release file (could be specified multiple times)")
+	cmd.Flag.String("deps-from-mirrors", "", "list of mirrors thats packages's dependencies should be fulfilled (comma-separated), default to none")
+	cmd.Flag.String("deps-from-repos", "", "list of repositories thats packages's dependencies should be fulfilled (comma-separated), default to none")
 
 	return cmd
 }

--- a/cmd/mirror_show.go
+++ b/cmd/mirror_show.go
@@ -68,6 +68,14 @@ func aptlyMirrorShowTxt(_ *commander.Command, args []string) error {
 			filterWithDeps = Yes
 		}
 		fmt.Printf("Filter With Deps: %s\n", filterWithDeps)
+		if repo.FilterWithDeps {
+			if len(repo.DepsFromMirrors) > 0 {
+				fmt.Printf("Include Dependencies Of Mirrors: %s\n", strings.Join(repo.DepsFromMirrors, ", "))
+			}
+			if len(repo.DepsFromRepos) > 0 {
+				fmt.Printf("Include Dependencies Of Repositories: %s\n", strings.Join(repo.DepsFromRepos, ", "))
+			}
+		}
 	}
 	if repo.LastDownloadDate.IsZero() {
 		fmt.Printf("Last update: never\n")

--- a/cmd/mirror_update.go
+++ b/cmd/mirror_update.go
@@ -67,14 +67,50 @@ func aptlyMirrorUpdate(cmd *commander.Command, args []string) error {
 	if repo.Filter != "" {
 		context.Progress().Printf("Applying filter...\n")
 		var filterQuery deb.PackageQuery
+		var packagesWithExtraDeps *deb.PackageList
 
 		filterQuery, err = query.Parse(repo.Filter)
 		if err != nil {
 			return fmt.Errorf("unable to update: %s", err)
 		}
 
+		if len(repo.DepsFromMirrors)+len(repo.DepsFromRepos) > 0 {
+			packagesWithExtraDeps = deb.NewPackageList()
+			for _, mirrorName := range repo.DepsFromMirrors {
+				extraMirror, lerr := context.CollectionFactory().RemoteRepoCollection().ByName(mirrorName)
+				if lerr != nil {
+					return fmt.Errorf("unable to update: %s", lerr)
+				}
+				lerr = context.CollectionFactory().RemoteRepoCollection().LoadComplete(extraMirror)
+				if lerr != nil {
+					return fmt.Errorf("unable to update: %s", lerr)
+				}
+				packageList, lerr := deb.NewPackageListFromRefList(extraMirror.RefList(), context.CollectionFactory().PackageCollection(), context.Progress())
+				if lerr != nil {
+					return fmt.Errorf("unable to update: %s", lerr)
+				}
+				packagesWithExtraDeps.Append(packageList)
+			}
+			for _, repoName := range repo.DepsFromRepos {
+				extraRepo, lerr := context.CollectionFactory().LocalRepoCollection().ByName(repoName)
+				if lerr != nil {
+					return fmt.Errorf("unable to update: %s", lerr)
+				}
+				lerr = context.CollectionFactory().LocalRepoCollection().LoadComplete(extraRepo)
+				if lerr != nil {
+					return fmt.Errorf("unable to update: %s", lerr)
+				}
+				packageList, lerr := deb.NewPackageListFromRefList(extraRepo.RefList(), context.CollectionFactory().PackageCollection(), context.Progress())
+				if lerr != nil {
+					return fmt.Errorf("unable to update: %s", lerr)
+				}
+				packagesWithExtraDeps.Append(packageList)
+			}
+			context.Progress().Printf("Extra packages with deps: %d\n", packagesWithExtraDeps.Len())
+		}
+
 		var oldLen, newLen int
-		oldLen, newLen, err = repo.ApplyFilter(context.DependencyOptions(), filterQuery, context.Progress())
+		oldLen, newLen, err = repo.ApplyFilter(context.DependencyOptions(), filterQuery, packagesWithExtraDeps, context.Progress())
 		if err != nil {
 			return fmt.Errorf("unable to update: %s", err)
 		}

--- a/cmd/mirror_update.go
+++ b/cmd/mirror_update.go
@@ -74,33 +74,34 @@ func aptlyMirrorUpdate(cmd *commander.Command, args []string) error {
 			return fmt.Errorf("unable to update: %s", err)
 		}
 
+		collectionFactory := context.NewCollectionFactory()
 		if len(repo.DepsFromMirrors)+len(repo.DepsFromRepos) > 0 {
 			packagesWithExtraDeps = deb.NewPackageList()
 			for _, mirrorName := range repo.DepsFromMirrors {
-				extraMirror, lerr := context.CollectionFactory().RemoteRepoCollection().ByName(mirrorName)
+				extraMirror, lerr := collectionFactory.RemoteRepoCollection().ByName(mirrorName)
 				if lerr != nil {
 					return fmt.Errorf("unable to update: %s", lerr)
 				}
-				lerr = context.CollectionFactory().RemoteRepoCollection().LoadComplete(extraMirror)
+				lerr = collectionFactory.RemoteRepoCollection().LoadComplete(extraMirror)
 				if lerr != nil {
 					return fmt.Errorf("unable to update: %s", lerr)
 				}
-				packageList, lerr := deb.NewPackageListFromRefList(extraMirror.RefList(), context.CollectionFactory().PackageCollection(), context.Progress())
+				packageList, lerr := deb.NewPackageListFromRefList(extraMirror.RefList(), collectionFactory.PackageCollection(), context.Progress())
 				if lerr != nil {
 					return fmt.Errorf("unable to update: %s", lerr)
 				}
 				packagesWithExtraDeps.Append(packageList)
 			}
 			for _, repoName := range repo.DepsFromRepos {
-				extraRepo, lerr := context.CollectionFactory().LocalRepoCollection().ByName(repoName)
+				extraRepo, lerr := collectionFactory.LocalRepoCollection().ByName(repoName)
 				if lerr != nil {
 					return fmt.Errorf("unable to update: %s", lerr)
 				}
-				lerr = context.CollectionFactory().LocalRepoCollection().LoadComplete(extraRepo)
+				lerr = collectionFactory.LocalRepoCollection().LoadComplete(extraRepo)
 				if lerr != nil {
 					return fmt.Errorf("unable to update: %s", lerr)
 				}
-				packageList, lerr := deb.NewPackageListFromRefList(extraRepo.RefList(), context.CollectionFactory().PackageCollection(), context.Progress())
+				packageList, lerr := deb.NewPackageListFromRefList(extraRepo.RefList(), collectionFactory.PackageCollection(), context.Progress())
 				if lerr != nil {
 					return fmt.Errorf("unable to update: %s", lerr)
 				}

--- a/cmd/repo_move.go
+++ b/cmd/repo_move.go
@@ -116,7 +116,7 @@ func aptlyRepoMoveCopyImport(cmd *commander.Command, args []string) error {
 		}
 	}
 
-	toProcess, err := srcList.FilterWithProgress(queries, withDeps, dstList, context.DependencyOptions(), architecturesList, context.Progress())
+	toProcess, err := srcList.FilterWithProgress(queries, withDeps, dstList, nil, context.DependencyOptions(), architecturesList, context.Progress())
 	if err != nil {
 		return fmt.Errorf("unable to %s: %s", command, err)
 	}

--- a/cmd/repo_remove.go
+++ b/cmd/repo_remove.go
@@ -45,7 +45,7 @@ func aptlyRepoRemove(cmd *commander.Command, args []string) error {
 	}
 
 	list.PrepareIndex()
-	toRemove, err := list.Filter(queries, false, nil, 0, nil)
+	toRemove, err := list.Filter(queries, false, nil, nil, 0, nil)
 	if err != nil {
 		return fmt.Errorf("unable to remove: %s", err)
 	}

--- a/cmd/snapshot_filter.go
+++ b/cmd/snapshot_filter.go
@@ -67,7 +67,7 @@ func aptlySnapshotFilter(cmd *commander.Command, args []string) error {
 	}
 
 	// Filter with dependencies as requested
-	result, err := packageList.FilterWithProgress(queries, withDeps, nil, context.DependencyOptions(), architecturesList, context.Progress())
+	result, err := packageList.FilterWithProgress(queries, withDeps, nil, nil, context.DependencyOptions(), architecturesList, context.Progress())
 	if err != nil {
 		return fmt.Errorf("unable to filter: %s", err)
 	}

--- a/cmd/snapshot_pull.go
+++ b/cmd/snapshot_pull.go
@@ -97,7 +97,7 @@ func aptlySnapshotPull(cmd *commander.Command, args []string) error {
 	}
 
 	// Filter with dependencies as requested
-	result, err := sourcePackageList.FilterWithProgress(queries, !noDeps, packageList, context.DependencyOptions(), architecturesList, context.Progress())
+	result, err := sourcePackageList.FilterWithProgress(queries, !noDeps, packageList, nil, context.DependencyOptions(), architecturesList, context.Progress())
 	if err != nil {
 		return fmt.Errorf("unable to pull: %s", err)
 	}

--- a/cmd/snapshot_search.go
+++ b/cmd/snapshot_search.go
@@ -104,7 +104,7 @@ func aptlySnapshotMirrorRepoSearch(cmd *commander.Command, args []string) error 
 	}
 
 	result, err := list.FilterWithProgress([]deb.PackageQuery{q}, withDeps,
-		nil, context.DependencyOptions(), architecturesList, context.Progress())
+		nil, nil, context.DependencyOptions(), architecturesList, context.Progress())
 	if err != nil {
 		return fmt.Errorf("unable to search: %s", err)
 	}

--- a/completion.d/aptly
+++ b/completion.d/aptly
@@ -154,7 +154,7 @@ _aptly()
           "create")
             if [[ $numargs -eq 0 ]]; then
               if [[ "$cur" == -* ]]; then
-                COMPREPLY=($(compgen -W "-filter= -filter-with-deps -force-components -ignore-signatures -keyring= -with-installer -with-sources -with-udebs" -- ${cur}))
+                COMPREPLY=($(compgen -W "-filter= -filter-with-deps -force-components -ignore-signatures -keyring= -with-installer -with-sources -with-udebs -deps-from-mirrors= -deps-from-repos=" -- ${cur}))
                 return 0
               fi
             fi
@@ -162,7 +162,7 @@ _aptly()
           "edit")
             if [[ $numargs -eq 0 ]]; then
               if [[ "$cur" == -* ]]; then
-                COMPREPLY=($(compgen -W "-archive-url= -filter= -filter-with-deps -ignore-signatures -keyring= -with-installer -with-sources -with-udebs" -- ${cur}))
+                COMPREPLY=($(compgen -W "-archive-url= -filter= -filter-with-deps -ignore-signatures -keyring= -with-installer -with-sources -with-udebs -deps-from-mirrors= -deps-from-repos=" -- ${cur}))
               else
                 COMPREPLY=($(compgen -W "$(__aptly_mirror_list)" -- ${cur}))
               fi

--- a/man/aptly.1
+++ b/man/aptly.1
@@ -483,6 +483,14 @@ $ aptly mirror create wheezy\-main http://mirror\.yandex\.ru/debian/ wheezy main
 Options:
 .
 .TP
+\-\fBdeps\-from\-mirrors\fR=
+list of mirrors thats packages\(cqs dependencies should be fulfilled (comma\-separated), default to none
+.
+.TP
+\-\fBdeps\-from\-repos\fR=
+list of repositories thats packages\(cqs dependencies should be fulfilled (comma\-separated), default to none
+.
+.TP
 \-\fBfilter\fR=
 filter packages in mirror
 .
@@ -660,6 +668,12 @@ Options:
 .TP
 \-\fBarchive\-url\fR=
 archive url is the root of archive
+\-\fBdeps\-from\-mirrors\fR=
+list of mirrors thats packages\(cqs dependencies should be fulfilled (comma\-separated), default to none
+.
+.TP
+\-\fBdeps\-from\-repos\fR=
+list of repositories thats packages\(cqs dependencies should be fulfilled (comma\-separated), default to none
 .
 .TP
 \-\fBfilter\fR=
@@ -2113,6 +2127,7 @@ Clemens Rabe (https://github\.com/seeraven)
 TJ Merritt (https://github\.com/tjmerritt)
 .
 .IP "\[ci]" 4
+<<<<<<< HEAD
 Matt Martyn (https://github\.com/MMartyn)
 .
 .IP "\[ci]" 4
@@ -2159,6 +2174,9 @@ Lorenzo Bolla (https://github\.com/lbolla)
 .
 .IP "\[ci]" 4
 Benj Fassbind (https://github\.com/randombenj)
+.
+.IP "\[ci]" 4
+Malte Swart (https://github\.com/mswart)
 .
 .IP "" 0
 

--- a/system/t03_help/MirrorCreateHelpTest_gold
+++ b/system/t03_help/MirrorCreateHelpTest_gold
@@ -21,6 +21,8 @@ Options:
   -dep-follow-source: when processing dependencies, follow from binary to Source packages
   -dep-follow-suggests: when processing dependencies, follow Suggests
   -dep-verbose-resolve: when processing dependencies, print detailed logs
+  -deps-from-mirrors: list of mirrors thats packages's dependencies should be fulfilled (comma-separated), default to none
+  -deps-from-repos: list of repositories thats packages's dependencies should be fulfilled (comma-separated), default to none
   -filter="": filter packages in mirror
   -filter-with-deps: when filtering, include dependencies of matching packages as well
   -force-architectures: (only with architecture list) skip check that requested architectures are listed in Release file

--- a/system/t03_help/MirrorCreateHelpTest_gold
+++ b/system/t03_help/MirrorCreateHelpTest_gold
@@ -21,8 +21,8 @@ Options:
   -dep-follow-source: when processing dependencies, follow from binary to Source packages
   -dep-follow-suggests: when processing dependencies, follow Suggests
   -dep-verbose-resolve: when processing dependencies, print detailed logs
-  -deps-from-mirrors: list of mirrors thats packages's dependencies should be fulfilled (comma-separated), default to none
-  -deps-from-repos: list of repositories thats packages's dependencies should be fulfilled (comma-separated), default to none
+  -deps-from-mirrors="": list of mirrors thats packages's dependencies should be fulfilled (comma-separated), default to none
+  -deps-from-repos="": list of repositories thats packages's dependencies should be fulfilled (comma-separated), default to none
   -filter="": filter packages in mirror
   -filter-with-deps: when filtering, include dependencies of matching packages as well
   -force-architectures: (only with architecture list) skip check that requested architectures are listed in Release file

--- a/system/t03_help/MirrorCreateTest_gold
+++ b/system/t03_help/MirrorCreateTest_gold
@@ -12,8 +12,8 @@ Options:
   -dep-follow-source: when processing dependencies, follow from binary to Source packages
   -dep-follow-suggests: when processing dependencies, follow Suggests
   -dep-verbose-resolve: when processing dependencies, print detailed logs
-  -deps-from-mirrors: list of mirrors thats packages's dependencies should be fulfilled (comma-separated), default to none
-  -deps-from-repos: list of repositories thats packages's dependencies should be fulfilled (comma-separated), default to none
+  -deps-from-mirrors="": list of mirrors thats packages's dependencies should be fulfilled (comma-separated), default to none
+  -deps-from-repos="": list of repositories thats packages's dependencies should be fulfilled (comma-separated), default to none
   -filter="": filter packages in mirror
   -filter-with-deps: when filtering, include dependencies of matching packages as well
   -force-architectures: (only with architecture list) skip check that requested architectures are listed in Release file

--- a/system/t03_help/MirrorCreateTest_gold
+++ b/system/t03_help/MirrorCreateTest_gold
@@ -12,6 +12,8 @@ Options:
   -dep-follow-source: when processing dependencies, follow from binary to Source packages
   -dep-follow-suggests: when processing dependencies, follow Suggests
   -dep-verbose-resolve: when processing dependencies, print detailed logs
+  -deps-from-mirrors: list of mirrors thats packages's dependencies should be fulfilled (comma-separated), default to none
+  -deps-from-repos: list of repositories thats packages's dependencies should be fulfilled (comma-separated), default to none
   -filter="": filter packages in mirror
   -filter-with-deps: when filtering, include dependencies of matching packages as well
   -force-architectures: (only with architecture list) skip check that requested architectures are listed in Release file

--- a/system/t03_help/WrongFlagTest_gold
+++ b/system/t03_help/WrongFlagTest_gold
@@ -13,6 +13,8 @@ Options:
   -dep-follow-source: when processing dependencies, follow from binary to Source packages
   -dep-follow-suggests: when processing dependencies, follow Suggests
   -dep-verbose-resolve: when processing dependencies, print detailed logs
+  -deps-from-mirrors: list of mirrors thats packages's dependencies should be fulfilled (comma-separated), default to none
+  -deps-from-repos: list of repositories thats packages's dependencies should be fulfilled (comma-separated), default to none
   -filter="": filter packages in mirror
   -filter-with-deps: when filtering, include dependencies of matching packages as well
   -force-architectures: (only with architecture list) skip check that requested architectures are listed in Release file

--- a/system/t03_help/WrongFlagTest_gold
+++ b/system/t03_help/WrongFlagTest_gold
@@ -13,8 +13,8 @@ Options:
   -dep-follow-source: when processing dependencies, follow from binary to Source packages
   -dep-follow-suggests: when processing dependencies, follow Suggests
   -dep-verbose-resolve: when processing dependencies, print detailed logs
-  -deps-from-mirrors: list of mirrors thats packages's dependencies should be fulfilled (comma-separated), default to none
-  -deps-from-repos: list of repositories thats packages's dependencies should be fulfilled (comma-separated), default to none
+  -deps-from-mirrors="": list of mirrors thats packages's dependencies should be fulfilled (comma-separated), default to none
+  -deps-from-repos="": list of repositories thats packages's dependencies should be fulfilled (comma-separated), default to none
   -filter="": filter packages in mirror
   -filter-with-deps: when filtering, include dependencies of matching packages as well
   -force-architectures: (only with architecture list) skip check that requested architectures are listed in Release file

--- a/system/t04_mirror/ListMirror6Test_gold
+++ b/system/t04_mirror/ListMirror6Test_gold
@@ -42,7 +42,9 @@
     "SkipArchitectureCheck": false,
     "DownloadSources": false,
     "DownloadUdebs": false,
-    "DownloadInstaller": false
+    "DownloadInstaller": false,
+    "DepsFromMirrors": null,
+    "DepsFromRepos": null
   },
   {
     "Name": "mirror2",
@@ -85,7 +87,9 @@
     "SkipArchitectureCheck": false,
     "DownloadSources": true,
     "DownloadUdebs": false,
-    "DownloadInstaller": false
+    "DownloadInstaller": false,
+    "DepsFromMirrors": null,
+    "DepsFromRepos": null
   },
   {
     "Name": "mirror3",
@@ -119,7 +123,9 @@
     "SkipArchitectureCheck": false,
     "DownloadSources": false,
     "DownloadUdebs": false,
-    "DownloadInstaller": false
+    "DownloadInstaller": false,
+    "DepsFromMirrors": null,
+    "DepsFromRepos": null
   },
   {
     "Name": "mirror4",
@@ -145,6 +151,8 @@
     "SkipArchitectureCheck": false,
     "DownloadSources": false,
     "DownloadUdebs": false,
-    "DownloadInstaller": false
+    "DownloadInstaller": false,
+    "DepsFromMirrors": null,
+    "DepsFromRepos": null
   }
 ]

--- a/system/t04_mirror/ShowMirror5Test_gold
+++ b/system/t04_mirror/ShowMirror5Test_gold
@@ -41,5 +41,7 @@
   "SkipArchitectureCheck": false,
   "DownloadSources": false,
   "DownloadUdebs": false,
-  "DownloadInstaller": false
+  "DownloadInstaller": false,
+  "DepsFromMirrors": null,
+  "DepsFromRepos": null
 }

--- a/system/t04_mirror/ShowMirror7Test_gold
+++ b/system/t04_mirror/ShowMirror7Test_gold
@@ -357,5 +357,7 @@
     "xvba-va-driver_0.8.0-5_i386",
     "ydpdict_1.0.0-2_amd64",
     "ydpdict_1.0.0-2_i386"
-  ]
+  ],
+  "DepsFromMirrors": null,
+  "DepsFromRepos": null
 }

--- a/system/t04_mirror/ShowMirror8Test_gold
+++ b/system/t04_mirror/ShowMirror8Test_gold
@@ -33,5 +33,7 @@
   "SkipArchitectureCheck": false,
   "DownloadSources": false,
   "DownloadUdebs": false,
-  "DownloadInstaller": false
+  "DownloadInstaller": false,
+  "DepsFromMirrors": null,
+  "DepsFromRepos": null
 }

--- a/system/t05_snapshot/ShowSnapshot4Test_gold
+++ b/system/t05_snapshot/ShowSnapshot4Test_gold
@@ -34,7 +34,9 @@
       "SkipArchitectureCheck": false,
       "DownloadSources": false,
       "DownloadUdebs": false,
-      "DownloadInstaller": false
+      "DownloadInstaller": false,
+      "DepsFromMirrors": null,
+      "DepsFromRepos": null
     }
   ],
   "Description": "Snapshot from mirror [wheezy-non-free]: http://mirror.yandex.ru/debian/ wheezy",

--- a/system/t05_snapshot/ShowSnapshot5Test_gold
+++ b/system/t05_snapshot/ShowSnapshot5Test_gold
@@ -36,7 +36,9 @@
       "SkipArchitectureCheck": false,
       "DownloadSources": false,
       "DownloadUdebs": false,
-      "DownloadInstaller": false
+      "DownloadInstaller": false,
+      "DepsFromMirrors": null,
+      "DepsFromRepos": null
     }
   ],
   "Packages": [


### PR DESCRIPTION
Fixes #357

## Description of the Change

Distributions contain a huge set of packages, mirroring them requires a large amount of storage and bandwidth. To mitigate this issues aptly provides an filter feature to reduce the set of mirrored packages. Especially it supports to limit the downloaded packages to a set of packages and their needed dependencies as well.

As this filter is self-contained within each mirror, it has two limitations:

1. **its difficult to partial mirror a security or updates mirror to match a filtered main repository.** Update and security repositories contain (newer) packages for a (small) subset of the whole distribution to fix bugs/security issues. As the repository contains not all packages, filtering breaks due to cuts within the dependency tree.

2. **integration of packages from other sources.** It is not possible to filter for all dependencies of a package if this package itself is not part of the mirror repository but instead published within another (local) repository.

In both cases all dependencies between repositories/mirrors have to be included manually in the mirror filter.

This commit introduces `-deps-from-mirrors` and `-deps-from-repos` options for mirrors. They are comma-separated lists referencing mirror/repository names.

If `-filter-with-deps` is activated all dependencies of packages from the references mirrors/repositories that are part of the current mirror are included in addition to the filter result itself. This resolves 2.

If in addition `-dep-follow-all-variants` is activated, all packages that are included in the referenced mirrors/repositories and present in the current mirror (matched by package name only) are selected to download, too. This resolves 1.

## Limitations / Questions

- I am not confident about the option names, but I lack ideas for shorter, more to the point ones.
- The implemented approach differs from the proposals in #357 - each mirror is updated on its own. If both mirrors have (many) packages with dependencies only in other mirrors, it might take some update rounds (update mirror 1, update mirror 2, update mirror 1 ...) to pick up all needed dependencies. I observed a similar behavior for experiments with xenial-mirrors and its security/update repositories. It took 2-3 updates to reach a stable filter point. I am currently unsure about the cause, I wound investigate further if the feature / fundamental implementation design is approached.
- I am unsure how to best implement functional tests.

## Checklist

- [x] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [x] man page updated (if applicable)
- [x] bash completion updated (if applicable)
- [ ] documentation updated
- [x] author name in `AUTHORS`
