### PR TITLE
Make database open attempts configurable also via config file

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -259,7 +259,13 @@ func (context *AptlyContext) _database() (database.Storage, error) {
 		}
 	}
 
-	tries := context.flags.Lookup("db-open-attempts").Value.Get().(int)
+	var tries int
+	if context.config().DatabaseOpenAttempts == -1 {
+		tries = context.flags.Lookup("db-open-attempts").Value.Get().(int)
+	} else {
+		tries = context.config().DatabaseOpenAttempts
+	}
+
 	const BaseDelay = 10 * time.Second
 	const Jitter = 1 * time.Second
 

--- a/man/aptly.1
+++ b/man/aptly.1
@@ -40,6 +40,7 @@ Configuration file is stored in JSON format (default values shown below):
   "downloadSpeedLimit": 0,
   "downloadRetries": 0,
   "architectures": [],
+  "databaseOpenAttempts": 10,
   "dependencyFollowSuggests": false,
   "dependencyFollowRecommends": false,
   "dependencyFollowAllVariants": false,
@@ -120,6 +121,10 @@ limit in kbytes/sec on download speed while mirroring remote repositories
 .TP
 \fBdownloadRetries\fR
 number of retries for download attempts
+.
+.TP
+\fBdatabaseOpenAttempts\fR
+number of attempts to open DB if it's locked by other instance; could be overridden with option \fB\-db-open-attempts\fR
 .
 .TP
 \fBarchitectures\fR

--- a/man/aptly.1.ronn.tmpl
+++ b/man/aptly.1.ronn.tmpl
@@ -31,6 +31,7 @@ Configuration file is stored in JSON format (default values shown below):
       "downloadConcurrency": 4,
       "downloadSpeedLimit": 0,
       "downloadRetries": 0,
+      "databaseOpenAttempts": 10,
       "architectures": [],
       "dependencyFollowSuggests": false,
       "dependencyFollowRecommends": false,
@@ -104,6 +105,10 @@ Options:
 
   * `downloadRetries`:
     number of retries for download attempts
+
+  * `databaseOpenAttempts`:
+    number of attempts to open DB if it's locked by other instance; could be overridden with option
+    `-db-open-attempts`
 
   * `architectures`:
     is a list of architectures to process; if left empty defaults to all available architectures; could be

--- a/system/lib.py
+++ b/system/lib.py
@@ -99,6 +99,7 @@ class BaseTest(object):
         "downloadConcurrency": 4,
         "downloadSpeedLimit": 0,
         "downloadRetries": 5,
+        "databaseOpenAttempts": 10,
         "architectures": [],
         "dependencyFollowSuggests": False,
         "dependencyFollowRecommends": False,

--- a/system/t02_config/ConfigShowTest_gold
+++ b/system/t02_config/ConfigShowTest_gold
@@ -3,6 +3,7 @@
     "downloadConcurrency": 4,
     "downloadSpeedLimit": 0,
     "downloadRetries": 5,
+    "databaseOpenAttempts": 10,
     "architectures": [],
     "dependencyFollowSuggests": false,
     "dependencyFollowRecommends": false,

--- a/system/t02_config/CreateConfigTest_gold
+++ b/system/t02_config/CreateConfigTest_gold
@@ -3,6 +3,7 @@
   "downloadConcurrency": 4,
   "downloadSpeedLimit": 0,
   "downloadRetries": 0,
+  "databaseOpenAttempts": -1,
   "architectures": [],
   "dependencyFollowSuggests": false,
   "dependencyFollowRecommends": false,

--- a/system/t02_config/aptly.conf
+++ b/system/t02_config/aptly.conf
@@ -1,6 +1,7 @@
 {
   "rootDir": "/tmp/aptly",
   "downloadConcurrency": 4,
+  "databaseOpenAttempts": 10,
   "architectures": [],
   "dependencyFollowSuggests": false,
   "dependencyFollowRecommends": false,

--- a/utils/config.go
+++ b/utils/config.go
@@ -12,6 +12,7 @@ type ConfigStructure struct { // nolint: maligned
 	DownloadConcurrency    int                              `json:"downloadConcurrency"`
 	DownloadLimit          int64                            `json:"downloadSpeedLimit"`
 	DownloadRetries        int                              `json:"downloadRetries"`
+	DatabaseOpenAttempts   int                              `json:"databaseOpenAttempts"`
 	Architectures          []string                         `json:"architectures"`
 	DepFollowSuggests      bool                             `json:"dependencyFollowSuggests"`
 	DepFollowRecommends    bool                             `json:"dependencyFollowRecommends"`
@@ -76,6 +77,7 @@ var Config = ConfigStructure{
 	RootDir:                filepath.Join(os.Getenv("HOME"), ".aptly"),
 	DownloadConcurrency:    4,
 	DownloadLimit:          0,
+	DatabaseOpenAttempts:   -1,
 	Architectures:          []string{},
 	DepFollowSuggests:      false,
 	DepFollowRecommends:    false,

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -23,6 +23,7 @@ func (s *ConfigSuite) TestLoadConfig(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(s.config.RootDir, Equals, "/opt/aptly/")
 	c.Check(s.config.DownloadConcurrency, Equals, 33)
+	c.Check(s.config.DatabaseOpenAttempts, Equals, 33)
 }
 
 func (s *ConfigSuite) TestSaveConfig(c *C) {
@@ -30,6 +31,7 @@ func (s *ConfigSuite) TestSaveConfig(c *C) {
 
 	s.config.RootDir = "/tmp/aptly"
 	s.config.DownloadConcurrency = 5
+	s.config.DatabaseOpenAttempts = 5
 	s.config.GpgProvider = "gpg"
 
 	s.config.FileSystemPublishRoots = map[string]FileSystemPublishRoot{"test": {
@@ -58,6 +60,7 @@ func (s *ConfigSuite) TestSaveConfig(c *C) {
 		"  \"downloadConcurrency\": 5,\n"+
 		"  \"downloadSpeedLimit\": 0,\n"+
 		"  \"downloadRetries\": 0,\n"+
+		"  \"databaseOpenAttempts\": 5,\n"+
 		"  \"architectures\": null,\n"+
 		"  \"dependencyFollowSuggests\": false,\n"+
 		"  \"dependencyFollowRecommends\": false,\n"+
@@ -115,4 +118,4 @@ func (s *ConfigSuite) TestSaveConfig(c *C) {
 		"}")
 }
 
-const configFile = `{"rootDir": "/opt/aptly/", "downloadConcurrency": 33}`
+const configFile = `{"rootDir": "/opt/aptly/", "downloadConcurrency": 33, "databaseOpenAttempts": 33}`


### PR DESCRIPTION
## Description of the Change

This makes the global command line flag `-db-open-attempts` a configuration option in aptly.conf (as `databaseOpenAttempts`).

We'd rather configure it there instead of adding the flag to every invocation of aptly in our CI/CD setup.

I couldn't test this change thoroughly, but I oriented on how it was done for other, similar flags/options.

Thanks!

## Checklist

- [x] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [x] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [x] documentation updated
- [ ] author name in `AUTHORS`
