### PR TITLE
.goxc.json: list os/arch explicitly to avoid darwin/386

### DIFF
--- a/.goxc.json
+++ b/.goxc.json
@@ -34,8 +34,7 @@
         }
     },
 	"ResourcesInclude": "README.rst,LICENSE,AUTHORS,man/aptly.1",
-	"Arch": "386 amd64",
-	"Os": "linux darwin freebsd",
+	"BuildConstraints": "linux,386 linux,amd64 darwin,amd64 freebsd,386 freebsd,amd64",
 	"MainDirsExclude": "_man,vendor",
 	"BuildSettings": {
 		"LdFlagsXVars": {


### PR DESCRIPTION
## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

Go 1.15 drops support for darwin/386 GOOS/GOARCH pair [1]. So, we have
to skip this pair, and thus cannot use simple os multiply arch anymore.
Switch to goxc's BuildConstraints config, which uses the same syntax as
Go's build constraint header [2].

[1] https://github.com/golang/go/issues/37610
[2] https://golang.org/cmd/go/#hdr-Build_constraints

Fixes #943

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [ ] author name in `AUTHORS`
