### PR TITLE
Add api publish mutex

### DIFF
--- a/api/publish.go
+++ b/api/publish.go
@@ -340,6 +340,8 @@ func apiPublishUpdateSwitch(c *gin.Context) {
 	resources = append(resources, string(published.Key()))
 	taskName := fmt.Sprintf("Update published %s (%s): %s", published.SourceKind, strings.Join(updatedComponents, " "), strings.Join(updatedSnapshots, ", "))
 	maybeRunTaskInBackground(c, taskName, resources, func(out aptly.Progress, detail *task.Detail) (*task.ProcessReturnValue, error) {
+		context.PublishMutex.Lock()
+		defer context.PublishMutex.Unlock()
 		err := published.Publish(context.PackagePool(), context, collectionFactory, signer, out, b.ForceOverwrite)
 		if err != nil {
 			return &task.ProcessReturnValue{Code: http.StatusInternalServerError, Value: nil}, fmt.Errorf("unable to update: %s", err)

--- a/context/context.go
+++ b/context/context.go
@@ -40,6 +40,7 @@ type AptlyContext struct {
 	flags, globalFlags *flag.FlagSet
 	configLoaded       bool
 
+	PublishMutex      sync.Mutex
 	progress          aptly.Progress
 	downloader        aptly.Downloader
 	taskList          *task.List
@@ -593,6 +594,7 @@ func NewContext(flags *flag.FlagSet) (*AptlyContext, error) {
 	var err error
 
 	context := &AptlyContext{
+		PublishMutex:      sync.Mutex{},
 		flags:             flags,
 		globalFlags:       flags,
 		dependencyOptions: -1,


### PR DESCRIPTION
At the moment it is posible to have multiple publish updates running at the same time. This is a problem as both processes try to update the same files and some unexpected
behaviour might occur.

By using a global mutex, only one publish can be updated at any time.

Fixes #1125
