### PR TITLE
api: Allow querying the packages endpoint

### DIFF
--- a/api/packages.go
+++ b/api/packages.go
@@ -15,3 +15,10 @@ func apiPackagesShow(c *gin.Context) {
 
 	c.JSON(200, p)
 }
+
+// GET /api/packages
+func apiPackages(c *gin.Context) {
+	collectionFactory := context.NewCollectionFactory()
+	collection := collectionFactory.PackageCollection()
+	showPackages(c, collection.AllPackageRefs(), collectionFactory)
+}

--- a/api/router.go
+++ b/api/router.go
@@ -138,6 +138,7 @@ func Router(c *ctx.AptlyContext) http.Handler {
 
 	{
 		root.GET("/packages/:key", apiPackagesShow)
+		root.GET("/packages", apiPackages)
 	}
 
 	{

--- a/system/t12_api/packages.py
+++ b/system/t12_api/packages.py
@@ -22,9 +22,7 @@ class PackagesAPITestShow(APITest):
         self.check_equal(resp.json()['State'], 2)
 
         # get information about package
-        resp = self.get("/api/packages/" + urllib.parse.quote('Psource pyspi 0.6.1-1.3 3a8b37cbd9a3559e'))
-        self.check_equal(resp.status_code, 200)
-        self.check_equal(resp.json(), {
+        pyspi_json = {
             'Architecture': 'any',
             'Binary': 'python-at-spi',
             'Build-Depends': 'debhelper (>= 5), cdbs, libatspi-dev, python-pyrex, python-support (>= 0.4), python-all-dev, libx11-dev',  # noqa
@@ -41,7 +39,24 @@ class PackagesAPITestShow(APITest):
             'ShortKey': 'Psource pyspi 0.6.1-1.3',
             'Standards-Version': '3.7.3',
             'Vcs-Svn': 'svn://svn.tribulaciones.org/srv/svn/pyspi/trunk',
-            'Version': '0.6.1-1.3'})
+            'Version': '0.6.1-1.3'
+        }
+
+        resp = self.get("/api/packages/" + urllib.parse.quote('Psource pyspi 0.6.1-1.3 3a8b37cbd9a3559e'))
+        self.check_equal(resp.status_code, 200)
+        self.check_equal(resp.json(), pyspi_json)
+
+        resp = self.get("/api/packages?q=pyspi")
+        self.check_equal(resp.status_code, 200)
+        self.check_equal(resp.json(), [pyspi_json["Key"]])
+
+        resp = self.get("/api/packages?q=pyspi&format=details")
+        self.check_equal(resp.status_code, 200)
+        self.check_equal(resp.json(), [pyspi_json])
 
         resp = self.get("/api/packages/" + urllib.parse.quote('Pamd64 no-such-package 1.0 3a8b37cbd9a3559e'))
         self.check_equal(resp.status_code, 404)
+
+        resp = self.get("/api/packages?q=no-such-package")
+        self.check_equal(resp.status_code, 200)
+        self.check_equal(resp.json(), [])


### PR DESCRIPTION
The ".../packages" endpoints for mirror, local repos and snapshots all
share the same syntax for querying. However the "/api/packages" endpoint
doesn't match this. Adjust that to allow for a bit more consistency and
allow querying the full package database.

The current endpoint functionality "/packages/:name" is kept intact and
can be used the same as now

Signed-off-by: Sjoerd Simons <sjoerd@collabora.com>