### PR TITLE
Add linkMethod relative symlink

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -49,3 +49,4 @@ List of contributors, in chronological order:
 * Samuel Mutel (https://github.com/smutel)
 * Russell Greene (https://github.com/russelltg)
 * Wade Simmons (https://github.com/wadey)
+* Tuan Lee (https://github.com/vleedev)

--- a/aptly/interfaces.go
+++ b/aptly/interfaces.go
@@ -52,7 +52,7 @@ type LocalPackagePool interface {
 	// Link generates hardlink to destination path
 	Link(path, dstPath string) error
 	// Symlink generates symlink to destination path
-	Symlink(path, dstPath string) error
+	Symlink(path, dstPath string, makeRelative bool) error
 	// FullPath generates full path to the file in pool
 	//
 	// Please use with care: it's not supposed to be used to access files

--- a/files/package_pool.go
+++ b/files/package_pool.go
@@ -400,7 +400,7 @@ func (pool *PackagePool) Symlink(path, dstPath string, makeRelative bool) error 
 	if makeRelative {
 		// Take dir of dst
 		dstDir := filepath.Dir(dstPath)
-		// Take relative path to go from destination directory to path
+		// Take relative path to go from path to destination directory
 		relativePath, err := filepath.Rel(dstDir, path)
 		if err != nil {
 			return err

--- a/files/package_pool.go
+++ b/files/package_pool.go
@@ -394,8 +394,20 @@ func (pool *PackagePool) Link(path, dstPath string) error {
 }
 
 // Symlink generates symlink to destination path
-func (pool *PackagePool) Symlink(path, dstPath string) error {
-	return os.Symlink(filepath.Join(pool.rootPath, path), dstPath)
+func (pool *PackagePool) Symlink(path, dstPath string, makeRelative bool) error {
+	// Convert path to absolute path
+	path = filepath.Join(pool.rootPath, path)
+	if makeRelative {
+		// Take dir of dst
+		dstDir := filepath.Dir(dstPath)
+		// Take relative path to go from destination directory to path
+		relativePath, err := filepath.Rel(dstDir, path)
+		if err != nil {
+			return err
+		}
+		path = relativePath
+	}
+	return os.Symlink(path, dstPath)
 }
 
 // FullPath generates full path to the file in pool

--- a/files/public_test.go
+++ b/files/public_test.go
@@ -13,12 +13,14 @@ import (
 )
 
 type PublishedStorageSuite struct {
-	root            string
-	storage         *PublishedStorage
-	storageSymlink  *PublishedStorage
-	storageCopy     *PublishedStorage
-	storageCopySize *PublishedStorage
-	cs              aptly.ChecksumStorage
+	root                   string
+	storage                *PublishedStorage
+	storageSymlink         *PublishedStorage
+	storageAbsoluteSymlink *PublishedStorage
+	storageRelativeSymlink *PublishedStorage
+	storageCopy            *PublishedStorage
+	storageCopySize        *PublishedStorage
+	cs                     aptly.ChecksumStorage
 }
 
 var _ = Suite(&PublishedStorageSuite{})
@@ -27,6 +29,8 @@ func (s *PublishedStorageSuite) SetUpTest(c *C) {
 	s.root = c.MkDir()
 	s.storage = NewPublishedStorage(filepath.Join(s.root, "public"), "", "")
 	s.storageSymlink = NewPublishedStorage(filepath.Join(s.root, "public_symlink"), "symlink", "")
+	s.storageAbsoluteSymlink = NewPublishedStorage(filepath.Join(s.root, "public_absolute_symlink"), "absoluteSymlink", "")
+	s.storageRelativeSymlink = NewPublishedStorage(filepath.Join(s.root, "public_relative_symlink"), "relativeSymlink", "")
 	s.storageCopy = NewPublishedStorage(filepath.Join(s.root, "public_copy"), "copy", "")
 	s.storageCopySize = NewPublishedStorage(filepath.Join(s.root, "public_copysize"), "copy", "size")
 	s.cs = NewMockChecksumStorage()
@@ -34,7 +38,9 @@ func (s *PublishedStorageSuite) SetUpTest(c *C) {
 
 func (s *PublishedStorageSuite) TestLinkMethodField(c *C) {
 	c.Assert(s.storage.linkMethod, Equals, LinkMethodHardLink)
-	c.Assert(s.storageSymlink.linkMethod, Equals, LinkMethodSymLink)
+	c.Assert(s.storageSymlink.linkMethod, Equals, LinkMethodAbsoluteSymLink)
+	c.Assert(s.storageAbsoluteSymlink.linkMethod, Equals, LinkMethodAbsoluteSymLink)
+	c.Assert(s.storageRelativeSymlink.linkMethod, Equals, LinkMethodRelativeSymLink)
 	c.Assert(s.storageCopy.linkMethod, Equals, LinkMethodCopy)
 	c.Assert(s.storageCopySize.linkMethod, Equals, LinkMethodCopy)
 }
@@ -47,6 +53,8 @@ func (s *PublishedStorageSuite) TestVerifyMethodField(c *C) {
 func (s *PublishedStorageSuite) TestPublicPath(c *C) {
 	c.Assert(s.storage.PublicPath(), Equals, filepath.Join(s.root, "public"))
 	c.Assert(s.storageSymlink.PublicPath(), Equals, filepath.Join(s.root, "public_symlink"))
+	c.Assert(s.storageAbsoluteSymlink.PublicPath(), Equals, filepath.Join(s.root, "public_absolute_symlink"))
+	c.Assert(s.storageRelativeSymlink.PublicPath(), Equals, filepath.Join(s.root, "public_relative_symlink"))
 	c.Assert(s.storageCopy.PublicPath(), Equals, filepath.Join(s.root, "public_copy"))
 	c.Assert(s.storageCopySize.PublicPath(), Equals, filepath.Join(s.root, "public_copysize"))
 }

--- a/man/aptly.1
+++ b/man/aptly.1
@@ -62,11 +62,19 @@ Configuration file is stored in JSON format (default values shown below):
     },
     "test2": {
       "rootDir": "/opt/srv2/aptly_public",
-      "linkMethod": "copy",
-      "verifyMethod": "md5"
+      "linkMethod": "absoluteSymlink"
     },
     "test3": {
       "rootDir": "/opt/srv3/aptly_public",
+      "linkMethod": "relativeSymlink"
+    },
+    "test4": {
+      "rootDir": "/opt/srv4/aptly_public",
+      "linkMethod": "copy",
+      "verifyMethod": "md5"
+    },
+    "test5": {
+      "rootDir": "/opt/srv5/aptly_public",
       "linkMethod": "hardlink"
     }
   },
@@ -205,7 +213,7 @@ The publish directory, e\.g\., \fB/opt/srv/aptly_public\fR\.
 .
 .TP
 \fBlinkMethod\fR
-This is one of \fBhardlink\fR, \fBsymlink\fR or \fBcopy\fR\. It specifies how aptly links the files from the internal pool to the published directory\. If not specified, empty or wrong, this defaults to \fBhardlink\fR\.
+This is one of \fBhardlink\fR, \fBsymlink\fR, \fBabsoluteSymlink\fR, \fBrelativeSymlink\fR or \fBcopy\fR\. It specifies how aptly links the files from the internal pool to the published directory\. The option \fBsymlink\fR will be treated as \fBabsoluteSymlink\fR\. If not specified, empty or wrong, this defaults to \fBhardlink\fR\.
 .
 .TP
 \fBverifyMethod\fR

--- a/man/aptly.1.ronn.tmpl
+++ b/man/aptly.1.ronn.tmpl
@@ -54,11 +54,19 @@ Configuration file is stored in JSON format (default values shown below):
         },
         "test2": {
           "rootDir": "/opt/srv2/aptly_public",
-          "linkMethod": "copy",
-          "verifyMethod": "md5"
+          "linkMethod": "absoluteSymlink"
         },
         "test3": {
           "rootDir": "/opt/srv3/aptly_public",
+          "linkMethod": "relativeSymlink"
+        },
+        "test4": {
+          "rootDir": "/opt/srv4/aptly_public",
+          "linkMethod": "copy",
+          "verifyMethod": "md5"
+        },
+        "test5": {
+          "rootDir": "/opt/srv5/aptly_public",
           "linkMethod": "hardlink"
         }
       },
@@ -187,8 +195,9 @@ and the following associated settings:
    * `rootDir`:
      The publish directory, e.g., `/opt/srv/aptly_public`.
    * `linkMethod`:
-     This is one of `hardlink`, `symlink` or `copy`. It specifies how aptly links the
-     files from the internal pool to the published directory.
+     This is one of `hardlink`, `symlink`, `absoluteSymlink`, `relativeSymlink` or `copy`.
+     It specifies how aptly links the files from the internal pool to the published directory.
+     The option `symlink` will be treated as `absoluteSymlink`.
      If not specified, empty or wrong, this defaults to `hardlink`.
    * `verifyMethod`:
      This is used only when setting the `linkMethod` to `copy`. Possible values are


### PR DESCRIPTION
It may relate to Fixes #783

## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

Guide [here](https://www.aptly.info/doc/feature/filesystem/)
Add linkMehod: **absoluteSymlink**, **relativeSymlink**

The default one is **symlink**. It will be treated as **absoluteSymlink**

Add to the document. Pull request here https://github.com/aptly-dev/www.aptly.info/pull/98

<!--

Why this change is important?

-->

## Checklist

- [x] unit-test added (if change is algorithm)
- [x] functional test added/updated (if change is functional)
- [x] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [x] documentation updated
- [x] author name in `AUTHORS`
