### PR TITLE
Fix: Make CodeCov pipeline non-blocking

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,3 +5,5 @@ coverage:
         target: auto
         threshold: 0%
         if_ci_failed: error
+        target: auto
+        threshold: 2%


### PR DESCRIPTION
Fixes #1154 

## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change
The CodeCov Pipeline will now only fail if the code coverage has fallen more than 2 percent with that Pull Request.

Why this change is important?

--> The pipeline should now no longer fail and block pull requests when only small fixes were applied

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [x] author name in `AUTHORS`
