### PR TITLE
Fix/S3 too many object listing

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -44,3 +44,4 @@ List of contributors, in chronological order:
 * Andre Roth (https://github.com/neolynx)
 * Lorenzo Bolla (https://github.com/lbolla)
 * Benj Fassbind (https://github.com/randombenj)
+* Daiki Watanabe (https://github.com/daikw)

--- a/s3/public.go
+++ b/s3/public.go
@@ -297,11 +297,18 @@ func (storage *PublishedStorage) RemoveDirs(path string, progress aptly.Progress
 func (storage *PublishedStorage) LinkFromPool(publishedDirectory, fileName string, sourcePool aptly.PackagePool,
 	sourcePath string, sourceChecksums utils.ChecksumInfo, force bool) error {
 
+	// in: prefix/pool/component/liba/libav/
+	// out: prefix
+	directoryRoot := func(path string) string {
+		return strings.Split(path, "/")[0]
+	}
+
+	prefix := directoryRoot(publishedDirectory)
 	relPath := filepath.Join(publishedDirectory, fileName)
 	poolPath := filepath.Join(storage.prefix, relPath)
 
 	if storage.pathCache == nil {
-		paths, md5s, err := storage.internalFilelist("", true)
+		paths, md5s, err := storage.internalFilelist(prefix, true)
 		if err != nil {
 			return errors.Wrap(err, "error caching paths under prefix")
 		}


### PR DESCRIPTION
## Requirements

- `aptly publish` becomes too slow to execute, if you use S3 as your storage, and your S3 bucket has full of objects.
- This is because `s3.ListObjectsPages` (used in `PublishedStorage#internalFilelist`) without `Prefix` option scans all of object inside the specified bucket.

## Description of the Change

- calculate `prefix` value from `publishedDirectory`
- call `PublishedStorage#internalFilelist` with `prefix` value

## Checklist

- ~[ ] unit-test added (if change is algorithm)~
- ~[ ] functional test added/updated (if change is functional)~
- ~[ ] man page updated (if applicable)~
- ~[ ] bash completion updated (if applicable)~
- ~[ ] documentation updated~
- [x] author name in `AUTHORS`
