### PR TITLE
Fix update mirror7 test

### DIFF
--- a/deb/remote.go
+++ b/deb/remote.go
@@ -33,7 +33,7 @@ const (
 
 // RemoteRepo represents remote (fetchable) Debian repository.
 //
-// Repostitory could be filtered when fetching by components, architectures
+// Repository could be filtered when fetching by components, architectures
 type RemoteRepo struct {
 	// Permanent internal ID
 	UUID string

--- a/system/t04_mirror/UpdateMirror7Test_gold
+++ b/system/t04_mirror/UpdateMirror7Test_gold
@@ -85,5 +85,6 @@ Downloading https://cloud.r-project.org/bin/linux/debian/jessie-cran35/rkward_0.
 Downloading https://cloud.r-project.org/bin/linux/debian/jessie-cran35/rkward_0.6.5-1~jessiecran.0_i386.deb...
 Mirror `flat` has been successfully updated.
 gpgv:                 aka "Johannes Ranke <jranke@uni-bremen.de>"
+gpgv:                using RSA key AD7B5162BA456BE3526F8D92FCAE2A0E115C3D8A
 gpgv: Good signature from "Johannes Ranke (Wissenschaftlicher Berater) <johannes.ranke@jrwb.de>"
-gpgv:  RSA key ID 115C3D8A
+gpgv: Signature made Mon Mar 11 20:45:28 2019 EET


### PR DESCRIPTION
This update was done with `system/run.py --capture UpdateMirror7Test`. I suppose there is other similar failures too, but I’ll look at them after this pull request is OK, so I can apply all necessary changes to them as necessary. So say if there is something I should take in account here.

I was running this test manually, with `system/run.py UpdateMirror7Test`. Since the format has changed, I fear this is related to gpg versions. For the record, I have SUSE 15-SP2, with gpg-2.2.5. I guess Travis manages to pass this test. Does that test pass to others, and which gpg version?

## Checklist

- [ ] unit-test added (if change is algorithm)
- [X] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [ ] author name in `AUTHORS`
