### PR TITLE
Revert "Don't remove API file socket if it exists and it's usable"

### DIFF
--- a/cmd/api_serve.go
+++ b/cmd/api_serve.go
@@ -58,25 +58,7 @@ func aptlyAPIServe(cmd *commander.Command, args []string) error {
 	listenURL, err := url.Parse(listen)
 	if err == nil && listenURL.Scheme == "unix" {
 		file := listenURL.Path
-
-		var stat os.FileInfo
-		stat, err = os.Stat(file)
-		shouldRemove := true
-
-		if err == nil && stat.Mode()&os.ModeSocket == os.ModeSocket {
-			shouldRemove = false
-		}
-
-		if err != nil && os.IsNotExist(err) {
-			shouldRemove = false
-		}
-
-		if shouldRemove {
-			err = os.Remove(file)
-			if err != nil {
-				fmt.Printf("Warning: error removing file %s: %s\n", file, err)
-			}
-		}
+		os.Remove(file)
 
 		var listener net.Listener
 		listener, err = net.Listen("unix", file)


### PR DESCRIPTION
See PR #807

Fixes: #849

This reverts commit 22848b010d55b818f3d03fdbca02a67bc8ee225b.

