### PR TITLE
Check both MD5 locations for S3 KMS support.

### DIFF
--- a/s3/public.go
+++ b/s3/public.go
@@ -335,7 +335,11 @@ func (storage *PublishedStorage) LinkFromPool(publishedPrefix, publishedRelPath,
 	sourceMD5 := sourceChecksums.MD5
 
 	if exists {
-		if len(destinationMD5) != 32 {
+		if sourceMD5 == "" {
+			return fmt.Errorf("unable to compare object, MD5 checksum missing")
+		}
+
+		if len(destinationMD5) != 32 || destinationMD5 != sourceMD5 {
 			// doesn’t look like a valid MD5,
 			// attempt to fetch one from the metadata
 			var err error
@@ -346,17 +350,13 @@ func (storage *PublishedStorage) LinkFromPool(publishedPrefix, publishedRelPath,
 			}
 			storage.pathCache[relPath] = destinationMD5
 		}
-		if sourceMD5 == "" {
-			return fmt.Errorf("unable to compare object, MD5 checksum missing")
-		}
 
 		if destinationMD5 == sourceMD5 {
 			return nil
 		}
 
-		if !force && destinationMD5 != sourceMD5 {
+		if !force {
 			return fmt.Errorf("error putting file to %s: file already exists and is different: %s", poolPath, storage)
-
 		}
 	}
 

--- a/s3/public.go
+++ b/s3/public.go
@@ -106,13 +106,13 @@ func (storage *PublishedStorage) setKMSFlag() {
 	params := &s3.GetBucketEncryptionInput{
 		Bucket: aws.String(storage.bucket),
 	}
-	output, err := storage.s3.GetBucketEncryption(params)
+	output, err := storage.s3.GetBucketEncryption(context.TODO(), params)
 	if err != nil {
 		return
 	}
 
 	if len(output.ServerSideEncryptionConfiguration.Rules) > 0 &&
-		*output.ServerSideEncryptionConfiguration.Rules[0].ApplyServerSideEncryptionByDefault.SSEAlgorithm == "aws:kms" {
+		output.ServerSideEncryptionConfiguration.Rules[0].ApplyServerSideEncryptionByDefault.SSEAlgorithm == "aws:kms" {
 		storage.encryptByDefault = true
 	}
 }

--- a/s3/public_test.go
+++ b/s3/public_test.go
@@ -347,7 +347,7 @@ func (s *PublishedStorageSuite) TestLinkFromPoolCache(c *C) {
 	c.Check(err, IsNil)
 
 	// Check only one listing request was done to the server
-	s.checkGetRequestsEqual(c, "/test?", []string{"/test?list-type=2&max-keys=1000&prefix=pool%2F"})
+	s.checkGetRequestsEqual(c, "/test?", []string{"/test?encryption=", "/test?encryption=", "/test?list-type=2&max-keys=1000&prefix=pool%2F"})
 
 	s.srv.Requests = nil
 	// Publish two packages at a different prefix


### PR DESCRIPTION
Replaces #1167

Fixes https://github.com/aptly-dev/aptly/issues/1117

## Description of the Change

If the S3 bucket used to house a repo has KMS encryption enabled then the etag of an object may not match the MD5 of the file. This may cause an incorrect error to be reported stating the file already exists and is different.

A mechanism exists to work around this issue by using the MD5 stored in object metadata. This check doesn't always cover the case where KMS is enabled as the fallback is only used if the etag is not 32 characters long.

This commit changes the fallback mechanism so that it is used in any case where the object's etag is not 32 characters _or_ if the S3 bucket has encryption enabled for new objects by default.


## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [ ] author name in `AUTHORS`
