### PR TITLE
fix: Add force-replace to 'repo import' command

### DIFF
--- a/cmd/repo_import.go
+++ b/cmd/repo_import.go
@@ -23,6 +23,7 @@ Example:
 
 	cmd.Flag.Bool("dry-run", false, "don't import, just show what would be imported")
 	cmd.Flag.Bool("with-deps", false, "follow dependencies when processing package-spec")
+	cmd.Flag.Bool("force-replace", false, "when adding package that conflicts with existing package, remove existing package")
 
 	return cmd
 }


### PR DESCRIPTION
Fixes #552

## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change
Add support for the "--force-replace" flag to "repo import"

Why this change is important?
To allow importing repos with duplicate packages

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [ ] author name in `AUTHORS`
