### PR TITLE
Keep checksum of not compressed index file even if it's not uploaded

### DIFF
--- a/deb/index_files.go
+++ b/deb/index_files.go
@@ -77,14 +77,17 @@ func (file *indexFile) Finalize(signer pgp.Signer) error {
 	file.tempFile.Close()
 
 	exts := []string{""}
+	cksumExts := exts
 	if file.compressable {
 		exts = append(exts, ".gz", ".bz2")
+		cksumExts = exts
 		if file.onlyGzip {
 			exts = []string{".gz"}
+			cksumExts = []string{"", ".gz"}
 		}
 	}
 
-	for _, ext := range exts {
+	for _, ext := range cksumExts {
 		var checksumInfo utils.ChecksumInfo
 
 		checksumInfo, err = utils.ChecksumsForFile(file.tempFilename + ext)

--- a/system/t06_publish/repo.py
+++ b/system/t06_publish/repo.py
@@ -69,6 +69,10 @@ class PublishRepo1Test(BaseTest):
         pathsSeen = set()
         for l in release:
             fileHash, fileSize, path = l.split()
+            if "Contents" in path and not path.endswith(".gz"):
+                # "Contents" are present in index, but not really written to disk
+                continue
+
             pathsSeen.add(path)
 
             fileSize = int(fileSize)
@@ -464,6 +468,10 @@ class PublishRepo17Test(BaseTest):
         pathsSeen = set()
         for l in release:
             fileHash, fileSize, path = l.split()
+            if "Contents" in path and not path.endswith(".gz"):
+                # "Contents" are present in index, but not really written to disk
+                continue
+
             pathsSeen.add(path)
 
             fileSize = int(fileSize)

--- a/system/t06_publish/snapshot.py
+++ b/system/t06_publish/snapshot.py
@@ -79,6 +79,10 @@ class PublishSnapshot1Test(BaseTest):
         pathsSeen = set()
         for l in release:
             fileHash, fileSize, path = l.split()
+            if "Contents" in path and not path.endswith(".gz"):
+                # "Contents" are present in index, but not really written to disk
+                continue
+
             pathsSeen.add(path)
 
             fileSize = int(fileSize)
@@ -724,6 +728,10 @@ class PublishSnapshot26Test(BaseTest):
         pathsSeen = set()
         for l in release:
             fileHash, fileSize, path = l.split()
+            if "Contents" in path and not path.endswith(".gz"):
+                # "Contents" are present in index, but not really written to disk
+                continue
+
             pathsSeen.add(path)
 
             fileSize = int(fileSize)
@@ -947,6 +955,10 @@ class PublishSnapshot35Test(BaseTest):
         pathsSeen = set()
         for l in release:
             fileHash, fileSize, path = l.split()
+            if "Contents" in path and not path.endswith(".gz"):
+                # "Contents" are present in index, but not really written to disk
+                continue
+
             pathsSeen.add(path)
 
             fileSize = int(fileSize)

--- a/system/t06_publish/switch.py
+++ b/system/t06_publish/switch.py
@@ -61,6 +61,10 @@ class PublishSwitch1Test(BaseTest):
         pathsSeen = set()
         for l in release:
             fileHash, fileSize, path = l.split()
+            if "Contents" in path and not path.endswith(".gz"):
+                # "Contents" are present in index, but not really written to disk
+                continue
+
             pathsSeen.add(path)
 
             fileSize = int(fileSize)
@@ -321,6 +325,10 @@ class PublishSwitch8Test(BaseTest):
         pathsSeen = set()
         for l in release:
             fileHash, fileSize, path = l.split()
+            if "Contents" in path and not path.endswith(".gz"):
+                # "Contents" are present in index, but not really written to disk
+                continue
+
             pathsSeen.add(path)
 
             fileSize = int(fileSize)
@@ -506,6 +514,10 @@ class PublishSwitch14Test(BaseTest):
         pathsSeen = set()
         for l in release:
             fileHash, fileSize, path = l.split()
+            if "Contents" in path and not path.endswith(".gz"):
+                # "Contents" are present in index, but not really written to disk
+                continue
+
             pathsSeen.add(path)
 
             fileSize = int(fileSize)

--- a/system/t06_publish/update.py
+++ b/system/t06_publish/update.py
@@ -61,6 +61,10 @@ class PublishUpdate1Test(BaseTest):
         pathsSeen = set()
         for l in release:
             fileHash, fileSize, path = l.split()
+            if "Contents" in path and not path.endswith(".gz"):
+                # "Contents" are present in index, but not really written to disk
+                continue
+
             pathsSeen.add(path)
 
             fileSize = int(fileSize)
@@ -402,6 +406,10 @@ class PublishUpdate12Test(BaseTest):
         pathsSeen = set()
         for l in release:
             fileHash, fileSize, path = l.split()
+            if "Contents" in path and not path.endswith(".gz"):
+                # "Contents" are present in index, but not really written to disk
+                continue
+
             pathsSeen.add(path)
 
             fileSize = int(fileSize)


### PR DESCRIPTION
Fixes: #756

## Description of the Change

See #756 for detailed description

## Checklist

- [ ] unit-test added (if change is algorithm)
- [x] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [x] author name in `AUTHORS`
