### PR TITLE
fixup: publish concurrency

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -58,3 +58,4 @@ List of contributors, in chronological order:
 * Ryan Gonzalez (https://github.com/refi64)
 * Paul Cacheux (https://github.com/paulcacheux)
 * Nic Waller (https://github.com/sf-nwaller)
+* Ramón N.Rodriguez (https://github.com/runitonmetal)


### PR DESCRIPTION
See  #1271

This MR addresses a concurrency issue with the `api/publish` endpoint, where concurrent PUTs typically fail. The MR in it self is not pretty, so consider this initial state of the MR a starting point of discussion.
The commits are intentionally separated in order to make it as easy as possible to observe the failing test (and test it against other likely better code changes).
