### PR TITLE
Allow GPGFinder to work with nonstandard GPG version strings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,3 +39,4 @@ List of contributors, in chronological order:
 * Nabil Bendafi (https://github.com/nabilbendafi)
 * Raphael Medaer (https://github.com/rmedaer)
 * Raul Benencia (https://github.com/rul)
+* Don Kuntz (https://github.com/dkuntz2)

--- a/pgp/gnupg_finder.go
+++ b/pgp/gnupg_finder.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"os/exec"
 	"regexp"
-	"strings"
 )
 
 // GPGVersion stores discovered GPG version
@@ -52,7 +51,7 @@ func GPG1Finder() GPGFinder {
 	return &pathGPGFinder{
 		gpgNames:                 []string{"gpg", "gpg1"},
 		gpgvNames:                []string{"gpgv", "gpgv1"},
-		expectedVersionSubstring: "(GnuPG) 1.",
+		expectedVersionSubstring: `\(GnuPG.*\) (1).(\d)`,
 		errorMessage:             "Couldn't find a suitable gpg executable. Make sure gnupg1 is available as either gpg(v) or gpg(v)1 in $PATH",
 	}
 }
@@ -62,7 +61,7 @@ func GPG2Finder() GPGFinder {
 	return &pathGPGFinder{
 		gpgNames:                 []string{"gpg", "gpg2"},
 		gpgvNames:                []string{"gpgv", "gpgv2"},
-		expectedVersionSubstring: "(GnuPG) 2.",
+		expectedVersionSubstring: `\(GnuPG.*\) (2).(\d)`,
 		errorMessage:             "Couldn't find a suitable gpg executable. Make sure gnupg2 is available as either gpg(v) or gpg(v)2 in $PATH",
 	}
 }
@@ -134,10 +133,11 @@ func cliVersionCheck(cmd string, marker string) (result bool, version GPGVersion
 	}
 
 	strOutput := string(output)
-	result = strings.Contains(strOutput, marker)
+	regex := regexp.MustCompile(marker)
 
 	version = GPG22xPlus
-	matches := gpgVersionRegex.FindStringSubmatch(strOutput)
+	matches := regex.FindStringSubmatch(strOutput)
+	result = (matches != nil)
 	if matches != nil {
 		if matches[1] == "1" {
 			version = GPG1x

--- a/pgp/gnupg_finder.go
+++ b/pgp/gnupg_finder.go
@@ -17,8 +17,6 @@ const (
 	GPG22xPlus GPGVersion = 4
 )
 
-var gpgVersionRegex = regexp.MustCompile(`\(GnuPG\) (\d)\.(\d)`)
-
 // GPGFinder implement search for gpg executables and returns version of discovered executables
 type GPGFinder interface {
 	FindGPG() (gpg string, version GPGVersion, err error)


### PR DESCRIPTION
## Description of the Change

This changes GPGFinder to allow for nonstandard version strings.

Specifically, I have MacGPG installed instead of upstream GPG, which results in the version string reading `gpg (GnuPG/MacGPG2) 2.2.17` instead of the expected `gpg (GnuPG) 2.2.17`

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [x] author name in `AUTHORS`

----

I'm not sure if the unchecked items are applicable. A unit test could probably be added, though I'm not entirely sure how other than possibly making a mock binary that responds to `--version` with the MacGPG version string and adding it to the test-bins.
