### PR TITLE
Feature: Add Merge Snapshot API

### DIFF
--- a/api/router.go
+++ b/api/router.go
@@ -159,6 +159,7 @@ func Router(c *ctx.AptlyContext) http.Handler {
 		root.GET("/snapshots/:name/packages", apiSnapshotsSearchPackages)
 		root.DELETE("/snapshots/:name", apiSnapshotsDrop)
 		root.GET("/snapshots/:name/diff/:withSnapshot", apiSnapshotsDiff)
+		root.POST("/snapshots/merge", apiSnapshotsMerge)
 	}
 
 	{


### PR DESCRIPTION
Is part of Issue #176

## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

I added the API `POST /api/snapshots/merge` to create a new snapshot from several others, analogous to the `aptly snapshot merge` command. 

(This is my first Aptly feature, please tell me if something's missing : ) )

Why this change is important?

--> Useful for remote management.

## Checklist

- [x] unit-test added (if change is algorithm)
- [x] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [x] author name in `AUTHORS`
