### PR TITLE
Fix #800: -skip-existing-packages for missing checksums

### DIFF
--- a/deb/reflist.go
+++ b/deb/reflist.go
@@ -69,7 +69,7 @@ func (l *PackageRefList) Encode() []byte {
 	return buf.Bytes()
 }
 
-// Decode decodes msgpack representation into PackageRefLit
+// Decode decodes msgpack representation into PackageRefList
 func (l *PackageRefList) Decode(input []byte) error {
 	decoder := codec.NewDecoderBytes(input, &codec.MsgpackHandle{})
 	return decoder.Decode(l)


### PR DESCRIPTION
Skipping of existing packages will now also work when not all checksums
are provided by the mirrored repository.
When this is the case, packages will be searched for in the package
pool.  And the search results will be validated against the requested
package.

Fixes #800 

I am aware this code does not contain any tests.  I am scheduling it for review first to see if my proposed solution is acceptable.  If it is, I can add some tests.


## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] documentation updated
- [ ] author name in `AUTHORS`
