### PR TITLE
Give info when unable to load list of repos

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -46,3 +46,4 @@ List of contributors, in chronological order:
 * Benj Fassbind (https://github.com/randombenj)
 * Markus Muellner (https://github.com/mmianl)
 * Chuan Liu (https://github.com/chuan)
+* Samuel Mutel (https://github.com/smutel)

--- a/cmd/publish_list.go
+++ b/cmd/publish_list.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 
 	"github.com/aptly-dev/aptly/deb"
@@ -35,6 +36,8 @@ func aptlyPublishListTxt(cmd *commander.Command, args []string) error {
 	err = collectionFactory.PublishedRepoCollection().ForEach(func(repo *deb.PublishedRepo) error {
 		e := collectionFactory.PublishedRepoCollection().LoadComplete(repo, collectionFactory)
 		if e != nil {
+			fmt.Fprintf(os.Stderr, "Error found on one publish (prefix:%s / distribution:%s / component:%s\n)",
+				repo.StoragePrefix(), repo.Distribution, repo.Components())
 			return e
 		}
 
@@ -82,6 +85,8 @@ func aptlyPublishListJSON(cmd *commander.Command, args []string) error {
 	err = context.NewCollectionFactory().PublishedRepoCollection().ForEach(func(repo *deb.PublishedRepo) error {
 		e := context.NewCollectionFactory().PublishedRepoCollection().LoadComplete(repo, context.NewCollectionFactory())
 		if e != nil {
+			fmt.Fprintf(os.Stderr, "Error found on one publish (prefix:%s / distribution:%s / component:%s\n)",
+				repo.StoragePrefix(), repo.Distribution, repo.Components())
 			return e
 		}
 


### PR DESCRIPTION
This PR is a workaround for #428.

## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

The idea is to have information about publish which is in trouble and to be able to drop it and to re-publish it.

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [X] author name in `AUTHORS`
