### PR TITLE
Improve test output regexes for better perf and Go 1.20 support 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -55,3 +55,4 @@ List of contributors, in chronological order:
 * Mauro Regli (https://github.com/reglim)
 * Alexander Zubarev (https://github.com/strike)
 * Nicolas Dostert (https://github.com/acdn-ndostert)
+* Ryan Gonzalez (https://github.com/refi64)

--- a/system/lib.py
+++ b/system/lib.py
@@ -296,7 +296,7 @@ class BaseTest(object):
             if is_aptly_command:
                 # remove the last two rows as go tests always print PASS/FAIL and coverage in those
                 # two lines. This would otherwise fail the tests as they would not match gold
-                match = re.search(r"EXIT: (\d)\n.*\ncoverage: .*", raw_output.decode("utf-8"))
+                match = re.search(r"EXIT: (\d)\n.*\n.*coverage: .*", raw_output.decode("utf-8"))
                 if match is None:
                     raise Exception("no matches found in output '%s'" % raw_output.decode("utf-8"))
 

--- a/system/lib.py
+++ b/system/lib.py
@@ -296,15 +296,12 @@ class BaseTest(object):
             if is_aptly_command:
                 # remove the last two rows as go tests always print PASS/FAIL and coverage in those
                 # two lines. This would otherwise fail the tests as they would not match gold
-                matches = re.findall(r"((.|\n)*)EXIT: (\d)\n.*\ncoverage: .*", raw_output.decode("utf-8"))
-                if not matches:
+                match = re.search(r"EXIT: (\d)\n.*\ncoverage: .*", raw_output.decode("utf-8"))
+                if match is None:
                     raise Exception("no matches found in output '%s'" % raw_output.decode("utf-8"))
 
-                output, _, returncode = matches[0]
-
-                output = output.encode()
-                returncodes.append(int(returncode))
-
+                output = match.string[:match.start()].encode()
+                returncodes.append(int(match.group(1)))
             else:
                 output = raw_output
 


### PR DESCRIPTION
From the first commit:

```
The current regex runs in exponential time, which massively impacts the
runtime of the test suite, taking several seconds (~4s on my system)
just to perform a single match. By replacing the mix of re.findall + the
initial capture group with re.search + some string slicing, the time
spent matching the regex becomes nearly instant, e.g.:

    $ make system-test TESTS='Config*'

goes from taking ~10s to ~1.5s.
```

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [ ] author name in `AUTHORS`
