### PR TITLE
RFC: Allow '/' in distribution name

### DIFF
--- a/deb/publish.go
+++ b/deb/publish.go
@@ -197,9 +197,6 @@ func NewPublishedRepo(storage, prefix, distribution string, architectures []stri
 		if distribution == "" || component == "" {
 			rootDistributions, rootComponents := walkUpTree(source, collectionFactory)
 			if distribution == "" {
-				for i := range rootDistributions {
-					rootDistributions[i] = strings.Replace(rootDistributions[i], "/", "-", -1)
-				}
 				discoveredDistributions = append(discoveredDistributions, rootDistributions...)
 			}
 			if component == "" {
@@ -262,10 +259,6 @@ func NewPublishedRepo(storage, prefix, distribution string, architectures []stri
 		} else {
 			return nil, fmt.Errorf("unable to guess distribution name, please specify explicitly")
 		}
-	}
-
-	if strings.Contains(distribution, "/") {
-		return nil, fmt.Errorf("invalid distribution %s, '/' is not allowed", distribution)
 	}
 
 	result.Distribution = distribution

--- a/deb/publish_test.go
+++ b/deb/publish_test.go
@@ -187,9 +187,6 @@ func (s *PublishedRepoSuite) TestNewPublishedRepo(c *C) {
 
 	_, err := NewPublishedRepo("", ".", "a", nil, []string{"main", "main"}, []interface{}{s.snapshot, s.snapshot2}, s.factory)
 	c.Check(err, ErrorMatches, "duplicate component name: main")
-
-	_, err = NewPublishedRepo("", ".", "wheezy/updates", nil, []string{"main"}, []interface{}{s.snapshot}, s.factory)
-	c.Check(err, ErrorMatches, "invalid distribution wheezy/updates, '/' is not allowed")
 }
 
 func (s *PublishedRepoSuite) TestPrefixNormalization(c *C) {
@@ -288,13 +285,6 @@ func (s *PublishedRepoSuite) TestDistributionComponentGuessing(c *C) {
 	repo, err = NewPublishedRepo("", "ppa", "", nil, []string{""}, []interface{}{s.localRepo}, s.factory)
 	c.Check(err, IsNil)
 	c.Check(repo.Distribution, Equals, "precise")
-	c.Check(repo.Components(), DeepEquals, []string{"contrib"})
-
-	s.localRepo.DefaultDistribution = "precise/updates"
-
-	repo, err = NewPublishedRepo("", "ppa", "", nil, []string{""}, []interface{}{s.localRepo}, s.factory)
-	c.Check(err, IsNil)
-	c.Check(repo.Distribution, Equals, "precise-updates")
 	c.Check(repo.Components(), DeepEquals, []string{"contrib"})
 
 	repo, err = NewPublishedRepo("", "ppa", "", nil, []string{"", "contrib"}, []interface{}{s.snapshot, s.snapshot2}, s.factory)


### PR DESCRIPTION
This is an RFC PR to follow up on the ongoing opened issue https://github.com/aptly-dev/aptly/issues/115
Possible duplicated or already a declined feature. But it's not really clear why this is considered a bug in aptly and what would be the consequences of allowing slash `/` characters in the distribution name.

This reverts commit 1daa076d65e642f2f365e3cd580a78548a9b65a6.

Fixes https://github.com/aptly-dev/aptly/issues/115

## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

<!--

Why this change is important?

-->

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [ ] author name in `AUTHORS`
