### PR TITLE
Lower memory usage for `aptly db cleanup`

### DIFF
--- a/cmd/db_cleanup.go
+++ b/cmd/db_cleanup.go
@@ -59,6 +59,8 @@ func aptlyDbCleanup(cmd *commander.Command, args []string) error {
 		return err
 	}
 
+	context.CollectionFactory().Flush()
+
 	if verbose {
 		context.Progress().ColoredPrintf("@{y}Loading local repos:@|")
 	}
@@ -90,6 +92,8 @@ func aptlyDbCleanup(cmd *commander.Command, args []string) error {
 		return err
 	}
 
+	context.CollectionFactory().Flush()
+
 	if verbose {
 		context.Progress().ColoredPrintf("@{y}Loading snapshots:@|")
 	}
@@ -117,6 +121,8 @@ func aptlyDbCleanup(cmd *commander.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	context.CollectionFactory().Flush()
 
 	if verbose {
 		context.Progress().ColoredPrintf("@{y}Loading published repositories:@|")
@@ -149,6 +155,8 @@ func aptlyDbCleanup(cmd *commander.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	context.CollectionFactory().Flush()
 
 	// ... and compare it to the list of all packages
 	context.Progress().ColoredPrintf("@{w!}Loading list of all packages...@|")
@@ -191,6 +199,8 @@ func aptlyDbCleanup(cmd *commander.Command, args []string) error {
 			context.Progress().ColoredPrintf("@{y!}Skipped deletion, as -dry-run has been requested.@|")
 		}
 	}
+
+	context.CollectionFactory().Flush()
 
 	// now, build a list of files that should be present in Repository (package pool)
 	context.Progress().ColoredPrintf("@{w!}Building list of files referenced by packages...@|")


### PR DESCRIPTION
## Description of the Change

This is not a complete fix, but the easiest first step.

During `db cleanup`, aptly is loading every repo/mirror/... into memory,
and even though each object is processed only once, collection holds
a reference to all the loaded objects, so they won't be GC'd until
process exits.

CollectionFactory.Flush() releases pointers to collection objects,
making objects egligble for GC.

This is not a complete fix, as during iteration we could have tried
to release a link to every object being GCed and that would have
helped much more.

See #761

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [x] author name in `AUTHORS`
