### PR TITLE
Fix: Drop Publish returned wrong status code if not found

### DIFF
--- a/api/publish.go
+++ b/api/publish.go
@@ -376,7 +376,7 @@ func apiPublishDrop(c *gin.Context) {
 
 	published, err := collection.ByStoragePrefixDistribution(storage, prefix, distribution)
 	if err != nil {
-		AbortWithJSONError(c, http.StatusInternalServerError, fmt.Errorf("unable to drop: %s", err))
+		AbortWithJSONError(c, http.StatusNotFound, fmt.Errorf("unable to drop: %s", err))
 		return
 	}
 


### PR DESCRIPTION
Fixes #1006 

## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

Deleting a publish that does not exist now results in a status code 404 instead of 500.

--> Status code 500 should be avoided if another status code represents the issue better to the consumer of the API.

## Checklist

- [x] unit-test added (if change is algorithm)
- [x] functional test added/updated (if change is functional)
- [x] man page updated (if applicable)
- [x] bash completion updated (if applicable)
- [x] documentation updated
- [x] author name in `AUTHORS`
