### PR TITLE
Skip uploading release versions of aptly to nightly repo

### DIFF
--- a/upload-artifacts.sh
+++ b/upload-artifacts.sh
@@ -17,6 +17,11 @@ for file in $packages; do
 done
 
 if [[ "$1" = "nightly" ]]; then
+    if echo "$version" | grep -vq "+"; then
+       # skip nightly when on release tag
+       exit 0
+    fi
+
     aptly_repository=aptly-nightly
     aptly_published=s3:repo.aptly.info:./nightly
 


### PR DESCRIPTION
This breaks releases, as two versions of the package with same version
might end up in internal.aptly.info.

