### PR TITLE
Fix: Switch gin mode depending on aptly.EnableDebug

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -52,3 +52,4 @@ List of contributors, in chronological order:
 * Steven Stone (https://github.com/smstone)
 * Josh Bayfield (https://github.com/jbayfield)
 * Boxjan (https://github.com/boxjan)
+* Mauro Regli (https://github.com/reglim)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -89,6 +89,10 @@ func (s *ApiSuite) HTTPRequest(method string, url string, body io.Reader) (*http
 	return w, nil
 }
 
+func (s *ApiSuite) TestGinRunsInReleaseMode(c *C) {
+	c.Check(gin.Mode(), Equals, gin.ReleaseMode)
+}
+
 func (s *ApiSuite) TestGetVersion(c *C) {
 	response, err := s.HTTPRequest("GET", "/api/version", nil)
 	c.Assert(err, IsNil)

--- a/api/router.go
+++ b/api/router.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sync/atomic"
 
+	"github.com/aptly-dev/aptly/aptly"
 	ctx "github.com/aptly-dev/aptly/context"
 	"github.com/aptly-dev/aptly/utils"
 	"github.com/gin-gonic/gin"
@@ -22,6 +23,12 @@ func apiMetricsGet() gin.HandlerFunc {
 
 // Router returns prebuilt with routes http.Handler
 func Router(c *ctx.AptlyContext) http.Handler {
+	if aptly.EnableDebug {
+		gin.SetMode(gin.DebugMode)
+	} else {
+		gin.SetMode(gin.ReleaseMode)
+	}
+
 	router := gin.New()
 	context = c
 


### PR DESCRIPTION
If aptly.EnableDebug is active, we use gin.DebugMode, otherwise we use gin.ReleaseMode to remove the annoying nudging messages when running the api.

Fixes #1103

## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

We now change the gin Mode before instantiating the server.

Why this change is important?

--> Performance of the API is improved in Release mode
--> No more annoying messages when running `aptly api serve`

## Checklist

- [x] unit-test added (if change is algorithm)
- [x] functional test added/updated (if change is functional)
- [x] man page updated (if applicable)
- [x] bash completion updated (if applicable)
- [x] documentation updated
- [x] author name in `AUTHORS`
