### PR TITLE
add forceVirtualHostedStyle for stores which only support virtual hosted style

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -51,3 +51,4 @@ List of contributors, in chronological order:
 * Wade Simmons (https://github.com/wadey)
 * Steven Stone (https://github.com/smstone)
 * Josh Bayfield (https://github.com/jbayfield)
+* Boxjan (https://github.com/boxjan)

--- a/context/context.go
+++ b/context/context.go
@@ -393,7 +393,7 @@ func (context *AptlyContext) GetPublishedStorage(name string) aptly.PublishedSto
 				params.AccessKeyID, params.SecretAccessKey, params.SessionToken,
 				params.Region, params.Endpoint, params.Bucket, params.ACL, params.Prefix, params.StorageClass,
 				params.EncryptionMethod, params.PlusWorkaround, params.DisableMultiDel,
-				params.ForceSigV2, params.Debug)
+				params.ForceSigV2, params.ForceVirtualHostedStyle, params.Debug)
 			if err != nil {
 				Fatal(err)
 			}

--- a/man/aptly.1
+++ b/man/aptly.1
@@ -84,6 +84,7 @@ Configuration file is stored in JSON format (default values shown below):
       "plusWorkaround": false,
       "disableMultiDel": false,
       "forceSigV2": false,
+      "forceVirtualHostedStyle": false,
       "debug": false
     }
   },
@@ -263,6 +264,10 @@ bucket name
 .TP
 \fBforceSigV2\fR
 (optional) disable Signature V4 support, useful with non\-AWS S3\-compatible object stores which do not support SigV4, shouldn\(cqt be enabled for AWS
+.
+.TP
+\fBforceVirtualHostedStyle\fR
+(optional) disable path style visit, useful with non\-AWS S3\-compatible object stores which only support virtual hosted style
 .
 .TP
 \fBdebug\fR

--- a/man/aptly.1.ronn.tmpl
+++ b/man/aptly.1.ronn.tmpl
@@ -76,6 +76,7 @@ Configuration file is stored in JSON format (default values shown below):
           "plusWorkaround": false,
           "disableMultiDel": false,
           "forceSigV2": false,
+          "forceVirtualHostedStyle": true,
           "debug": false
         }
       },
@@ -251,6 +252,9 @@ and associated settings:
    * `forceSigV2`:
      (optional) disable Signature V4 support, useful with non-AWS S3-compatible object stores
      which do not support SigV4, shouldn't be enabled for AWS
+   * `forceVirtualHostedStyle`:
+     (optional) disable path style visit, useful with non-AWS S3-compatible object stores
+     which only support virtual hosted style
    * `debug`:
      (optional) enables detailed request/response dump for each S3 operation
 

--- a/s3/public.go
+++ b/s3/public.go
@@ -79,15 +79,19 @@ func NewPublishedStorageRaw(
 
 // NewPublishedStorage creates new instance of PublishedStorage with specified S3 access
 // keys, region and bucket name
-func NewPublishedStorage(accessKey, secretKey, sessionToken, region, endpoint, bucket, defaultACL, prefix,
-	storageClass, encryptionMethod string, plusWorkaround, disableMultiDel, forceSigV2, debug bool) (*PublishedStorage, error) {
+func NewPublishedStorage(
+	accessKey, secretKey, sessionToken, region, endpoint, bucket, defaultACL, prefix, storageClass, encryptionMethod string,
+	plusWorkaround, disableMultiDel, forceSigV2, forceVirtualHostedStyle, debug bool) (*PublishedStorage, error) {
 
 	config := &aws.Config{
 		Region: aws.String(region),
 	}
 
 	if endpoint != "" {
-		config = config.WithEndpoint(endpoint).WithS3ForcePathStyle(true)
+		config = config.WithEndpoint(endpoint)
+		if !forceVirtualHostedStyle {
+			config = config.WithS3ForcePathStyle(true)
+		}
 	}
 
 	if accessKey != "" {

--- a/s3/public_test.go
+++ b/s3/public_test.go
@@ -29,11 +29,11 @@ func (s *PublishedStorageSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(s.srv, NotNil)
 
-	s.storage, err = NewPublishedStorage("aa", "bb", "", "test-1", s.srv.URL(), "test", "", "", "", "", false, true, false, false)
+	s.storage, err = NewPublishedStorage("aa", "bb", "", "test-1", s.srv.URL(), "test", "", "", "", "", false, true, false, false, false)
 	c.Assert(err, IsNil)
-	s.prefixedStorage, err = NewPublishedStorage("aa", "bb", "", "test-1", s.srv.URL(), "test", "", "lala", "", "", false, true, false, false)
+	s.prefixedStorage, err = NewPublishedStorage("aa", "bb", "", "test-1", s.srv.URL(), "test", "", "lala", "", "", false, true, false, false, false)
 	c.Assert(err, IsNil)
-	s.noSuchBucketStorage, err = NewPublishedStorage("aa", "bb", "", "test-1", s.srv.URL(), "no-bucket", "", "", "", "", false, true, false, false)
+	s.noSuchBucketStorage, err = NewPublishedStorage("aa", "bb", "", "test-1", s.srv.URL(), "no-bucket", "", "", "", "", false, true, false, false, false)
 	c.Assert(err, IsNil)
 
 	_, err = s.storage.s3.CreateBucket(&s3.CreateBucketInput{Bucket: aws.String("test")})

--- a/utils/config.go
+++ b/utils/config.go
@@ -46,20 +46,21 @@ type FileSystemPublishRoot struct {
 
 // S3PublishRoot describes single S3 publishing entry point
 type S3PublishRoot struct {
-	Region           string `json:"region"`
-	Bucket           string `json:"bucket"`
-	Endpoint         string `json:"endpoint"`
-	AccessKeyID      string `json:"awsAccessKeyID"`
-	SecretAccessKey  string `json:"awsSecretAccessKey"`
-	SessionToken     string `json:"awsSessionToken"`
-	Prefix           string `json:"prefix"`
-	ACL              string `json:"acl"`
-	StorageClass     string `json:"storageClass"`
-	EncryptionMethod string `json:"encryptionMethod"`
-	PlusWorkaround   bool   `json:"plusWorkaround"`
-	DisableMultiDel  bool   `json:"disableMultiDel"`
-	ForceSigV2       bool   `json:"forceSigV2"`
-	Debug            bool   `json:"debug"`
+	Region                  string `json:"region"`
+	Bucket                  string `json:"bucket"`
+	Endpoint                string `json:"endpoint"`
+	AccessKeyID             string `json:"awsAccessKeyID"`
+	SecretAccessKey         string `json:"awsSecretAccessKey"`
+	SessionToken            string `json:"awsSessionToken"`
+	Prefix                  string `json:"prefix"`
+	ACL                     string `json:"acl"`
+	StorageClass            string `json:"storageClass"`
+	EncryptionMethod        string `json:"encryptionMethod"`
+	PlusWorkaround          bool   `json:"plusWorkaround"`
+	DisableMultiDel         bool   `json:"disableMultiDel"`
+	ForceSigV2              bool   `json:"forceSigV2"`
+	ForceVirtualHostedStyle bool   `json:"forceVirtualHostedStyle"`
+	Debug                   bool   `json:"debug"`
 }
 
 // SwiftPublishRoot describes single OpenStack Swift publishing entry point

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -102,6 +102,7 @@ func (s *ConfigSuite) TestSaveConfig(c *C) {
 		"      \"plusWorkaround\": false,\n"+
 		"      \"disableMultiDel\": false,\n"+
 		"      \"forceSigV2\": false,\n"+
+		"      \"forceVirtualHostedStyle\": false,\n"+
 		"      \"debug\": false\n"+
 		"    }\n"+
 		"  },\n"+


### PR DESCRIPTION
## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change
Some of s3 style store not support path style, need a option to control it

## Checklist

- [x] unit-test added (if change is algorithm)
- [x] functional test added/updated (if change is functional)
- [x] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [x] documentation updated
- [x] author name in `AUTHORS`
