### PR TITLE
Return an empty array if no tasks are available

### DIFF
--- a/api/task_test.go
+++ b/api/task_test.go
@@ -71,5 +71,5 @@ func (s *TaskSuite) TestTasksClear(c *C) {
 	c.Check(response.Code, Equals, 200)
 	response, _ = s.HTTPRequest("GET", "/api/tasks", nil)
 	c.Check(response.Code, Equals, 200)
-	c.Check(response.Body.String(), Equals, "null")
+	c.Check(response.Body.String(), Equals, "[]")
 }

--- a/task/list.go
+++ b/task/list.go
@@ -33,7 +33,7 @@ func NewList() *List {
 
 // GetTasks gets complete list of tasks
 func (list *List) GetTasks() []Task {
-	var tasks []Task
+	tasks := []Task{}
 	list.Lock()
 	for _, task := range list.tasks {
 		tasks = append(tasks, *task)


### PR DESCRIPTION
All other api endpoints also send empty arrays instead of nil. Closes #1123

Fixes #1123

## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

Returns an empty array instead of nil if there are no tasks available
