### PR TITLE
Skip loading reflists when listing published repos

### DIFF
--- a/api/publish.go
+++ b/api/publish.go
@@ -61,7 +61,7 @@ func apiPublishList(c *gin.Context) {
 	result := make([]*deb.PublishedRepo, 0, collection.Len())
 
 	err := collection.ForEach(func(repo *deb.PublishedRepo) error {
-		err := collection.LoadComplete(repo, collectionFactory)
+		err := collection.LoadShallow(repo, collectionFactory)
 		if err != nil {
 			return err
 		}

--- a/cmd/publish_list.go
+++ b/cmd/publish_list.go
@@ -34,7 +34,7 @@ func aptlyPublishListTxt(cmd *commander.Command, _ []string) error {
 	published := make([]string, 0, collectionFactory.PublishedRepoCollection().Len())
 
 	err = collectionFactory.PublishedRepoCollection().ForEach(func(repo *deb.PublishedRepo) error {
-		e := collectionFactory.PublishedRepoCollection().LoadComplete(repo, collectionFactory)
+		e := collectionFactory.PublishedRepoCollection().LoadShallow(repo, collectionFactory)
 		if e != nil {
 			fmt.Fprintf(os.Stderr, "Error found on one publish (prefix:%s / distribution:%s / component:%s\n)",
 				repo.StoragePrefix(), repo.Distribution, repo.Components())


### PR DESCRIPTION
## Description of the Change

Loading the reflists to list publish information takes a significant amount of time, even though the resulting info doesn't actually use any of the reflists.

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [x] author name in `AUTHORS`
