### PR TITLE
Fix/publish concurrency

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -60,3 +60,4 @@ List of contributors, in chronological order:
 * Nic Waller (https://github.com/sf-nwaller)
 * iofq (https://github.com/iofq)
 * Noa Resare (https://github.com/nresare)
+* Ramón N.Rodriguez (https://github.com/runitonmetal)

--- a/Makefile
+++ b/Makefile
@@ -101,4 +101,7 @@ docker-system-tests:  ## Run system tests in docker container (add TEST=t04_mirr
 golangci-lint:  ## Run golangci-line in docker container
 	docker run -t --rm -v ~/.cache/golangci-lint/v1.56.2:/root/.cache -v ${PWD}:/app -w /app golangci/golangci-lint:v1.56.2 golangci-lint run
 
+flake8:
+	flake8 system
+
 .PHONY: help man modules version release goxc docker-build docker-system-tests

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,9 @@ version:  ## Print aptly version
 docker-build-system-tests:  ## Build system-test docker image
 	docker build -f system/Dockerfile --no-cache . -t aptly-system-test
 
+docker-unit-tests:  ## Run unit tests in docker container
+	docker run -t --rm -v ${PWD}:/app aptly-system-test go test -v ./... -gocheck.v=true
+
 docker-system-tests:  ## Run system tests in docker container (add TEST=t04_mirror to run only specific tests)
 	docker run -t --rm -v ${PWD}:/app aptly-system-test /app/system/run-system-tests $(TEST)
 

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ ifeq ($(RUN_LONG_TESTS), yes)
 	go test -v -coverpkg="./..." -c -tags testruncli
 	if [ ! -e ~/aptly-fixture-db ]; then git clone https://github.com/aptly-dev/aptly-fixture-db.git ~/aptly-fixture-db/; fi
 	if [ ! -e ~/aptly-fixture-pool ]; then git clone https://github.com/aptly-dev/aptly-fixture-pool.git ~/aptly-fixture-pool/; fi
-	PATH=$(BINPATH)/:$(PATH) && . system/env/bin/activate && APTLY_VERSION=$(VERSION) $(PYTHON) system/run.py --long $(TESTS) --coverage-dir $(COVERAGE_DIR) $(CAPTURE)
+	PATH=$(BINPATH)/:$(PATH) && . system/env/bin/activate && APTLY_VERSION=$(VERSION) FORCE_COLOR=1 $(PYTHON) system/run.py --long $(TESTS) --coverage-dir $(COVERAGE_DIR) $(CAPTURE)
 endif
 
 docker-test: install
@@ -96,13 +96,13 @@ docker-build-system-tests:  ## Build system-test docker image
 	docker build -f system/Dockerfile --no-cache . -t aptly-system-test
 
 docker-unit-tests:  ## Run unit tests in docker container
-	docker run -t --rm -v ${PWD}:/app aptly-system-test go test -v ./... -gocheck.v=true
+	docker run -it --rm -v ${PWD}:/app aptly-system-test go test -v ./... -gocheck.v=true
 
 docker-system-tests:  ## Run system tests in docker container (add TEST=t04_mirror to run only specific tests)
-	docker run -t --rm -v ${PWD}:/app aptly-system-test /app/system/run-system-tests $(TEST)
+	docker run -it --rm -v ${PWD}:/app aptly-system-test /app/system/run-system-tests $(TEST)
 
 golangci-lint:  ## Run golangci-line in docker container
-	docker run -t --rm -v ~/.cache/golangci-lint/v1.56.2:/root/.cache -v ${PWD}:/app -w /app golangci/golangci-lint:v1.56.2 golangci-lint run
+	docker run -it --rm -v ~/.cache/golangci-lint/v1.56.2:/root/.cache -v ${PWD}:/app -w /app golangci/golangci-lint:v1.56.2 golangci-lint run
 
 flake8:
 	flake8 system

--- a/context/context.go
+++ b/context/context.go
@@ -567,6 +567,9 @@ func (context *AptlyContext) Shutdown() {
 			context.fileMemProfile = nil
 		}
 	}
+	if context.taskList != nil {
+		context.taskList.Stop()
+	}
 	if context.database != nil {
 		context.database.Close()
 		context.database = nil

--- a/system/Dockerfile
+++ b/system/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends curl gnupg &
 
 RUN echo deb http://deb.debian.org/debian bookworm-backports main > /etc/apt/sources.list.d/backports.list
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends apg bzip2 xz-utils ca-certificates golang/bookworm-backports golang-go/bookworm-backports golang-doc/bookworm-backports golang-src/bookworm-backports make git python3 python3-requests-unixsocket && \
+    apt-get install -y --no-install-recommends apg bzip2 xz-utils ca-certificates golang/bookworm-backports golang-go/bookworm-backports golang-doc/bookworm-backports golang-src/bookworm-backports make git python3 python3-requests-unixsocket python3-termcolor && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m --shell /bin/sh --home-dir /var/lib/aptly aptly

--- a/system/Dockerfile
+++ b/system/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends curl gnupg &
 
 RUN echo deb http://deb.debian.org/debian bookworm-backports main > /etc/apt/sources.list.d/backports.list
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends apg bzip2 xz-utils ca-certificates golang/bookworm-backports golang-go/bookworm-backports golang-doc/bookworm-backports golang-src/bookworm-backports make git python3 python3-requests-unixsocket python3-termcolor && \
+    apt-get install -y --no-install-recommends apg bzip2 xz-utils ca-certificates golang/bookworm-backports golang-go/bookworm-backports golang-doc/bookworm-backports golang-src/bookworm-backports make git python3 python3-requests-unixsocket python3-termcolor python3-swiftclient python3-boto && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m --shell /bin/sh --home-dir /var/lib/aptly aptly

--- a/system/lib.py
+++ b/system/lib.py
@@ -20,6 +20,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 import zlib
+
 from pathlib import Path
 from uuid import uuid4
 
@@ -246,7 +247,7 @@ class BaseTest(object):
         if hasattr(self, "fixtureCmds"):
             for cmd in self.fixtureCmds:
                 output = self.run_cmd(cmd)
-                print("\n")
+                print("fixture Output:\n")
                 for line in output.decode("utf-8").split("\n"):
                     print(f"    {line}")
 

--- a/system/run-system-tests
+++ b/system/run-system-tests
@@ -4,7 +4,7 @@
 rm -rf /app/tmp
 rm -rf /tmp/aptly*
 
-usermod -u `stat -c %u /app` aptly
+usermod -u `stat -c %u /app` aptly >/dev/null
 chown -R `stat -c %u /app` /var/lib/aptly
 
 # use same /home/runner dir as in github workflow

--- a/system/run.py
+++ b/system/run.py
@@ -81,7 +81,7 @@ def run(include_long_tests=False, capture_results=False, tests=None, filters=Non
                     if not matches:
                         continue
 
-                sys.stdout.write("%s:%s... " % (test, o.__name__))
+                sys.stdout.write(colored("%s:%s... ", color="yellow", attrs=["bold"]) % (test, o.__name__))
                 sys.stdout.flush()
 
                 t = o()
@@ -105,9 +105,9 @@ def run(include_long_tests=False, capture_results=False, tests=None, filters=Non
                     typ, val, tb = sys.exc_info()
                     fails.append((test, t, typ, val, tb, testModule))
                     traceback.print_exception(typ, val, tb)
-                    sys.stdout.write(colored("FAIL\n", color="red"))
+                    sys.stdout.write(colored("FAIL\n", color="red", attrs=["bold"]))
                 else:
-                    sys.stdout.write(colored("OK\n", color="green"))
+                    sys.stdout.write(colored("OK\n", color="green", attrs=["bold"]))
 
                 t.shutdown()
 

--- a/system/run.py
+++ b/system/run.py
@@ -33,16 +33,6 @@ def natural_key(string_):
     return [int(s) if s.isdigit() else s for s in re.split(r'(\d+)', string_)]
 
 
-def walk_modules(package):
-    yield importlib.import_module(package)
-    for name in sorted(glob.glob(package + "/*.py"), key=natural_key):
-        name = os.path.splitext(os.path.basename(name))[0]
-        if name == "__init__":
-            continue
-
-        yield importlib.import_module(package + "." + name)
-
-
 class TestStdout:
     def __init__(self):
         self.output = []
@@ -112,7 +102,7 @@ def run(include_long_tests=False, capture_results=False, tests=None, filters=Non
                     if not matches:
                         continue
 
-                orig_stdout.write(colored("%s: %s ... ", color="yellow", attrs=["bold"]) % (test, o.__name__))
+                orig_stdout.write("%s: %s ... " % (test, colored(o.__name__, color="yellow", attrs=["bold"])))
                 orig_stdout.flush()
 
                 t = o()

--- a/system/t12_api/publish.py
+++ b/system/t12_api/publish.py
@@ -283,7 +283,6 @@ class PublishUpdateAPITestRepo(APITest):
         self.check_not_exists("public/" + prefix + "dists/")
 
 
-
 class PublishConcurrentUpdateAPITestRepo(APITest):
     """
     PUT /publish/:prefix/:distribution (local repos), DELETE /publish/:prefix/:distribution

--- a/system/t12_api/tasks.py
+++ b/system/t12_api/tasks.py
@@ -20,9 +20,9 @@ class TaskAPITestParallelTasks(APITest):
         resp = self.put("/api/mirrors/" + mirror_name, json=mirror_desc, params={'_async': True})
         self.check_equal(resp.status_code, 202)
 
-        # check that two mirror updates cannot run at the same time
+        # check that two mirror updates are queuedd
         resp2 = self.put("/api/mirrors/" + mirror_name, json=mirror_desc, params={'_async': True})
-        self.check_equal(resp2.status_code, 409)
+        self.check_equal(resp2.status_code, 202)
 
         return resp.json()['ID'], mirror_name
 

--- a/task/list.go
+++ b/task/list.go
@@ -125,7 +125,7 @@ func (list *List) RunTaskInBackground(name string, resources []string, process P
 
 	tasks := list.usedResources.UsedBy(resources)
 	for len(tasks) > 0 {
-		for _, task := range(tasks) {
+		for _, task := range tasks {
 			list.Unlock()
 			list.wgTasks[task.ID].Wait()
 			list.Lock()

--- a/task/list.go
+++ b/task/list.go
@@ -56,6 +56,7 @@ func (list *List) consumer() {
 				list.Lock()
 				{
 					task.processReturnValue = retValue
+					task.err = err
 					if err != nil {
 						task.output.Printf("Task failed with error: %v", err)
 						task.State = FAILED
@@ -240,4 +241,15 @@ func (list *List) WaitForTaskByID(ID int) (Task, error) {
 
 	wgTask.Wait()
 	return list.GetTaskByID(ID)
+}
+
+// GetTaskError returns the Task error for a given id
+func (list *List) GetTaskErrorByID(ID int) (error, error) {
+	task, err := list.GetTaskByID(ID)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return task.err, nil
 }

--- a/task/list_test.go
+++ b/task/list_test.go
@@ -50,4 +50,5 @@ func (s *ListSuite) TestList(c *check.C) {
 	c.Check(detail, check.Equals, "Details")
 	_, deleteErr := list.DeleteTaskByID(task.ID)
 	c.Check(deleteErr, check.IsNil)
+        list.Stop()
 }

--- a/task/task.go
+++ b/task/task.go
@@ -47,6 +47,7 @@ type Task struct {
 	detail             *Detail
 	process            Process
 	processReturnValue *ProcessReturnValue
+	err                error
 	Name               string
 	ID                 int
 	State              State

--- a/task/task.go
+++ b/task/task.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"sync"
 	"sync/atomic"
 
 	"github.com/aptly-dev/aptly/aptly"
@@ -49,17 +50,21 @@ type Task struct {
 	Name               string
 	ID                 int
 	State              State
+	resources          []string
+	wgTask             *sync.WaitGroup
 }
 
 // NewTask creates new task
-func NewTask(process Process, name string, ID int) *Task {
+func NewTask(process Process, name string, ID int, resources []string, wgTask *sync.WaitGroup) *Task {
 	task := &Task{
-		output:  NewOutput(),
-		detail:  &Detail{},
-		process: process,
-		Name:    name,
-		ID:      ID,
-		State:   IDLE,
+		output:    NewOutput(),
+		detail:    &Detail{},
+		process:   process,
+		Name:      name,
+		ID:        ID,
+		State:     IDLE,
+		resources: resources,
+		wgTask:    wgTask,
 	}
 	return task
 }


### PR DESCRIPTION
Replaces #1261
Fixes #1276, #1125

## Description of the Change

PR Updated: synchronous and asynchronous requests are queued until the resoures become available.

This MR addresses a concurrency issue with the `api/publish` endpoint, where concurrent PUTs typically fail. The MR in it self is not pretty, so consider this initial state of the MR a starting point of discussion.
The commits are intentionally separated in order to make it as easy as possible to observe the failing test (and test it against other likely better code changes).