### PR TITLE
source package upload: allow + in version

### DIFF
--- a/deb/import.go
+++ b/deb/import.go
@@ -136,8 +136,9 @@ func ImportPackageFiles(list *PackageList, packageFiles []string, forceReplace b
 			return nil, nil, err
 		}
 
+		filename := strings.Replace(filepath.Base(file), "%2B", "+", -1)
 		mainPackageFile := PackageFile{
-			Filename:  filepath.Base(file),
+			Filename:  filename,
 			Checksums: checksums,
 		}
 
@@ -152,7 +153,9 @@ func ImportPackageFiles(list *PackageList, packageFiles []string, forceReplace b
 
 		// go over all the other files
 		for i := range files {
-			sourceFile := filepath.Join(filepath.Dir(file), filepath.Base(files[i].Filename))
+			// convert plus to %2B, as this is how the file is stored on disk
+			filename := strings.Replace(filepath.Base(files[i].Filename), "+", "%2B", -1)
+			sourceFile := filepath.Join(filepath.Dir(file), filename)
 
 			_, err = os.Stat(sourceFile)
 			if err == nil {


### PR DESCRIPTION
## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

Aptly ignores source package archive files if they have a plus in the version. This happens because files uploaded to aptly have plus signes url escaped, but the filename inside the dsc file is not escaped. This changes fixes this behavior, by unescaping the filename when needed.

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [ ] author name in `AUTHORS`
