### PR TITLE
Fix the installer path for Ubuntu Focal

### DIFF
--- a/deb/index_files.go
+++ b/deb/index_files.go
@@ -242,7 +242,7 @@ func newIndexFiles(publishedStorage aptly.PublishedStorage, basePath, tempDir, s
 	}
 }
 
-func (files *indexFiles) PackageIndex(component, arch string, udeb, installer bool) *indexFile {
+func (files *indexFiles) PackageIndex(component, arch string, udeb bool, installer bool, distribution string) *indexFile {
 	if arch == ArchitectureSource {
 		udeb = false
 	}
@@ -257,7 +257,11 @@ func (files *indexFiles) PackageIndex(component, arch string, udeb, installer bo
 			if udeb {
 				relativePath = filepath.Join(component, "debian-installer", fmt.Sprintf("binary-%s", arch), "Packages")
 			} else if installer {
-				relativePath = filepath.Join(component, fmt.Sprintf("installer-%s", arch), "current", "images", "SHA256SUMS")
+				if distribution == "focal" {
+					relativePath = filepath.Join(component, fmt.Sprintf("installer-%s", arch), "current", "legacy-images", "SHA256SUMS")
+				} else {
+					relativePath = filepath.Join(component, fmt.Sprintf("installer-%s", arch), "current", "images", "SHA256SUMS")
+				}
 			} else {
 				relativePath = filepath.Join(component, fmt.Sprintf("binary-%s", arch), "Packages")
 			}

--- a/deb/package.go
+++ b/deb/package.go
@@ -189,7 +189,12 @@ func NewInstallerPackageFromControlFile(input Stanza, repo *RemoteRepo, componen
 		return nil, err
 	}
 
-	relPath := filepath.Join("dists", repo.Distribution, component, fmt.Sprintf("%s-%s", p.Name, architecture), "current", "images")
+	var relPath string
+	if repo.Distribution == "focal" {
+		relPath = filepath.Join("dists", repo.Distribution, component, fmt.Sprintf("%s-%s", p.Name, architecture), "current", "legacy-images")
+	} else {
+		relPath = filepath.Join("dists", repo.Distribution, component, fmt.Sprintf("%s-%s", p.Name, architecture), "current", "images")
+	}
 	for i := range files {
 		files[i].downloadPath = relPath
 

--- a/deb/publish.go
+++ b/deb/publish.go
@@ -602,7 +602,7 @@ func (p *PublishedRepo) Publish(packagePool aptly.PackagePool, publishedStorageP
 
 		// For all architectures, pregenerate packages/sources files
 		for _, arch := range p.Architectures {
-			indexes.PackageIndex(component, arch, false, false)
+			indexes.PackageIndex(component, arch, false, false, p.Distribution)
 		}
 
 		list.PrepareIndex()
@@ -626,7 +626,11 @@ func (p *PublishedRepo) Publish(packagePool aptly.PackagePool, publishedStorageP
 						}
 						relPath = filepath.Join("pool", component, poolDir)
 					} else {
-						relPath = filepath.Join("dists", p.Distribution, component, fmt.Sprintf("%s-%s", pkg.Name, arch), "current", "images")
+						if p.Distribution == "focal" {
+							relPath = filepath.Join("dists", p.Distribution, component, fmt.Sprintf("%s-%s", pkg.Name, arch), "current", "legacy-images")
+						} else {
+							relPath = filepath.Join("dists", p.Distribution, component, fmt.Sprintf("%s-%s", pkg.Name, arch), "current", "images")
+						}
 					}
 
 					err = pkg.LinkFromPool(publishedStorage, packagePool, p.Prefix, relPath, forceOverwrite)
@@ -664,7 +668,7 @@ func (p *PublishedRepo) Publish(packagePool aptly.PackagePool, publishedStorageP
 						}
 					}
 
-					bufWriter, err = indexes.PackageIndex(component, arch, pkg.IsUdeb, pkg.IsInstaller).BufWriter()
+					bufWriter, err = indexes.PackageIndex(component, arch, pkg.IsUdeb, pkg.IsInstaller, p.Distribution).BufWriter()
 					if err != nil {
 						return err
 					}
@@ -718,7 +722,7 @@ func (p *PublishedRepo) Publish(packagePool aptly.PackagePool, publishedStorageP
 
 			// For all architectures, pregenerate .udeb indexes
 			for _, arch := range p.Architectures {
-				indexes.PackageIndex(component, arch, true, false)
+				indexes.PackageIndex(component, arch, true, false, p.Distribution)
 			}
 		}
 

--- a/deb/remote.go
+++ b/deb/remote.go
@@ -259,7 +259,11 @@ func (repo *RemoteRepo) UdebPath(component string, architecture string) string {
 // InstallerPath returns path of Packages files for given component and
 // architecture
 func (repo *RemoteRepo) InstallerPath(component string, architecture string) string {
-	return fmt.Sprintf("%s/installer-%s/current/images/SHA256SUMS", component, architecture)
+	if repo.Distribution == "focal" {
+		return fmt.Sprintf("%s/installer-%s/current/legacy-images/SHA256SUMS", component, architecture)
+	} else {
+		return fmt.Sprintf("%s/installer-%s/current/images/SHA256SUMS", component, architecture)
+	}
 }
 
 // PackageURL returns URL of package file relative to repository root


### PR DESCRIPTION
Ubuntu has started depreciating the Debian installer in focal
and moved the installer images to a different path. In versions
after focal, they are completely removed. This basically gives
us more time to figure out how to use the new system.

Fixes #1018

## Requirements

This is the first time I've worked with Go, so I'm not familiar with the test suite. I needed this quick and am contributing back my fixes. I've tested that it properly mirrors the new `legacy-images` properly. You are welcome to ignore it if you would rather do things differently. I just don't have any additional time to contribute.

## Description of the Change

<!--

Why this change is important?

-->

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [ ] author name in `AUTHORS`
