### PR TITLE
Adding authorisation options for API access

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -63,3 +63,4 @@ List of contributors, in chronological order:
 * Ramón N.Rodriguez (https://github.com/runitonmetal)
 * Golf Hu (https://github.com/hudeng-go)
 * Cookie Fei (https://github.com/wuhuang26)
+* Brett Hawn (https://github.com/bpiraeus)

--- a/api/auth.go
+++ b/api/auth.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"crypto/tls"
+	"fmt"
+	"strings"
+
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-gonic/gin"
+	"github.com/go-ldap/ldap/v3"
+)
+
+func Authorize(username string, password string) (ok bool) {
+	config := context.Config()
+
+	if config.Auth.Type != "" {
+		switch strings.ToLower(config.Auth.Type) {
+		case "ldap":
+			ok = doLdapAuth(username, password)
+		default:
+			return false
+		}
+		if ok != true {
+			return false
+		}
+	}
+	return true
+}
+
+func doLdapAuth(username string, password string) bool {
+	config := context.Config()
+	attributes := []string{"DN", "CN"}
+
+	server := config.Auth.Server
+	dn := config.Auth.LdapDN
+	filter := fmt.Sprintf(config.Auth.LdapFilter, username)
+
+	// connect to ldap server
+	conn, err := ldap.Dial("tcp", server)
+	if err != nil {
+		return false
+	}
+	defer conn.Close()
+
+	// reconnect via tls
+	err = conn.StartTLS(&tls.Config{InsecureSkipVerify: config.Auth.SecureTLS})
+	if err != nil {
+		return false
+	}
+
+	// format our request and then fire it off
+	request := ldap.NewSearchRequest(dn, ldap.ScopeWholeSubtree, 0, 0, 0, false, filter, attributes, nil)
+	search, err := conn.Search(request)
+	if err != nil {
+		return false
+	}
+	// get our modified dn and then check our user for auth
+	udn := search.Entries[0].DN
+	err = conn.Bind(udn, password)
+	if err != nil {
+		return false
+	}
+	return true
+}
+
+func getGroups(c *gin.Context, username string) {
+
+	var groups []string
+	config := context.Config()
+	dn := fmt.Sprintf("%s", config.Auth.LdapDN)
+	session := sessions.Default(c)
+	// connect to ldap server
+	server := fmt.Sprintf("%s", config.Auth.Server)
+	conn, err := ldap.Dial("tcp", server)
+	if err != nil {
+		return
+	}
+	// reconnect via tls
+	err = conn.StartTLS(&tls.Config{InsecureSkipVerify: true})
+	if err != nil {
+		return
+	}
+	filter := fmt.Sprintf("(|(member=uid=%s,ou=people,dc=llnw,dc=com)(member=uid=%s,ou=people,dc=llnw,dc=com))", username, username)
+	request := ldap.NewSearchRequest(dn, ldap.ScopeWholeSubtree, 0, 0, 0, false, filter, []string{"dn", "cn"}, nil)
+	search, err := conn.Search(request)
+	if err != nil {
+		return
+	}
+	if len(search.Entries) < 1 {
+		return
+	}
+	for _, v := range search.Entries {
+		value := strings.Split(strings.TrimLeft(v.DN, "cn="), ",")[0]
+		groups = append(groups, fmt.Sprintf("%s,", value))
+	}
+	session.Set("Groups", groups)
+	return
+}
+
+func checkGroup(c *gin.Context, ldgroup string) bool {
+	session := sessions.Default(c)
+	groups := session.Get("Groups")
+	if ldgroup == "" {
+		return true
+	}
+	for _, v := range groups.([]string) {
+		if strings.Contains(v, ldgroup) {
+			return true
+		}
+	}
+	return false
+}
+
+func CheckGroup(c *gin.Context, ldgroup string) (err error) {
+	if !checkGroup(c, ldgroup) {
+		err = fmt.Errorf("Authorisation Failred")
+	}
+	return err
+}

--- a/api/auth.go
+++ b/api/auth.go
@@ -20,7 +20,7 @@ func Authorize(username string, password string) (ok bool) {
 		default:
 			return false
 		}
-		if ok != true {
+		if !ok  {
 			return false
 		}
 	}
@@ -67,7 +67,7 @@ func getGroups(c *gin.Context, username string) {
 
 	var groups []string
 	config := context.Config()
-	dn := fmt.Sprintf("%s", config.Auth.LdapDN)
+	dn := config.Auth.LdapDN
 	session := sessions.Default(c)
 	// connect to ldap server
 	server := fmt.Sprintf("%s", config.Auth.Server)
@@ -94,7 +94,6 @@ func getGroups(c *gin.Context, username string) {
 		groups = append(groups, fmt.Sprintf("%s,", value))
 	}
 	session.Set("Groups", groups)
-	return
 }
 
 func checkGroup(c *gin.Context, ldgroup string) bool {

--- a/api/publish.go
+++ b/api/publish.go
@@ -169,6 +169,11 @@ func apiPublishRepoOrSnapshot(c *gin.Context) {
 				return
 			}
 
+			err = CheckGroup(c, localRepo.LdapGroup)
+			if err != nil {
+				c.AbortWithError(403, err)
+			}
+
 			resources = append(resources, string(localRepo.Key()))
 			err = localCollection.LoadComplete(localRepo)
 			if err != nil {

--- a/api/repos.go
+++ b/api/repos.go
@@ -87,6 +87,7 @@ func apiReposCreate(c *gin.Context) {
 		Comment             string
 		DefaultDistribution string
 		DefaultComponent    string
+		LdapGroup           string
 	}
 
 	if c.Bind(&b) != nil {
@@ -96,6 +97,7 @@ func apiReposCreate(c *gin.Context) {
 	repo := deb.NewLocalRepo(b.Name, b.Comment)
 	repo.DefaultComponent = b.DefaultComponent
 	repo.DefaultDistribution = b.DefaultDistribution
+	repo.LdapGroup = b.LdapGroup
 
 	collectionFactory := context.NewCollectionFactory()
 	collection := collectionFactory.LocalRepoCollection()
@@ -115,6 +117,7 @@ func apiReposEdit(c *gin.Context) {
 		Comment             *string
 		DefaultDistribution *string
 		DefaultComponent    *string
+		LdapGroup           *string
 	}
 
 	if c.Bind(&b) != nil {
@@ -127,6 +130,12 @@ func apiReposEdit(c *gin.Context) {
 	repo, err := collection.ByName(c.Params.ByName("name"))
 	if err != nil {
 		AbortWithJSONError(c, 404, err)
+		return
+	}
+
+	err = CheckGroup(c, repo.LdapGroup)
+	if err != nil {
+		c.AbortWithError(403, err)
 		return
 	}
 
@@ -147,6 +156,9 @@ func apiReposEdit(c *gin.Context) {
 	}
 	if b.DefaultComponent != nil {
 		repo.DefaultComponent = *b.DefaultComponent
+	}
+	if b.LdapGroup != nil {
+		repo.LdapGroup = *b.LdapGroup
 	}
 
 	err = collection.Update(repo)
@@ -193,6 +205,12 @@ func apiReposDrop(c *gin.Context) {
 	repo, err := collection.ByName(name)
 	if err != nil {
 		AbortWithJSONError(c, 404, err)
+		return
+	}
+
+	err = CheckGroup(c, repo.LdapGroup)
+	if err != nil {
+		c.AbortWithError(403, err)
 		return
 	}
 
@@ -257,6 +275,12 @@ func apiReposPackagesAddDelete(c *gin.Context, taskNamePrefix string, cb func(li
 	err = collection.LoadComplete(repo)
 	if err != nil {
 		AbortWithJSONError(c, 500, err)
+		return
+	}
+
+	err = CheckGroup(c, repo.LdapGroup)
+	if err != nil {
+		c.AbortWithError(403, err)
 		return
 	}
 
@@ -363,6 +387,12 @@ func apiReposPackageFromDir(c *gin.Context) {
 	err = collection.LoadComplete(repo)
 	if err != nil {
 		AbortWithJSONError(c, 500, err)
+		return
+	}
+
+	err = CheckGroup(c, repo.LdapGroup)
+	if err != nil {
+		c.AbortWithError(403, err)
 		return
 	}
 
@@ -649,6 +679,11 @@ func apiReposIncludePackageFromDir(c *gin.Context) {
 		repo, err := collectionFactory.LocalRepoCollection().ByName(repoTemplateString)
 		if err != nil {
 			AbortWithJSONError(c, 404, err)
+			return
+		}
+		err = CheckGroup(c, repo.LdapGroup)
+		if err != nil {
+			c.AbortWithError(403, err)
 			return
 		}
 

--- a/api/snapshot.go
+++ b/api/snapshot.go
@@ -200,6 +200,12 @@ func apiSnapshotsCreateFromRepository(c *gin.Context) {
 		return
 	}
 
+	err = CheckGroup(c, repo.LdapGroup)
+	if err != nil {
+		c.AbortWithError(403, err)
+		return
+	}
+
 	// including snapshot resource key
 	resources := []string{string(repo.Key()), "S" + b.Name}
 	taskName := fmt.Sprintf("Create snapshot of repo %s", name)

--- a/cmd/repo_create.go
+++ b/cmd/repo_create.go
@@ -18,6 +18,7 @@ func aptlyRepoCreate(cmd *commander.Command, args []string) error {
 	repo := deb.NewLocalRepo(args[0], context.Flags().Lookup("comment").Value.String())
 	repo.DefaultDistribution = context.Flags().Lookup("distribution").Value.String()
 	repo.DefaultComponent = context.Flags().Lookup("component").Value.String()
+	repo.LdapGroup = context.Flags().Lookup("ldap-group").Value.String()
 
 	uploadersFile := context.Flags().Lookup("uploaders-file").Value.Get().(string)
 	if uploadersFile != "" {
@@ -79,6 +80,7 @@ Example:
 	cmd.Flag.String("distribution", "", "default distribution when publishing")
 	cmd.Flag.String("component", "main", "default component when publishing")
 	cmd.Flag.String("uploaders-file", "", "uploaders.json to be used when including .changes into this repository")
+	cmd.Flag.String("ldap-group", "", "ldap group that owns the repo, leave empty to allow ALL")
 
 	return cmd
 }

--- a/cmd/repo_edit.go
+++ b/cmd/repo_edit.go
@@ -39,6 +39,8 @@ func aptlyRepoEdit(cmd *commander.Command, args []string) error {
 			repo.DefaultComponent = flag.Value.String()
 		case "uploaders-file":
 			uploadersFile = pointer.ToString(flag.Value.String())
+		case "ldap-group":
+			repo.LdapGroup = flag.Value.String()
 		}
 	})
 
@@ -82,6 +84,7 @@ Example:
 	cmd.Flag.String("distribution", "", "default distribution when publishing")
 	cmd.Flag.String("component", "", "default component when publishing")
 	cmd.Flag.String("uploaders-file", "", "uploaders.json to be used when including .changes into this repository")
+	cmd.Flag.String("ldap-group", "", "ldap group that owns the repo, leave empty to allow ALL")
 
 	return cmd
 }

--- a/cmd/repo_show.go
+++ b/cmd/repo_show.go
@@ -45,6 +45,7 @@ func aptlyRepoShowTxt(_ *commander.Command, args []string) error {
 	fmt.Printf("Comment: %s\n", repo.Comment)
 	fmt.Printf("Default Distribution: %s\n", repo.DefaultDistribution)
 	fmt.Printf("Default Component: %s\n", repo.DefaultComponent)
+	fmt.Printf("Ldap Group: %s\n", repo.LdapGroup)
 	if repo.Uploaders != nil {
 		fmt.Printf("Uploaders: %s\n", repo.Uploaders)
 	}

--- a/completion.d/_aptly
+++ b/completion.d/_aptly
@@ -242,6 +242,7 @@ local keyring="*-keyring=[gpg keyring to use when verifying Release file (could 
                 local create_edit=("-comment=[any text that would be used to described local repository]:comment: "
                             "-component=[default component when publishing]:component:($components)"
                             "-distribution=[default distribution when publishing]:distribution:($dists)"
+                            "-ldap-group=[ldap group for repo actions, empty by default]:ldap-group"
                             $aptly_uploaders
                             )
 

--- a/deb/local.go
+++ b/deb/local.go
@@ -27,6 +27,8 @@ type LocalRepo struct {
 	Uploaders *Uploaders `codec:"Uploaders,omitempty" json:"-"`
 	// "Snapshot" of current list of packages
 	packageRefs *PackageRefList
+	// ldap group for repos
+	LdapGroup string `codec:",ldap-group"`
 }
 
 // NewLocalRepo creates new instance of Debian local repository
@@ -52,6 +54,14 @@ func (repo *LocalRepo) NumPackages() int {
 		return 0
 	}
 	return repo.packageRefs.Len()
+}
+
+// LdapGroup returns the ldapgroup if any for the repo
+func (repo *LocalRepo) GetLDGroup() string {
+	if repo.LdapGroup != "" {
+		return fmt.Sprintf("[%s]", repo.LdapGroup)
+	}
+	return ""
 }
 
 // RefList returns package list for repo

--- a/man/aptly.1.ronn.tmpl
+++ b/man/aptly.1.ronn.tmpl
@@ -113,7 +113,14 @@ Configuration file is stored in JSON format (default values shown below):
           "prefix": "",
           "endpoint": ""
         }
-      }
+      },
+      "Auth": {
+        "authType: "",
+        "server\": "",
+        "ldapDN\": "",
+        "ldapFilter": "",
+        "secureTLS": false
+       }
     }
 
 Options:
@@ -207,6 +214,9 @@ Options:
   * `AzurePublishEndpoints`:
     configuration of Azure publishing endpoints (see below)
 
+  * `Auth`:
+    configuration of authorization for repos, only supports ldap at this time (see below)
+
 ## CUSTOM PACKAGE POOLS
 
 aptly defaults to storing downloaded packages at `rootDir/`pool. In order to
@@ -219,6 +229,7 @@ two values:
   * `azure`: Store the package pool in an Azure Blob Storage container. Any
     keys in the below section on Azure publishing may be set on the
     `packagePoolStorage` object in order to configure the Azure connection.
+
 
 ## FILESYSTEM PUBLISHING ENDPOINTS
 
@@ -347,6 +358,26 @@ configuration file. Each endpoint has its name and associated settings:
     endpoint URL to connect to, as described in
     [the Azure documentation](https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string);
     defaults to `https://$accountName.blob.core.windows.net`
+
+## AUTH ENDPOINTS
+
+Authorization for repos may be configured for ldap groups (and is extensible for others),
+default is no authorization.
+
+   * `authType`:
+     auth type, only supports ldap currently
+
+   * `server`:
+     auth server to use (eg. ldaps://ldap.example.com)
+
+   * `ldapDN`:
+     DN for ldap searches
+
+   * `ldapFilter:
+     ldap filter
+
+   * `secureTLS`:
+     enable secureTLS, default is off
 
 ## PACKAGE QUERY
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -11,6 +11,8 @@ import (
 // ConfigStructure is structure of main configuration
 type ConfigStructure struct { // nolint: maligned
 	RootDir                string                           `json:"rootDir"`
+	LogFile                string                           `json:"logFile"`
+	UseAuth                bool                             `json:"useAuth"`
 	DownloadConcurrency    int                              `json:"downloadConcurrency"`
 	DownloadLimit          int64                            `json:"downloadSpeedLimit"`
 	DownloadRetries        int                              `json:"downloadRetries"`
@@ -43,6 +45,7 @@ type ConfigStructure struct { // nolint: maligned
 	ServeInAPIMode         bool                             `json:"serveInAPIMode"`
 	DatabaseBackend        DBConfig                         `json:"databaseBackend"`
 	EnableSwaggerEndpoint  bool                             `json:"enableSwaggerEndpoint"`
+	Auth                   AAuth                            `json:"Auth"`
 }
 
 // DBConfig
@@ -150,9 +153,19 @@ type AzureEndpoint struct {
 	Endpoint    string `json:"endpoint"`
 }
 
+type AAuth struct {
+	Type       string `json:"authType"`
+	Server     string `json:"server"`
+	LdapDN     string `json:"ldapDN"`
+	LdapFilter string `json:"ldapFilter"`
+	SecureTLS  bool   `json:"secureTLS"`
+}
+
 // Config is configuration for aptly, shared by all modules
 var Config = ConfigStructure{
 	RootDir:                filepath.Join(os.Getenv("HOME"), ".aptly"),
+	LogFile:                "",
+	UseAuth:                false, // should we enable auth
 	DownloadConcurrency:    4,
 	DownloadLimit:          0,
 	Downloader:             "default",
@@ -182,6 +195,7 @@ var Config = ConfigStructure{
 	LogFormat:              "default",
 	ServeInAPIMode:         false,
 	EnableSwaggerEndpoint:  false,
+	Auth:                   AAuth{},
 }
 
 // LoadConfig loads configuration from json file

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -65,6 +65,8 @@ func (s *ConfigSuite) TestSaveConfig(c *C) {
 	c.Check(string(buf), Equals, ""+
 		"{\n"+
 		"  \"rootDir\": \"/tmp/aptly\",\n"+
+		"  \"logFile\": \"\",\n"+
+		"  \"useAuth\": false,\n"+
 		"  \"downloadConcurrency\": 5,\n"+
 		"  \"downloadSpeedLimit\": 0,\n"+
 		"  \"downloadRetries\": 0,\n"+
@@ -149,7 +151,14 @@ func (s *ConfigSuite) TestSaveConfig(c *C) {
 		"    \"url\": \"\",\n"+
                 "    \"dbPath\": \"\"\n" +
 		"  },\n"+
-                "  \"enableSwaggerEndpoint\": false\n" +
+                "  \"enableSwaggerEndpoint\": false,\n" +
+		"  \"Auth\": {\n"+
+		"    \"authType\": \"\",\n"+
+		"    \"server\": \"\",\n"+
+		"    \"ldapDN\": \"\",\n"+
+		"    \"ldapFilter\": \"\",\n"+
+		"    \"secureTLS\": false\n"+
+		"  }\n"+
 		"}")
 }
 


### PR DESCRIPTION
Fixes #

## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

<!--

Adds authorisation options into aptly for the API and local repositories, currently only ldap auth is available however it is designed to accept other methods without a lot of additional work.

allows for per-repository ldap group authorisation ensuring only those in the correct group may muddle with the repo.

-->

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [ ] author name in `AUTHORS`
