### PR TITLE
api: allow parameters with urlencoded names

### DIFF
--- a/api/router.go
+++ b/api/router.go
@@ -21,6 +21,7 @@ func Router(c *ctx.AptlyContext) http.Handler {
 	context = c
 
 	router := gin.Default()
+	router.UseRawPath = true
 	router.Use(gin.ErrorLogger())
 
 	if c.Config().EnableMetricsEndpoint {


### PR DESCRIPTION
Aptly allows create e.g. repos with a / to use those with the REST api
the router needs to allow urlencoded parameters in various places to
represent this. A specific example of this is the /api/repos/:name/packages path

Signed-off-by: Sjoerd Simons <sjoerd@collabora.com>