### PR TITLE
Publish releases and nightly builds from ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,22 @@ jobs:
         run: |
           make release
 
+      - name: Publish nightly release to aptly
+        if: github.ref == 'refs/heads/master'
+        env:
+          APTLY_USER: ${{ secrets.APTLY_USER }}
+          APTLY_PASSWORD: ${{ secrets.APTLY_PASSWORD }}
+        run: |
+          bash upload-artefacts.sh nightly
+
+      - name: Publish release to aptly
+        if: startsWith(github.event.ref, 'refs/tags')
+        env:
+          APTLY_USER: ${{ secrets.APTLY_USER }}
+          APTLY_PASSWORD: ${{ secrets.APTLY_PASSWORD }}
+        run: |
+          bash upload-artefacts.sh release
+
       - name: Upload artifacts to GitHub Release
         if: startsWith(github.event.ref, 'refs/tags')
         uses: softprops/action-gh-release@v1

--- a/upload-artifacts.sh
+++ b/upload-artifacts.sh
@@ -7,7 +7,7 @@ packages=${builds}*.deb
 folder=`mktemp -u tmp.XXXXXXXXXXXXXXX`
 aptly_user="$APTLY_USER"
 aptly_password="$APTLY_PASSWORD"
-aptly_api="https://internal.aptly.info"
+aptly_api="https://aptly-ops.aptly.info"
 version=`make version`
 
 for file in $packages; do


### PR DESCRIPTION
## Description of the Change

#920 

We moved the whole aptly infrastructure to our own infrastructure and moved `internal.aptly.info` to `aptly-ops.aptly.info`
so we can publish new releases there. :tada: 

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [ ] author name in `AUTHORS`
