### PR TITLE
Cope with zero-length http downloads w/o Content-Length header

### DIFF
--- a/http/download.go
+++ b/http/download.go
@@ -111,6 +111,10 @@ func (downloader *downloaderImpl) GetLength(ctx context.Context, url string) (in
 	}
 
 	if resp.ContentLength < 0 {
+		// an existing, but zero-length file can be reported with ContentLength -1
+		if resp.StatusCode == 200 && resp.ContentLength == -1 {
+			return 0, nil
+		}
 		return -1, fmt.Errorf("could not determine length of %s", url)
 	}
 


### PR DESCRIPTION
Fixes #999

## Description of the Change

Cope with web servers responding with HTTP Code 200 but no Content-Length header for zero-length files.