### PR TITLE
workaround to provide focal legacy image installer

### DIFF
--- a/deb/index_files.go
+++ b/deb/index_files.go
@@ -246,7 +246,13 @@ func (files *indexFiles) PackageIndex(component, arch string, udeb, installer bo
 	if arch == ArchitectureSource {
 		udeb = false
 	}
-	key := fmt.Sprintf("pi-%s-%s-%v-%v", component, arch, udeb, installer)
+	var installer_combined bool
+	if legacy_installer || installer {
+		installer_combined = true
+	} else {
+		installer_combined = false
+	}
+	key := fmt.Sprintf("pi-%s-%s-%v-%v", component, arch, udeb, installer_combined)
 	file, ok := files.indexes[key]
 	if !ok {
 		var relativePath string
@@ -268,8 +274,8 @@ func (files *indexFiles) PackageIndex(component, arch string, udeb, installer bo
 		file = &indexFile{
 			parent:        files,
 			discardable:   false,
-			compressable:  !installer,
-			detachedSign:  installer,
+			compressable:  !installer_combined,
+			detachedSign:  installer_combined,
 			clearSign:     false,
 			acquireByHash: files.acquireByHash,
 			relativePath:  relativePath,

--- a/deb/index_files.go
+++ b/deb/index_files.go
@@ -242,7 +242,7 @@ func newIndexFiles(publishedStorage aptly.PublishedStorage, basePath, tempDir, s
 	}
 }
 
-func (files *indexFiles) PackageIndex(component, arch string, udeb, installer bool) *indexFile {
+func (files *indexFiles) PackageIndex(component, arch string, udeb, installer bool, legacy_installer bool) *indexFile {
 	if arch == ArchitectureSource {
 		udeb = false
 	}
@@ -256,6 +256,8 @@ func (files *indexFiles) PackageIndex(component, arch string, udeb, installer bo
 		} else {
 			if udeb {
 				relativePath = filepath.Join(component, "debian-installer", fmt.Sprintf("binary-%s", arch), "Packages")
+			} else if legacy_installer {
+				relativePath = filepath.Join(component, fmt.Sprintf("installer-%s", arch), "current", "legacy-images", "SHA256SUMS")
 			} else if installer {
 				relativePath = filepath.Join(component, fmt.Sprintf("installer-%s", arch), "current", "images", "SHA256SUMS")
 			} else {

--- a/deb/package.go
+++ b/deb/package.go
@@ -188,8 +188,13 @@ func NewInstallerPackageFromControlFile(input Stanza, repo *RemoteRepo, componen
 	if err != nil {
 		return nil, err
 	}
-
-	relPath := filepath.Join("dists", repo.Distribution, component, fmt.Sprintf("%s-%s", p.Name, architecture), "current", "images")
+	var images string
+	if strings.Contains(repo.Distribution, "focal") {
+		images = "legacy-images"
+	} else {
+		images = "images"
+	}
+	relPath := filepath.Join("dists", repo.Distribution, component, fmt.Sprintf("%s-%s", p.Name, architecture), "current", images)
 	for i := range files {
 		files[i].downloadPath = relPath
 

--- a/deb/publish.go
+++ b/deb/publish.go
@@ -583,7 +583,7 @@ func (p *PublishedRepo) Publish(packagePool aptly.PackagePool, publishedStorageP
 
 		// For all architectures, pregenerate packages/sources files
 		for _, arch := range p.Architectures {
-			indexes.PackageIndex(component, arch, false, false)
+			indexes.PackageIndex(component, arch, false, false,false)
 		}
 
 		if progress != nil {
@@ -650,7 +650,11 @@ func (p *PublishedRepo) Publish(packagePool aptly.PackagePool, publishedStorageP
 						}
 					}
 
-					bufWriter, err = indexes.PackageIndex(component, arch, pkg.IsUdeb, pkg.IsInstaller).BufWriter()
+					if pkg.IsInstaller && strings.Contains(p.Distribution, "focal") {
+						bufWriter, err = indexes.PackageIndex(component, arch, pkg.IsUdeb, false, true).BufWriter()
+					} else {
+						bufWriter, err = indexes.PackageIndex(component, arch, pkg.IsUdeb, true, false).BufWriter()
+					}
 					if err != nil {
 						return err
 					}
@@ -708,7 +712,7 @@ func (p *PublishedRepo) Publish(packagePool aptly.PackagePool, publishedStorageP
 
 			// For all architectures, pregenerate .udeb indexes
 			for _, arch := range p.Architectures {
-				indexes.PackageIndex(component, arch, true, false)
+				indexes.PackageIndex(component, arch, true, false, false)
 			}
 		}
 

--- a/deb/remote.go
+++ b/deb/remote.go
@@ -253,7 +253,11 @@ func (repo *RemoteRepo) UdebPath(component string, architecture string) string {
 // InstallerPath returns path of Packages files for given component and
 // architecture
 func (repo *RemoteRepo) InstallerPath(component string, architecture string) string {
-	return fmt.Sprintf("%s/installer-%s/current/images/SHA256SUMS", component, architecture)
+	if strings.Contains(repo.Distribution, "focal") {
+		return fmt.Sprintf("%s/installer-%s/current/legacy-images/SHA256SUMS", component, architecture)
+	} else {
+		return fmt.Sprintf("%s/installer-%s/current/images/SHA256SUMS", component, architecture)
+	}
 }
 
 // PackageURL returns URL of package file relative to repository root

--- a/deb/remote.go
+++ b/deb/remote.go
@@ -253,11 +253,13 @@ func (repo *RemoteRepo) UdebPath(component string, architecture string) string {
 // InstallerPath returns path of Packages files for given component and
 // architecture
 func (repo *RemoteRepo) InstallerPath(component string, architecture string) string {
+	var images string
 	if strings.Contains(repo.Distribution, "focal") {
-		return fmt.Sprintf("%s/installer-%s/current/legacy-images/SHA256SUMS", component, architecture)
+		images = "legacy-images"
 	} else {
-		return fmt.Sprintf("%s/installer-%s/current/images/SHA256SUMS", component, architecture)
+		images = "images"
 	}
+	return fmt.Sprintf("%s/installer-%s/current/%s/SHA256SUMS", component, architecture, images)
 }
 
 // PackageURL returns URL of package file relative to repository root


### PR DESCRIPTION
Fixes #
Focal Repo changed its Installer URL

## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

<!--

aptly is unable to provide focal installer files without this workaround

-->
Issue is described in #922 