### PR TITLE
Update ParsePrefix to handle prefixes with literal colons

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,3 +40,4 @@ List of contributors, in chronological order:
 * Raphael Medaer (https://github.com/rmedaer)
 * Raul Benencia (https://github.com/rul)
 * Don Kuntz (https://github.com/dkuntz2)
+* Charles Duffy (https://github.com/charles-dyfis-net)

--- a/context/context.go
+++ b/context/context.go
@@ -343,7 +343,7 @@ func (context *AptlyContext) GetPublishedStorage(name string) aptly.PublishedSto
 
 	publishedStorage, ok := context.publishedStorages[name]
 	if !ok {
-		if name == "" {
+		if name == "" || name == "filesystem" {
 			publishedStorage = files.NewPublishedStorage(filepath.Join(context.config().RootDir, "public"), "hardlink", "")
 		} else if strings.HasPrefix(name, "filesystem:") {
 			params, ok := context.config().FileSystemPublishRoots[name[11:]]


### PR DESCRIPTION
Fixes #958

## Requirements

- [X] New unit tests added covering the algorithm change
- [ ] New functional tests added ensuring end-to-end functionality with updated filenames
- [X] No new regressions in the test suite seen (gpg tests broken on my platform, can't get a clean `make test` even with unmodified codebase).

## Description of the Change

Without this, publication locations containing a `:` -- a perfectly legal character in UNIX directory names -- are not possible.

With this change, the following commands work, but did not before:

```
aptly publish snapshot -distribution=test test-releases-1.2.3-qa-final:1.2.3.1 test/releases/1.2.3/qa-final:1.2.3.1
aptly publish snapshot -distribution=test test-releases-1.2.3-qa-final:1.2.3.1 filesystem:test/releases/1.2.3/qa-final:1.2.3.1
aptly publish snapshot -distribution=test test-releases-1.2.3-qa-final:1.2.3.1 filesystem::test/releases/1.2.3/qa-final:1.2.3.1
aptly publish snapshot -distribution=test test-releases-1.2.3-qa-final:1.2.3.1 filesystem:fsname:test/releases/1.2.3/qa-final:1.2.3.1
```

...as do corresponding API calls.

## Checklist

- [X] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [X] author name in `AUTHORS`
