### PR TITLE
fix failing build on hosts with wildcard dns (fixes #1230)

### DIFF
--- a/http/download_test.go
+++ b/http/download_test.go
@@ -115,7 +115,7 @@ func (s *DownloaderSuite) TestDownload404(c *C) {
 }
 
 func (s *DownloaderSuite) TestDownloadConnectError(c *C) {
-	c.Assert(s.d.Download(s.ctx, "http://nosuch.host/", s.tempfile.Name()),
+	c.Assert(s.d.Download(s.ctx, "http://nosuch.host.invalid./", s.tempfile.Name()),
 		ErrorMatches, ".*no such host")
 }
 
@@ -150,7 +150,7 @@ func (s *DownloaderSuite) TestGetLength404(c *C) {
 }
 
 func (s *DownloaderSuite) TestGetLengthConnectError(c *C) {
-	_, err := s.d.GetLength(s.ctx, "http://nosuch.host/")
+	_, err := s.d.GetLength(s.ctx, "http://nosuch.host.invalid./")
 
 	c.Assert(err, ErrorMatches, ".*no such host")
 }

--- a/http/grab_test.go
+++ b/http/grab_test.go
@@ -106,7 +106,7 @@ func (s *GrabDownloaderSuite) TestDownload404(c *C) {
 }
 
 func (s *GrabDownloaderSuite) TestDownloadConnectError(c *C) {
-	c.Assert(s.d.Download(s.ctx, "http://nosuch.host/", s.tempfile.Name()),
+	c.Assert(s.d.Download(s.ctx, "http://nosuch.host.invalid./", s.tempfile.Name()),
 		ErrorMatches, ".*no such host")
 }
 
@@ -130,7 +130,7 @@ func (s *GrabDownloaderSuite) TestGetLength404(c *C) {
 }
 
 func (s *GrabDownloaderSuite) TestGetLengthConnectError(c *C) {
-	_, err := s.d.GetLength(s.ctx, "http://nosuch.host/")
+	_, err := s.d.GetLength(s.ctx, "http://nosuch.host.invalid./")
 
 	c.Assert(err, ErrorMatches, ".*no such host")
 }


### PR DESCRIPTION
Replaces #1231

on hosts which have wildcard dns domains in their local domain search list, builds failed because "nosuch.host" could actually be resolved.

Since ".host" isn't a recommended TLD by RFC2606, we use ".invalid" now. And since this is not enough to fix the problem, we use now absoulte domain names (having a '.' at the end)

Fixes #1230

## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

<!--

Why this change is important?

-->

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [ ] author name in `AUTHORS`
