### PR TITLE
Update the gpg key of the `repo.aptly.info` repository in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ To install aptly on Debian/Ubuntu, add new repository to ``/etc/apt/sources.list
 
 And import key that is used to sign the release::
 
-    $ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ED75B5A4483DA07C
+    $ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EE727D4449467F0E
 
 After that you can install aptly as any other software package::
 


### PR DESCRIPTION
## Fixes

Using the gpg key in the README:

```shell
Err:1 http://repo.aptly.info squeeze InRelease                                                         
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY EE727D4449467F0E
```


## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

The actual repo uses different gpg key. Either the repo has been taken over, or the README is out of date.

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [x] documentation updated
- [ ] author name in `AUTHORS`
