### PR TITLE
Fix: Remove Batch from API options, set to true by default

### DIFF
--- a/api/publish.go
+++ b/api/publish.go
@@ -16,7 +16,6 @@ import (
 // SigningOptions is a shared between publish API GPG options structure
 type SigningOptions struct {
 	Skip           bool
-	Batch          bool
 	GpgKey         string
 	Keyring        string
 	SecretKeyring  string
@@ -33,7 +32,9 @@ func getSigner(options *SigningOptions) (pgp.Signer, error) {
 	signer.SetKey(options.GpgKey)
 	signer.SetKeyRing(options.Keyring, options.SecretKeyring)
 	signer.SetPassphrase(options.Passphrase, options.PassphraseFile)
-	signer.SetBatch(options.Batch)
+
+	// If Batch is false, GPG will ask for passphrase on stdin, which would block the api process
+	signer.SetBatch(true)
 
 	err := signer.Init()
 	if err != nil {

--- a/pgp/internal.go
+++ b/pgp/internal.go
@@ -46,7 +46,8 @@ type GoSigner struct {
 	signerConfig  *packet.Config
 }
 
-// SetBatch controls whether we allowed to interact with user
+// SetBatch controls whether we allowed to interact with user, for example
+// for getting the passphrase from stdin.
 func (g *GoSigner) SetBatch(batch bool) {
 	g.batch = batch
 }


### PR DESCRIPTION
It doesn't make sense to expose the Batch option, which, if `false` enables input from stdin for gpg passphrases, which blocks the api thread. Because of this, I removed the option, and set it to `true` by default.

## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

* Remove `Batch` option
* Set `Batch` to true internally

Why this change is important?

So the API can't get hung up because a user tries to sign a publish with a key that requires a passphrase he didn't provide in the request.

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [x] documentation updated
- [x] author name in `AUTHORS`
