### PR TITLE
Parse dependency architecture even without version

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,3 +37,4 @@ List of contributors, in chronological order:
 * William Manley (https://github.com/wmanley)
 * Shengjing Zhu (https://github.com/zhsj)
 * Nabil Bendafi (https://github.com/nabilbendafi)
+* Raphael Medaer (https://github.com/rmedaer)

--- a/deb/version.go
+++ b/deb/version.go
@@ -236,6 +236,17 @@ func ParseDependencyVariants(variants string) (l []Dependency, err error) {
 	return
 }
 
+// ParseDependencyArch parses the dependency name in format "pkg:any" into name and architecture
+func ParseDependencyArch(d *Dependency) {
+	if strings.ContainsRune(d.Pkg, ':') {
+		parts := strings.SplitN(d.Pkg, ":", 2)
+		d.Pkg, d.Architecture = parts[0], parts[1]
+		if d.Architecture == "any" {
+			d.Architecture = ""
+		}
+	}
+}
+
 // ParseDependency parses dependency in format "pkg (>= 1.35) [arch]" into parts
 func ParseDependency(dep string) (d Dependency, err error) {
 	if strings.HasSuffix(dep, "}") {
@@ -252,6 +263,7 @@ func ParseDependency(dep string) (d Dependency, err error) {
 	if !strings.HasSuffix(dep, ")") {
 		d.Pkg = strings.TrimSpace(dep)
 		d.Relation = VersionDontCare
+		ParseDependencyArch(&d)
 		return
 	}
 
@@ -262,13 +274,7 @@ func ParseDependency(dep string) (d Dependency, err error) {
 	}
 
 	d.Pkg = strings.TrimSpace(dep[0:i])
-	if strings.ContainsRune(d.Pkg, ':') {
-		parts := strings.SplitN(d.Pkg, ":", 2)
-		d.Pkg, d.Architecture = parts[0], parts[1]
-		if d.Architecture == "any" {
-			d.Architecture = ""
-		}
-	}
+	ParseDependencyArch(&d)
 
 	rel := ""
 	if dep[i+1] == '>' || dep[i+1] == '<' || dep[i+1] == '=' {

--- a/deb/version_test.go
+++ b/deb/version_test.go
@@ -232,4 +232,8 @@ func (s *VersionSuite) TestDependencyString(c *C) {
 	d, _ = ParseDependency("dpkg")
 	d.Architecture = "i386"
 	c.Check(d.String(), Equals, "dpkg [i386]")
+
+	d, _ = ParseDependency("dpkg:any")
+	c.Check(d.Pkg, Equals, "dpkg")
+	c.Check(d.Architecture, Equals, "")
 }


### PR DESCRIPTION
This commit closes: #145

## Description of the Change

The dependency format "pkg:arch" (e.g. "python3:any") was not well parsed if not any version is given. This commit splits the dependency name and architecture in all cases.

## Checklist

- [x] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [x] author name in `AUTHORS`
