### PR TITLE
Use correct version compare

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -47,3 +47,4 @@ List of contributors, in chronological order:
 * Markus Muellner (https://github.com/mmianl)
 * Chuan Liu (https://github.com/chuan)
 * Samuel Mutel (https://github.com/smutel)
+* Russell Greene (https://github.com/russelltg)

--- a/deb/query.go
+++ b/deb/query.go
@@ -168,15 +168,15 @@ func (q *FieldQuery) Matches(pkg PackageLike) bool {
 	case VersionDontCare:
 		return field != ""
 	case VersionEqual:
-		return field == q.Value
+		return CompareVersions(field, q.Value) == 0
 	case VersionGreater:
-		return field > q.Value
+		return CompareVersions(field, q.Value) > 0
 	case VersionGreaterOrEqual:
-		return field >= q.Value
+		return CompareVersions(field, q.Value) >= 0
 	case VersionLess:
-		return field < q.Value
+		return CompareVersions(field, q.Value) < 0
 	case VersionLessOrEqual:
-		return field <= q.Value
+		return CompareVersions(field, q.Value) <= 0
 	case VersionPatternMatch:
 		matched, err := filepath.Match(q.Value, field)
 		return err == nil && matched

--- a/deb/query_test.go
+++ b/deb/query_test.go
@@ -1,0 +1,23 @@
+package deb
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+type QuerySuite struct {
+}
+
+var _ = Suite(&QuerySuite{})
+
+func (s *QuerySuite) TestVersionCompare(c *C) {
+	q := FieldQuery{"Version", VersionLess, "5.0.0.2", nil}
+
+	p100 := Package{}
+	p100.Version = "5.0.0.100"
+
+	p1 := Package{}
+	p1.Version = "5.0.0.1"
+
+	c.Check(q.Matches(&p100), Equals, false)
+	c.Check(q.Matches(&p1), Equals, true)
+}

--- a/deb/version_test.go
+++ b/deb/version_test.go
@@ -98,6 +98,8 @@ func (s *VersionSuite) TestCompareVersions(c *C) {
 
 	c.Check(CompareVersions("1.0-133-avc", "1.1"), Equals, -1)
 	c.Check(CompareVersions("1.0-133-avc", "1.0"), Equals, 1)
+
+	c.Check(CompareVersions("5.2.0.3", "5.2.0.283"), Equals, -1)
 }
 
 func (s *VersionSuite) TestParseDependency(c *C) {


### PR DESCRIPTION
Reopen of https://github.com/aptly-dev/aptly/pull/1065 after messed up rebase.
@russelltg sorry about that but please use `git pull --rebase` in the future to avoid having strange merge commits in the history ;)

