### PR TITLE
Fix azurite dir for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
       - name: Install Azurite
         id: azuright
         uses: potatoqualitee/azuright@v1.1
+        with:
+          directory: ${{ runner.temp }}
 
       - name: Get aptly version
         run: |


### PR DESCRIPTION
## Description of the Change

By default Azurite action runs under `/tmp`. The directory is not stable between jobs. (I saw files under `/tmp` being cleared between jobs.) This has caused CI job failures in recent pull requests that added Azure system test, e.g. https://github.com/aptly-dev/aptly/actions/runs/2352295323. This change fixes the issue by setting the Azurite running directory to the runner temp directory.



