### PR TITLE
gpg api: allow self signed and use default gpg version

### DIFF
--- a/api/gpg.go
+++ b/api/gpg.go
@@ -25,7 +25,7 @@ func apiGPGAddKey(c *gin.Context) {
 	}
 
 	var err error
-	args := []string{"--no-default-keyring"}
+	args := []string{"--no-default-keyring", "--allow-non-selfsigned-uid"}
 	keyring := "trustedkeys.gpg"
 	if len(b.Keyring) > 0 {
 		keyring = b.Keyring
@@ -73,11 +73,11 @@ func apiGPGAddKey(c *gin.Context) {
 	// there is no error handling for such as gpg will do this for us
 	cmd := exec.Command(gpg, args...)
 	fmt.Printf("running %s %s\n", gpg, strings.Join(args, " "))
-	cmd.Stdout = os.Stdout
-	if err = cmd.Run(); err != nil {
-		AbortWithJSONError(c, 400, err)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		c.JSON(400, string(out))
 		return
 	}
 
-	c.JSON(200, gin.H{})
+	c.JSON(200, string(out))
 }


### PR DESCRIPTION
## Description of the Change

Self signed GPG keys were refused, which is something aptly should allow, if a repo for mirroring is singed this way.

Also, use the default GPG version, as in the other parts for using GPG keys.

The API also returns the gpg command output, instead of just a failure.

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
