### PR TITLE
Fix returncode when deleting a mirror with snapshot

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -54,3 +54,4 @@ List of contributors, in chronological order:
 * Boxjan (https://github.com/boxjan)
 * Mauro Regli (https://github.com/reglim)
 * Alexander Zubarev (https://github.com/strike)
+* Nicolas Dostert (https://github.com/acdn-ndostert)

--- a/api/mirror.go
+++ b/api/mirror.go
@@ -157,7 +157,7 @@ func apiMirrorsDrop(c *gin.Context) {
 			snapshots := snapshotCollection.ByRemoteRepoSource(repo)
 
 			if len(snapshots) > 0 {
-				return &task.ProcessReturnValue{Code: http.StatusInternalServerError, Value: nil}, fmt.Errorf("won't delete mirror with snapshots, use 'force=1' to override")
+				return &task.ProcessReturnValue{Code: http.StatusForbidden, Value: nil}, fmt.Errorf("won't delete mirror with snapshots, use 'force=1' to override")
 			}
 		}
 


### PR DESCRIPTION
When trying to delete a mirror that has snapshot and not providing the force option, the API should not return a `500
StatusInternalServerError`.
A `403 StatusForbidden` is more appropriate when the condition is expected by the server.

Fixes #

## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

I was able to run `make modules install` and `make test` with success but I'm not able to run `make system-test` because of missing dependencies (gpg1).

## Description of the Change

When implementing a client for Aptly API the `500` HTTP status code returned does not make it clear that there is an issue with the request.
From https://www.rfc-editor.org/rfc/rfc9110.html#name-500-internal-server-error

> [15.6.1. ](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.6.1)[500 Internal Server Error](https://www.rfc-editor.org/rfc/rfc9110.html#name-500-internal-server-error)
> The 500 (Internal Server Error) status code indicates that the server encountered an unexpected condition that prevented it from fulfilling the request.

The condition preventing the request to be fulfill is not unexpected and is even documented in the response.

## Checklist

<s>- [ ] unit-test added (if change is algorithm)</s>
<s>- [ ] functional test added/updated (if change is functional)</s>
<s>- [ ] man page updated (if applicable)</s>
<s>- [ ] bash completion updated (if applicable)</s>
<s>- [ ] documentation updated</s>
- [x] author name in `AUTHORS`
