### PR TITLE
Use github.com/aptly-dev/aptly as the go package path.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,8 +86,8 @@ to prepend it or to skip this test if you're security conscious.
 
 As Go is using repository path in import paths, it's better to clone aptly repo (not your fork) at default location:
 
-    mkdir -p ~/go/src/github.com/smira
-    cd ~/go/src/github.com/smira
+    mkdir -p ~/go/src/github.com/aptly-dev
+    cd ~/go/src/github.com/aptly-dev
     git clone git@github.com:aptly-dev/aptly.git
     cd aptly
 


### PR DESCRIPTION
Fixes: `make install` will fail when following the current CONTRIBUTING.md

```
❯ make install
go install -v -ldflags "-X main.Version=1.3.0+30+g72ff71f"
main.go:8:2: cannot find package "github.com/aptly-dev/aptly/aptly" in any of:
        /home/steven/osrf/aptly_gopath/src/github.com/smira/aptly/vendor/github.com/aptly-dev/aptly/aptly (vendor tree)
        /usr/lib/go-1.10/src/github.com/aptly-dev/aptly/aptly (from $GOROOT)
        /home/steven/osrf/aptly_gopath/src/github.com/aptly-dev/aptly/aptly (from $GOPATH)
main.go:9:2: cannot find package "github.com/aptly-dev/aptly/cmd" in any of:
        /home/steven/osrf/aptly_gopath/src/github.com/smira/aptly/vendor/github.com/aptly-dev/aptly/cmd (vendor tree)
        /usr/lib/go-1.10/src/github.com/aptly-dev/aptly/cmd (from $GOROOT)
        /home/steven/osrf/aptly_gopath/src/github.com/aptly-dev/aptly/cmd (from $GOPATH)
Makefile:37: recipe for target 'install' failed
```

## Description of the Change

Updates contributor documentation for the updated go package name.

## Checklist

- [ ] ~~unit-test added (if change is algorithm)~~
- [ ] ~~functional test added/updated (if change is functional)~~
- [ ] ~~man page updated (if applicable)~~
- [ ] ~~bash completion updated (if applicable)~~
- [x] documentation updated
- [ ] author name in `AUTHORS` *Does this merit an AUTHORS update? I am not bothered about being added for such a small docs fix.*
