### PR TITLE
Support custom Azure publish endpoint

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -45,3 +45,4 @@ List of contributors, in chronological order:
 * Lorenzo Bolla (https://github.com/lbolla)
 * Benj Fassbind (https://github.com/randombenj)
 * Markus Muellner (https://github.com/mmianl)
+* Chuan Liu (https://github.com/chuan)

--- a/azure/public_test.go
+++ b/azure/public_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 type PublishedStorageSuite struct {
-	accountName, accountKey  string
-	storage, prefixedStorage *PublishedStorage
+	accountName, accountKey, endpoint string
+	storage, prefixedStorage          *PublishedStorage
 }
 
 var _ = Suite(&PublishedStorageSuite{})
@@ -55,6 +55,7 @@ func (s *PublishedStorageSuite) SetUpSuite(c *C) {
 		println("  2. AZURE_STORAGE_ACCESS_KEY")
 		c.Skip("AZURE_STORAGE_ACCESS_KEY not set.")
 	}
+	s.endpoint = os.Getenv("AZURE_STORAGE_ENDPOINT")
 }
 
 func (s *PublishedStorageSuite) SetUpTest(c *C) {
@@ -63,13 +64,13 @@ func (s *PublishedStorageSuite) SetUpTest(c *C) {
 
 	var err error
 
-	s.storage, err = NewPublishedStorage(s.accountName, s.accountKey, container, "")
+	s.storage, err = NewPublishedStorage(s.accountName, s.accountKey, container, "", s.endpoint)
 	c.Assert(err, IsNil)
 	cnt := s.storage.container
 	_, err = cnt.Create(context.Background(), azblob.Metadata{}, azblob.PublicAccessContainer)
 	c.Assert(err, IsNil)
 
-	s.prefixedStorage, err = NewPublishedStorage(s.accountName, s.accountKey, container, prefix)
+	s.prefixedStorage, err = NewPublishedStorage(s.accountName, s.accountKey, container, prefix, s.endpoint)
 	c.Assert(err, IsNil)
 }
 
@@ -249,7 +250,7 @@ func (s *PublishedStorageSuite) TestRemoveDirsPlus(c *C) {
 
 	list, err := s.storage.Filelist("")
 	c.Check(err, IsNil)
-	c.Check(list, DeepEquals, []string{"a", "b", "c",  "lala/a b", "lala/a+b", "lala/c", "testa"})
+	c.Check(list, DeepEquals, []string{"a", "b", "c", "lala/a b", "lala/a+b", "lala/c", "testa"})
 }
 
 func (s *PublishedStorageSuite) TestRenameFile(c *C) {
@@ -354,7 +355,7 @@ func (s *PublishedStorageSuite) TestSymLink(c *C) {
 	c.Check(err, IsNil)
 	c.Check(link, Equals, "a/b")
 
-	c.Skip("copy not available in s3test")
+	c.Skip("copy not available in azure test")
 }
 
 func (s *PublishedStorageSuite) TestFileExists(c *C) {

--- a/context/context.go
+++ b/context/context.go
@@ -417,7 +417,7 @@ func (context *AptlyContext) GetPublishedStorage(name string) aptly.PublishedSto
 
 			var err error
 			publishedStorage, err = azure.NewPublishedStorage(
-				params.AccountName, params.AccountKey, params.Container, params.Prefix)
+				params.AccountName, params.AccountKey, params.Container, params.Prefix, params.Endpoint)
 			if err != nil {
 				Fatal(err)
 			}

--- a/man/aptly.1
+++ b/man/aptly.1
@@ -104,6 +104,7 @@ Configuration file is stored in JSON format (default values shown below):
       "accountKey": "",
       "container": "repo",
       "prefix": ""
+      "endpoint": "blob.core.windows.net"
     }
   }
 }

--- a/man/aptly.1.ronn.tmpl
+++ b/man/aptly.1.ronn.tmpl
@@ -96,6 +96,7 @@ Configuration file is stored in JSON format (default values shown below):
           "accountKey": "",
           "container": "repo",
           "prefix": ""
+          "endpoint": "blob.core.windows.net"
         }
       }
     }

--- a/utils/config.go
+++ b/utils/config.go
@@ -82,6 +82,7 @@ type AzurePublishRoot struct {
 	AccountKey  string `json:"accountKey"`
 	Container   string `json:"container"`
 	Prefix      string `json:"prefix"`
+	Endpoint    string `json:"endpoint"`
 }
 
 // Config is configuration for aptly, shared by all modules

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -124,7 +124,8 @@ func (s *ConfigSuite) TestSaveConfig(c *C) {
 		"      \"accountName\": \"\",\n"+
 		"      \"accountKey\": \"\",\n"+
 		"      \"container\": \"repo\",\n"+
-		"      \"prefix\": \"\"\n"+
+		"      \"prefix\": \"\",\n"+
+		"      \"endpoint\": \"\"\n"+
 		"    }\n"+
 		"  },\n"+
 		"  \"AsyncAPI\": false,\n"+


### PR DESCRIPTION
## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

Add custom endpoint config for publishing to Azure blob storage. This is needed to support publishing to Azure sovereign clouds, i.e. China, Germany, and the US government. The change also made it possible to test the Azure publishing via [the Azure storage emulator](https://github.com/Azure/Azurite) by setting the endpoint to the local emulator address.

## Checklist

- [x] unit-test added (if change is algorithm)
- ~~[ ] functional test added/updated (if change is functional)~~
- [x] man page updated (if applicable)
- ~~[ ] bash completion updated (if applicable)~~
- [x] documentation updated
- [x] author name in `AUTHORS`
