### PR TITLE
Skip GPG version check `APTLY_SKIP_GPG_VERSION_CHECK=1` is set in the env

### DIFF
--- a/pgp/gnupg.go
+++ b/pgp/gnupg.go
@@ -18,6 +18,9 @@ var (
 	_ Verifier = &GpgVerifier{}
 )
 
+// Skip GPG version check for GPG 1.x
+var skipGPGVersionCheck bool
+
 // GpgSigner is implementation of Signer interface using gpg as external program
 type GpgSigner struct {
 	gpg                        string
@@ -84,7 +87,7 @@ func cliVersionCheck(cmd string, marker string) bool {
 	if err != nil {
 		return false
 	}
-	return strings.Contains(string(output), marker)
+	return skipGPGVersionCheck || strings.Contains(string(output), marker)
 }
 
 func findSuitableCLI(cmds []string, versionMarker string) string {
@@ -425,4 +428,12 @@ func (g *GpgVerifier) ExtractClearsigned(clearsigned io.Reader) (text *os.File, 
 	}
 
 	return
+}
+
+func init() {
+	skipCheck := os.Getenv("APTLY_SKIP_GPG_VERSION_CHECK")
+	switch strings.ToLower(skipCheck) {
+	case "1", "y", "yes", "true":
+		skipGPGVersionCheck = true
+	}
 }


### PR DESCRIPTION
This allows to force using GnuPG 2.x even if aptly is not 100% ready
to use it.

See #741, #657

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [ ] author name in `AUTHORS`
