### PR TITLE
Proposed keyserver changed to functional one

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ To install aptly on Debian/Ubuntu, add new repository to ``/etc/apt/sources.list
 
 And import key that is used to sign the release::
 
-    $ apt-key adv --keyserver pool.sks-keyservers.net --recv-keys ED75B5A4483DA07C
+    $ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ED75B5A4483DA07C
 
 After that you can install aptly as any other software package::
 

--- a/pgp/gnupg.go
+++ b/pgp/gnupg.go
@@ -263,7 +263,7 @@ func (g *GpgVerifier) runGpgv(args []string, context string, showKeyTip bool) (*
 				keys[i] = string(result.MissingKeys[i])
 			}
 
-			fmt.Printf("gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver pool.sks-keyservers.net --recv-keys %s\n\n",
+			fmt.Printf("gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver keyserver.ubuntu.com --recv-keys %s\n\n",
 				strings.Join(keys, " "))
 
 			fmt.Printf("Sometimes keys are stored in repository root in file named Release.key, to import such key:\n\n")

--- a/pgp/internal.go
+++ b/pgp/internal.go
@@ -335,7 +335,7 @@ func (g *GoVerifier) showImportKeyTip(signers []signatureResult) {
 			keys = append(keys, string(KeyFromUint64(signer.IssuerKeyID)))
 		}
 
-		fmt.Printf("gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver pool.sks-keyservers.net --recv-keys %s\n\n",
+		fmt.Printf("gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver keyserver.ubuntu.com --recv-keys %s\n\n",
 			strings.Join(keys, " "))
 
 		fmt.Printf("Sometimes keys are stored in repository root in file named Release.key, to import such key:\n\n")


### PR DESCRIPTION
Fixes #990 - the not so much experienced users are confused by cryptic error message

## Requirements

This is only minor change. No extra requrements

## Description of the Change

The current example uses  pool.sks-keyservers.net that is no longer operating. The new one is working well:

```shell
repo@apt:~/bin$ gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver pool.sks-keyservers.net --recv-keys CE1A3DD5E3C94F49
gpg: keyserver receive failed: No name
repo@apt:~/bin$ 
repo@apt:~/bin$ gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver keyserver.ubuntu.com --recv-keys CE1A3DD5E3C94F49
gpg: key CE1A3DD5E3C94F49: public key "MariaDB Enterprise Signing Key <signing-key@mariadb.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
```
