### PR TITLE
Print publish storage on graph

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -53,3 +53,4 @@ List of contributors, in chronological order:
 * Josh Bayfield (https://github.com/jbayfield)
 * Boxjan (https://github.com/boxjan)
 * Mauro Regli (https://github.com/reglim)
+* Alexander Zubarev (https://github.com/strike)

--- a/deb/graph.go
+++ b/deb/graph.go
@@ -119,8 +119,8 @@ func BuildGraph(collectionFactory *CollectionFactory, layout string) (gographviz
 			"shape":     "Mrecord",
 			"style":     "filled",
 			"fillcolor": "darkolivegreen1",
-			"label": fmt.Sprintf("%sPublished %s/%s|comp: %s|arch: %s%s", labelStart,
-				repo.Prefix, repo.Distribution, strings.Join(repo.Components(), " "),
+			"label": fmt.Sprintf("%sPublished %s|comp: %s|arch: %s%s", labelStart,
+				repo.GetPath(), strings.Join(repo.Components(), " "),
 				strings.Join(repo.Architectures, ", "), labelEnd),
 		})
 


### PR DESCRIPTION
This helps visually distinguish between local publications and those on S3.

## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

In PR, I changed publish name function to `repo.GetPath()` ([source](https://github.com/aptly-dev/aptly/blob/9c6f8966664a77b5e5989a383dcf2175c5c8b15c/deb/publish.go#L526)) which returns the same data (`repo.Prefix`, `repo.Distribution`), but also return storage if exists.

For visualization. In master:
![master](https://user-images.githubusercontent.com/223260/231872860-753bd953-44d1-4fd6-b1a9-5cefa738e78f.png)
In PR:
![pr](https://user-images.githubusercontent.com/223260/231872927-0a9440e4-f9ac-4109-8fef-b3414919d71e.png)

## Checklist

- [x] author name in `AUTHORS`
