### PR TITLE
Enable Azure publish unit tests in Github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,10 @@ jobs:
           pip install -U pip setuptools
           pip install -r system/requirements.txt
 
+      - name: Install Azurite
+        id: azuright
+        uses: potatoqualitee/azuright@v1.1
+
       - name: Get aptly version
         run: |
            make version
@@ -83,6 +87,9 @@ jobs:
       - name: Make
         env:
           RUN_LONG_TESTS: ${{ matrix.run_long_tests }}
+          AZURE_STORAGE_ENDPOINT: "127.0.0.1:10000"
+          AZURE_STORAGE_ACCOUNT: "devstoreaccount1"
+          AZURE_STORAGE_ACCESS_KEY: "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
         run: |
           make
 


### PR DESCRIPTION
## Description of the Change

Enable Azure publishing unit tests in Github actions using Azure storage emulator (https://github.com/Azure/Azurite). 

## Why is this change important?

Ensure Azure publish APIs are tested in CI jobs.

Including Azurite in CI also enables adding system tests for Azure publishing functionalities in the future. Since there are already some issues (e.g., https://github.com/aptly-dev/aptly/issues/1060) reported on the Azure publish command, I plan to add system tests to cover common usages.

