### PR TITLE
add support for travis attaching build artifacts to releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ man/aptly.1.ronn
 .goxc.local.json
 
 system/env/
+
+# created by make build for release artifacts
+build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,9 @@ matrix:
     - go: 1.9.x
       env: RUN_LONG_TESTS=yes
     - go: 1.10.x
-      env: RUN_LONG_TESTS=yes
+      env:
+        - RUN_LONG_TESTS=yes
+        - DEPLOY_BINARIES=yes
     - go: master
       env: RUN_LONG_TESTS=no
 
@@ -54,3 +56,18 @@ notifications:
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
     on_start: false     # default: false
+
+before_deploy:
+  - make build
+  - export FILE_TO_UPLOAD=$(ls build/aptly-*)
+
+deploy:
+  provider: releases
+  api_key:
+    - secure: "MMk5S1Im6RrVudZasjtlCJa/rvRp4oavrR86WI2kQszs1iZIcdGyVhHiOGfWTwMjA/3iPdbAdu/WrjxCwI14GC5ws+rs8ICO6JIZktjtAwlfwlrV+nsrCiYx1EThghq43VEcykgz2UAJoJj/egv+UCEpe8yDTsvJ6we5HiXdTw0="
+  file_glob: true
+  file: "${FILE_TO_UPLOAD}"
+  skip_cleanup: true
+  on:
+    tags: true
+    condition: "$DEPLOY_BINARIES = yes"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 GOVERSION=$(shell go version | awk '{print $$3;}')
-VERSION=$(shell git describe --tags | sed 's@^v@@' | sed 's@-@+@g')
+ifdef TRAVIS_TAG
+	TAG=$(TRAVIS_TAG)
+else
+	TAG="$(shell git describe --tags)"
+endif
+VERSION=$(shell echo $(TAG) | sed 's@^v@@' | sed 's@-@+@g')
 PACKAGES=context database deb files gpg http query swift s3 utils
 PYTHON?=python
 TESTS?=
@@ -30,6 +35,11 @@ endif
 
 install:
 	go install -v -ldflags "-X main.Version=$(VERSION)"
+
+build:
+	rm -rf build
+	mkdir -p build
+	go build -v -ldflags "-X main.Version=$(VERSION)" -o "build/aptly-$(VERSION)"
 
 system/env: system/requirements.txt
 ifeq ($(RUN_LONG_TESTS), yes)
@@ -71,4 +81,4 @@ man:
 version:
 	@echo $(VERSION)
 
-.PHONY: man version
+.PHONY: man version build


### PR DESCRIPTION
- new phony target build: same as install but creating aptly-$version and
  putting it into a build/ subdir
- env TRAVIS_TAG in the makefile now overrides the TAG lookup, this ensures
  that the tag travis is working with is actually the one being used to
  construct the version number
- subdir is gitignored
- travis runs new target - lists artifacts - deploys artifacts to github

all of the above only happens on builds that are a tag and DEPLOY_BINARIES
is set to yes (which is only the case for latest stable go version)
