### PR TITLE
Timeout CI build job after 30 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
     name: test
     runs-on: ubuntu-20.04
     continue-on-error: ${{ matrix.allow_failure }}
+    timeout-minutes: 30
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
Fix #1032

Fixes #

## Description of the Change

Add a 30 minutes timeout to CI build test, to avoid runaway tests.
Currently sane unittests run in less than 10 minutes.
