### PR TITLE
S3: support disabling ACL with `none` value

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -48,3 +48,4 @@ List of contributors, in chronological order:
 * Chuan Liu (https://github.com/chuan)
 * Samuel Mutel (https://github.com/smutel)
 * Russell Greene (https://github.com/russelltg)
+* Wade Simmons (https://github.com/wadey)

--- a/man/aptly.1
+++ b/man/aptly.1
@@ -238,7 +238,7 @@ bucket name
 .
 .TP
 \fBacl\fR
-(optional) assign ACL to published files (one of the canned ACLs in Amazon terminology)\. Useful values: \fBprivate\fR (default) or \fBpublic\-read\fR (public repository)\. Public repositories could be consumed by \fBapt\fR using HTTP endpoint (Amazon bucket should be configured for "website hosting"), for private repositories special apt S3 transport is required\.
+(optional) assign ACL to published files (one of the canned ACLs in Amazon terminology)\. Useful values: \fBprivate\fR (default), \fBpublic\-read\fR (public repository) or \fBnone\fR (don\(cqt set ACL)\. Public repositories could be consumed by \fBapt\fR using HTTP endpoint (Amazon bucket should be configured for "website hosting"), for private repositories special apt S3 transport is required\.
 .
 .TP
 \fBawsAccessKeyID\fR, \fBawsSecretAccessKey\fR

--- a/man/aptly.1.ronn.tmpl
+++ b/man/aptly.1.ronn.tmpl
@@ -223,8 +223,8 @@ and associated settings:
      no prefix (bucket root)
    * `acl`:
      (optional) assign ACL to published files (one of the canned ACLs in Amazon
-     terminology). Useful values: `private` (default) or `public-read` (public
-     repository). Public repositories could be consumed by `apt` using
+     terminology). Useful values: `private` (default), `public-read` (public
+     repository) or `none` (don't set ACL). Public repositories could be consumed by `apt` using
      HTTP endpoint (Amazon bucket should be configured for "website hosting"),
      for private repositories special apt S3 transport is required.
    * `awsAccessKeyID`, `awsSecretAccessKey`:

--- a/s3/public.go
+++ b/s3/public.go
@@ -49,6 +49,8 @@ func NewPublishedStorageRaw(
 ) (*PublishedStorage, error) {
 	if defaultACL == "" {
 		defaultACL = "private"
+	} else if defaultACL == "none" {
+		defaultACL = ""
 	}
 
 	if storageClass == "STANDARD" {


### PR DESCRIPTION
This change lets you disable ACL when using S3 by using a configuration
value of `none`. This way we maintain backward compatibility with the
default setting being `private`.

Fixes: #1067

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [X] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [X] author name in `AUTHORS`
