### PR TITLE
return the snapshot in apiSnapshotsCreate

### DIFF
--- a/api/snapshot.go
+++ b/api/snapshot.go
@@ -160,7 +160,7 @@ func apiSnapshotsCreate(c *gin.Context) {
 		if err != nil {
 			return &task.ProcessReturnValue{Code: http.StatusBadRequest, Value: nil}, err
 		}
-		return &task.ProcessReturnValue{Code: http.StatusCreated, Value: nil}, nil
+		return &task.ProcessReturnValue{Code: http.StatusCreated, Value: snapshot}, nil
 	})
 }
 


### PR DESCRIPTION
In v1.4.0 it [returned the snapshot](https://github.com/aptly-dev/aptly/blob/v1.4.0/api/snapshot.go#L168), but this was removed (by accident) in v1.5.0. This adds it back.

## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

<!--

Why this change is important?

-->

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [ ] author name in `AUTHORS`
