### PR TITLE
Bump Go supported version to 1.11-1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,11 @@ matrix:
       env: RUN_LONG_TESTS=no
   fast_finish: true
   include:
-    - go: 1.10.x
-      env: RUN_LONG_TESTS=no
     - go: 1.11.x
-      env: RUN_LONG_TESTS=yes
+      env: RUN_LONG_TESTS=no
     - go: 1.12.x
+      env: RUN_LONG_TESTS=yes
+    - go: 1.13.x
       env:
         - RUN_LONG_TESTS=yes
         - DEPLOY_BINARIES=yes

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ If you would like to use nightly builds (unstable), please use following reposit
 
 Binary executables (depends almost only on libc) are available for download from `GitHub Releases <https://github.com/aptly-dev/aptly/releases>`_.
 
-If you have Go environment set up, you can build aptly from source by running (go 1.10+ required)::
+If you have Go environment set up, you can build aptly from source by running (go 1.11+ required)::
 
     mkdir -p $GOPATH/src/github.com/aptly-dev/aptly
     git clone https://github.com/aptly-dev/aptly $GOPATH/src/github.com/aptly-dev/aptly


### PR DESCRIPTION
This might allow to switch to Go modules as the next step.

