### PR TITLE
Replace Docker container w aptly & nginx in README

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -33,3 +33,4 @@ List of contributors, in chronological order:
 * Petr Jediny (https://github.com/pjediny)
 * Maximilian Stein (https://github.com/steinymity)
 * Strajan Sebastian (https://github.com/strajansebastian)
+* Artem Smirnov (https://github.com/urpylka)

--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ Vagrant:
 Docker:
 
 -    `Docker container <https://github.com/mikepurvis/aptly-docker>`_ with aptly inside by Mike Purvis
--    `Docker container <https://github.com/bryanhong/docker-aptly>`_ with aptly and nginx by Bryan Hong
+-    `Docker container <https://github.com/urpylka/docker-aptly>`_ with aptly and nginx by Artem Smirnov
 
 With configuration management systems:
 

--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ If you have Go environment set up, you can build aptly from source by running (g
     cd $GOPATH/src/github.com/aptly-dev/aptly
     make install
 
-Binary would be installed to ```$GOPATH/bin/aptly``.
+Binary would be installed to ``$GOPATH/bin/aptly``.
 
 Contributing
 ------------


### PR DESCRIPTION
## Requirements

Documentation should be updated. CI should pass.

## Description of the Change

Old project for run docker w aptly not supported long time.
All functional doesn't work.
I create updated and worked fork based on original repo Bryan Hong.

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [x] documentation updated
- [x] author name in `AUTHORS`