### PR TITLE
Allow custom codename

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -50,3 +50,4 @@ List of contributors, in chronological order:
 * Russell Greene (https://github.com/russelltg)
 * Wade Simmons (https://github.com/wadey)
 * Steven Stone (https://github.com/smstone)
+* Josh Bayfield (https://github.com/jbayfield)

--- a/AUTHORS
+++ b/AUTHORS
@@ -49,3 +49,4 @@ List of contributors, in chronological order:
 * Samuel Mutel (https://github.com/smutel)
 * Russell Greene (https://github.com/russelltg)
 * Wade Simmons (https://github.com/wadey)
+* Steven Stone (https://github.com/smstone)

--- a/cmd/publish_repo.go
+++ b/cmd/publish_repo.go
@@ -48,6 +48,7 @@ Example:
 	cmd.Flag.String("butautomaticupgrades", "", "set  value for ButAutomaticUpgrades field")
 	cmd.Flag.String("label", "", "label to publish")
 	cmd.Flag.String("suite", "", "suite to publish (defaults to distribution)")
+	cmd.Flag.String("codename", "", "codename to publish (defaults to distribution)")
 	cmd.Flag.Bool("force-overwrite", false, "overwrite files in package pool in case of mismatch")
 	cmd.Flag.Bool("acquire-by-hash", false, "provide index files by hash")
 

--- a/cmd/publish_snapshot.go
+++ b/cmd/publish_snapshot.go
@@ -132,6 +132,7 @@ func aptlyPublishSnapshotOrRepo(cmd *commander.Command, args []string) error {
 	}
 	published.Label = context.Flags().Lookup("label").Value.String()
 	published.Suite = context.Flags().Lookup("suite").Value.String()
+	published.Codename = context.Flags().Lookup("codename").Value.String()
 
 	published.SkipContents = context.Config().SkipContentsPublishing
 
@@ -239,6 +240,7 @@ Example:
 	cmd.Flag.String("butautomaticupgrades", "", "overwrite value for ButAutomaticUpgrades field")
 	cmd.Flag.String("label", "", "label to publish")
 	cmd.Flag.String("suite", "", "suite to publish (defaults to distribution)")
+	cmd.Flag.String("codename", "", "codename to publish (defaults to distribution)")
 	cmd.Flag.Bool("force-overwrite", false, "overwrite files in package pool in case of mismatch")
 	cmd.Flag.Bool("acquire-by-hash", false, "provide index files by hash")
 

--- a/completion.d/_aptly
+++ b/completion.d/_aptly
@@ -457,6 +457,7 @@ local keyring="*-keyring=[gpg keyring to use when verifying Release file (could 
                             "-distribution=[distribution name to publish]:distribution:($dists)"
                             "-label=[label to publish]:label: "
                             "-suite=[suite to publish]:suite: "
+                            "-codename=[codename to publish]:codename: "
                             "-notautomatic=[set value for NotAutomatic field]:notautomatic: "
                             "-origin=[origin name to publish]:origin: "
                             ${components_options[@]}

--- a/completion.d/aptly
+++ b/completion.d/aptly
@@ -503,7 +503,7 @@ _aptly()
           "snapshot"|"repo")
             if [[ $numargs -eq 0 ]]; then
               if [[ "$cur" == -* ]]; then
-                COMPREPLY=($(compgen -W "-acquire-by-hash -batch -butautomaticupgrades= -component= -distribution= -force-overwrite -gpg-key= -keyring= -label= -suite= -codename= -notautomatic= -origin= -passphrase= -passphrase-file= -secret-keyring= -skip-contents -skip-signing" -- ${cur}))
+                COMPREPLY=($(compgen -W "-acquire-by-hash -batch -butautomaticupgrades= -component= -distribution= -force-overwrite -gpg-key= -keyring= -label= -suite= -codename= -notautomatic= -origin= -passphrase= -passphrase-file= -secret-keyring= -skip-contents -skip-bz2 -skip-signing" -- ${cur}))
               else
                 if [[ "$subcmd" == "snapshot" ]]; then
                   COMPREPLY=($(compgen -W "$(__aptly_snapshot_list)" -- ${cur}))

--- a/completion.d/aptly
+++ b/completion.d/aptly
@@ -503,7 +503,7 @@ _aptly()
           "snapshot"|"repo")
             if [[ $numargs -eq 0 ]]; then
               if [[ "$cur" == -* ]]; then
-                COMPREPLY=($(compgen -W "-acquire-by-hash -batch -butautomaticupgrades= -component= -distribution= -force-overwrite -gpg-key= -keyring= -label= -suite= -notautomatic= -origin= -passphrase= -passphrase-file= -secret-keyring= -skip-contents -skip-bz2 -skip-signing" -- ${cur}))
+                COMPREPLY=($(compgen -W "-acquire-by-hash -batch -butautomaticupgrades= -component= -distribution= -force-overwrite -gpg-key= -keyring= -label= -suite= -codename= -notautomatic= -origin= -passphrase= -passphrase-file= -secret-keyring= -skip-contents -skip-signing" -- ${cur}))
               else
                 if [[ "$subcmd" == "snapshot" ]]; then
                   COMPREPLY=($(compgen -W "$(__aptly_snapshot_list)" -- ${cur}))

--- a/deb/publish.go
+++ b/deb/publish.go
@@ -44,6 +44,7 @@ type PublishedRepo struct {
 	ButAutomaticUpgrades string
 	Label                string
 	Suite                string
+	Codename             string
 	// Architectures is a list of all architectures published
 	Architectures []string
 	// SourceKind is "local"/"repo"
@@ -312,6 +313,7 @@ func (p *PublishedRepo) MarshalJSON() ([]byte, error) {
 		"Label":                p.Label,
 		"Origin":               p.Origin,
 		"Suite":                p.Suite,
+		"Codename":             p.Codename,
 		"NotAutomatic":         p.NotAutomatic,
 		"ButAutomaticUpgrades": p.ButAutomaticUpgrades,
 		"Prefix":               p.Prefix,
@@ -364,6 +366,10 @@ func (p *PublishedRepo) String() string {
 
 	if p.Suite != "" {
 		extras = append(extras, fmt.Sprintf("suite: %s", p.Suite))
+	}
+
+	if p.Codename != "" {
+		extras = append(extras, fmt.Sprintf("codename: %s", p.Codename))
 	}
 
 	extra = strings.Join(extras, ", ")
@@ -511,6 +517,14 @@ func (p *PublishedRepo) GetSuite() string {
 		return p.Distribution
 	}
 	return p.Suite
+}
+
+// GetCodename returns default or manual Codename:
+func (p *PublishedRepo) GetCodename() string {
+	if p.Codename == "" {
+		return p.Distribution
+	}
+	return p.Codename
 }
 
 // Publish publishes snapshot (repository) contents, links package files, generates Packages & Release files, signs them
@@ -735,6 +749,7 @@ func (p *PublishedRepo) Publish(packagePool aptly.PackagePool, publishedStorageP
 				release["Origin"] = p.GetOrigin()
 				release["Label"] = p.GetLabel()
 				release["Suite"] = p.GetSuite()
+				release["Codename"] = p.GetCodename()
 				if p.AcquireByHash {
 					release["Acquire-By-Hash"] = "yes"
 				}
@@ -793,7 +808,7 @@ func (p *PublishedRepo) Publish(packagePool aptly.PackagePool, publishedStorageP
 	}
 	release["Label"] = p.GetLabel()
 	release["Suite"] = p.GetSuite()
-	release["Codename"] = p.Distribution
+	release["Codename"] = p.GetCodename()
 	release["Date"] = time.Now().UTC().Format("Mon, 2 Jan 2006 15:04:05 MST")
 	release["Architectures"] = strings.Join(utils.StrSlicesSubstract(p.Architectures, []string{ArchitectureSource}), " ")
 	if p.AcquireByHash {

--- a/man/aptly.1
+++ b/man/aptly.1
@@ -1500,6 +1500,10 @@ don\(cqt sign Release files with GPG
 \-\fBsuite\fR=
 suite to publish (defaults to distribution)
 .
+.TP
+\-\fBcodename\fR=
+codename to publish (defaults to distribution)
+.
 .SH "PUBLISH SNAPSHOT"
 \fBaptly\fR \fBpublish\fR \fBsnapshot\fR \fIname\fR [[\fIendpoint\fR:]\fIprefix\fR]
 .
@@ -1602,6 +1606,10 @@ don\(cqt sign Release files with GPG
 .TP
 \-\fBsuite\fR=
 suite to publish (defaults to distribution)
+.
+.TP
+\-\fBcodename\fR=
+codename to publish (defaults to distribution)
 .
 .SH "UPDATE PUBLISHED REPOSITORY BY SWITCHING TO NEW SNAPSHOT"
 \fBaptly\fR \fBpublish\fR \fBswitch\fR \fIdistribution\fR [[\fIendpoint\fR:]\fIprefix\fR] \fInew\-snapshot\fR

--- a/system/t06_publish/PublishList5Test_gold
+++ b/system/t06_publish/PublishList5Test_gold
@@ -6,6 +6,7 @@
       "i386"
     ],
     "ButAutomaticUpgrades": "",
+    "Codename": "",
     "Distribution": "maverick",
     "Label": "",
     "NotAutomatic": "",
@@ -29,6 +30,7 @@
       "amd64"
     ],
     "ButAutomaticUpgrades": "",
+    "Codename": "",
     "Distribution": "wheezy",
     "Label": "",
     "NotAutomatic": "",
@@ -53,6 +55,7 @@
       "i386"
     ],
     "ButAutomaticUpgrades": "",
+    "Codename": "",
     "Distribution": "maverick",
     "Label": "",
     "NotAutomatic": "",
@@ -77,6 +80,7 @@
       "i386"
     ],
     "ButAutomaticUpgrades": "",
+    "Codename": "",
     "Distribution": "maverick",
     "Label": "label1",
     "NotAutomatic": "",

--- a/system/t06_publish/PublishShow3Test_gold
+++ b/system/t06_publish/PublishShow3Test_gold
@@ -5,6 +5,7 @@
     "i386"
   ],
   "ButAutomaticUpgrades": "",
+  "Codename": "",
   "Distribution": "maverick",
   "Label": "",
   "NotAutomatic": "",

--- a/system/t06_publish/PublishShow4Test_gold
+++ b/system/t06_publish/PublishShow4Test_gold
@@ -5,6 +5,7 @@
     "i386"
   ],
   "ButAutomaticUpgrades": "",
+  "Codename": "",
   "Distribution": "maverick",
   "Label": "",
   "NotAutomatic": "",

--- a/system/t06_publish/PublishSnapshot1Test_release_amd64
+++ b/system/t06_publish/PublishSnapshot1Test_release_amd64
@@ -2,5 +2,6 @@ Origin: LP-PPA-gladky-anton-gnuplot
 Label: . maverick
 Archive: maverick
 Suite: maverick
+Codename: maverick
 Architecture: amd64
 Component: main

--- a/system/t06_publish/PublishSnapshot1Test_release_i386
+++ b/system/t06_publish/PublishSnapshot1Test_release_i386
@@ -2,5 +2,6 @@ Origin: LP-PPA-gladky-anton-gnuplot
 Label: . maverick
 Archive: maverick
 Suite: maverick
+Codename: maverick
 Architecture: i386
 Component: main

--- a/system/t06_publish/PublishSnapshot35Test_release_udeb_i386
+++ b/system/t06_publish/PublishSnapshot35Test_release_udeb_i386
@@ -2,5 +2,6 @@ Origin: Debian
 Label: . stretch
 Archive: stretch
 Suite: stretch
+Codename: stretch
 Architecture: i386
 Component: main

--- a/system/t06_publish/PublishSnapshot39Test_release_amd64
+++ b/system/t06_publish/PublishSnapshot39Test_release_amd64
@@ -2,5 +2,6 @@ Origin: LP-PPA-gladky-anton-gnuplot
 Label: . maverick
 Archive: maverick
 Suite: stable
+Codename: maverick
 Architecture: amd64
 Component: main

--- a/system/t06_publish/PublishSnapshot39Test_release_i386
+++ b/system/t06_publish/PublishSnapshot39Test_release_i386
@@ -2,5 +2,6 @@ Origin: LP-PPA-gladky-anton-gnuplot
 Label: . maverick
 Archive: maverick
 Suite: stable
+Codename: maverick
 Architecture: i386
 Component: main

--- a/system/t12_api/publish.py
+++ b/system/t12_api/publish.py
@@ -41,6 +41,7 @@ class PublishAPITestRepo(APITest):
         repo_expected = {
             'AcquireByHash': False,
             'Architectures': ['i386', 'source'],
+            'Codename': '',
             'Distribution': 'wheezy',
             'Label': '',
             'Origin': '',
@@ -86,6 +87,7 @@ class PublishAPITestRepo(APITest):
         repo2_expected = {
             'AcquireByHash': False,
             'Architectures': ['amd64', 'i386'],
+            'Codename': '',
             'Distribution': distribution,
             'Label': '',
             'Origin': '',
@@ -164,6 +166,7 @@ class PublishSnapshotAPITest(APITest):
         repo_expected = {
             'AcquireByHash': True,
             'Architectures': ['i386'],
+            'Codename': '',
             'Distribution': 'squeeze',
             'Label': 'fun',
             'Origin': 'earth',
@@ -249,6 +252,7 @@ class PublishUpdateAPITestRepo(APITest):
         repo_expected = {
             'AcquireByHash': True,
             'Architectures': ['i386', 'source'],
+            'Codename': '',
             'Distribution': 'wheezy',
             'Label': '',
             'Origin': '',
@@ -343,6 +347,7 @@ class PublishUpdateSkipCleanupAPITestRepo(APITest):
         repo_expected = {
             'AcquireByHash': False,
             'Architectures': ['i386', 'source'],
+            'Codename': '',
             'Distribution': 'wheezy',
             'Label': '',
             'Origin': '',
@@ -406,6 +411,7 @@ class PublishSwitchAPITestRepo(APITest):
         repo_expected = {
             'AcquireByHash': False,
             'Architectures': ['i386', 'source'],
+            'Codename': '',
             'Distribution': 'wheezy',
             'Label': '',
             'NotAutomatic': '',
@@ -449,6 +455,7 @@ class PublishSwitchAPITestRepo(APITest):
         repo_expected = {
             'AcquireByHash': False,
             'Architectures': ['i386', 'source'],
+            'Codename': '',
             'Distribution': 'wheezy',
             'Label': '',
             'Origin': '',
@@ -510,6 +517,7 @@ class PublishSwitchAPISkipCleanupTestRepo(APITest):
         repo_expected = {
             'AcquireByHash': False,
             'Architectures': ['i386', 'source'],
+            'Codename': '',
             'Distribution': 'wheezy',
             'Label': '',
             'NotAutomatic': '',
@@ -546,6 +554,7 @@ class PublishSwitchAPISkipCleanupTestRepo(APITest):
         repo_expected = {
             'AcquireByHash': False,
             'Architectures': ['i386', 'source'],
+            'Codename': '',
             'Distribution': 'otherdist',
             'Label': '',
             'NotAutomatic': '',
@@ -584,6 +593,7 @@ class PublishSwitchAPISkipCleanupTestRepo(APITest):
         repo_expected = {
             'AcquireByHash': False,
             'Architectures': ['i386', 'source'],
+            'Codename': '',
             'Distribution': 'wheezy',
             'Label': '',
             'Origin': '',


### PR DESCRIPTION
## Description of the Change

This is a continuation on #892, but rebased and with fixed system tests so that it is hopefully closer to being ready for merging. With many thanks to @smstone for the work on this feature.

_Original description:_

This change will allow users to set a custom Codename in the release files when publishing.

This PR is inspired/guided by https://github.com/aptly-dev/aptly/pull/874

Why this change is important?

While testing out Aptly, our test apt-get clients were exiting with non-zero status since Codename was changed in the release files that are baked out by Aptly:

```
E: Repository 'http://debianrepo.example.com/bionic unstable InRelease' changed its 'Codename' value from '' to 'unstable'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
```

I attempted to update system tests / man pages, apologies if something was missed. I can also split these out into separate commits, if that is preferable.

## Checklist

- [ ] unit-test added (if change is algorithm)
- [x] functional test added/updated (if change is functional)
- [x] man page updated (if applicable)
- [x] bash completion updated (if applicable)
- [ ] documentation updated
- [x] author name in `AUTHORS`
