### PR TITLE
Introduce option `-multi-dist` to the publish commands

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,3 +59,4 @@ List of contributors, in chronological order:
 * Paul Cacheux (https://github.com/paulcacheux)
 * Nic Waller (https://github.com/sf-nwaller)
 * iofq (https://github.com/iofq)
+* Noa Resare (https://github.com/nresare)

--- a/api/publish.go
+++ b/api/publish.go
@@ -101,6 +101,7 @@ func apiPublishRepoOrSnapshot(c *gin.Context) {
 		Architectures        []string
 		Signing              SigningOptions
 		AcquireByHash        *bool
+		MultiDist            bool
 	}
 
 	if c.Bind(&b) != nil {
@@ -226,7 +227,7 @@ func apiPublishRepoOrSnapshot(c *gin.Context) {
 			return &task.ProcessReturnValue{Code: http.StatusBadRequest, Value: nil}, fmt.Errorf("prefix/distribution already used by another published repo: %s", duplicate)
 		}
 
-		err := published.Publish(context.PackagePool(), context, collectionFactory, signer, publishOutput, b.ForceOverwrite)
+		err := published.Publish(context.PackagePool(), context, collectionFactory, signer, publishOutput, b.ForceOverwrite, b.MultiDist)
 		if err != nil {
 			return &task.ProcessReturnValue{Code: http.StatusInternalServerError, Value: nil}, fmt.Errorf("unable to publish: %s", err)
 		}
@@ -257,6 +258,7 @@ func apiPublishUpdateSwitch(c *gin.Context) {
 			Name      string `binding:"required"`
 		}
 		AcquireByHash *bool
+		MultiDist     bool
 	}
 
 	if c.Bind(&b) != nil {
@@ -341,7 +343,7 @@ func apiPublishUpdateSwitch(c *gin.Context) {
 	resources = append(resources, string(published.Key()))
 	taskName := fmt.Sprintf("Update published %s (%s): %s", published.SourceKind, strings.Join(updatedComponents, " "), strings.Join(updatedSnapshots, ", "))
 	maybeRunTaskInBackground(c, taskName, resources, func(out aptly.Progress, _ *task.Detail) (*task.ProcessReturnValue, error) {
-		err := published.Publish(context.PackagePool(), context, collectionFactory, signer, out, b.ForceOverwrite)
+		err := published.Publish(context.PackagePool(), context, collectionFactory, signer, out, b.ForceOverwrite, b.MultiDist)
 		if err != nil {
 			return &task.ProcessReturnValue{Code: http.StatusInternalServerError, Value: nil}, fmt.Errorf("unable to update: %s", err)
 		}

--- a/cmd/publish_repo.go
+++ b/cmd/publish_repo.go
@@ -51,6 +51,7 @@ Example:
 	cmd.Flag.String("codename", "", "codename to publish (defaults to distribution)")
 	cmd.Flag.Bool("force-overwrite", false, "overwrite files in package pool in case of mismatch")
 	cmd.Flag.Bool("acquire-by-hash", false, "provide index files by hash")
+	cmd.Flag.Bool("multi-dist", false, "enable multiple packages with the same filename in different distributions")
 
 	return cmd
 }

--- a/cmd/publish_snapshot.go
+++ b/cmd/publish_snapshot.go
@@ -116,6 +116,7 @@ func aptlyPublishSnapshotOrRepo(cmd *commander.Command, args []string) error {
 	origin := context.Flags().Lookup("origin").Value.String()
 	notAutomatic := context.Flags().Lookup("notautomatic").Value.String()
 	butAutomaticUpgrades := context.Flags().Lookup("butautomaticupgrades").Value.String()
+	multiDist := context.Flags().Lookup("multi-dist").Value.Get().(bool)
 
 	published, err := deb.NewPublishedRepo(storage, prefix, distribution, context.ArchitecturesList(), components, sources, collectionFactory)
 	if err != nil {
@@ -165,7 +166,7 @@ func aptlyPublishSnapshotOrRepo(cmd *commander.Command, args []string) error {
 		context.Progress().ColoredPrintf("@rWARNING@|: force overwrite mode enabled, aptly might corrupt other published repositories sharing the same package pool.\n")
 	}
 
-	err = published.Publish(context.PackagePool(), context, collectionFactory, signer, context.Progress(), forceOverwrite)
+	err = published.Publish(context.PackagePool(), context, collectionFactory, signer, context.Progress(), forceOverwrite, multiDist)
 	if err != nil {
 		return fmt.Errorf("unable to publish: %s", err)
 	}
@@ -242,6 +243,7 @@ Example:
 	cmd.Flag.String("codename", "", "codename to publish (defaults to distribution)")
 	cmd.Flag.Bool("force-overwrite", false, "overwrite files in package pool in case of mismatch")
 	cmd.Flag.Bool("acquire-by-hash", false, "provide index files by hash")
+	cmd.Flag.Bool("multi-dist", false, "enable multiple packages with the same filename in different distributions")
 
 	return cmd
 }

--- a/cmd/publish_switch.go
+++ b/cmd/publish_switch.go
@@ -14,6 +14,7 @@ func aptlyPublishSwitch(cmd *commander.Command, args []string) error {
 	var err error
 
 	components := strings.Split(context.Flags().Lookup("component").Value.String(), ",")
+	multiDist := context.Flags().Lookup("multi-dist").Value.Get().(bool)
 
 	if len(args) < len(components)+1 || len(args) > len(components)+2 {
 		cmd.Usage()
@@ -100,7 +101,7 @@ func aptlyPublishSwitch(cmd *commander.Command, args []string) error {
 		published.SkipBz2 = context.Flags().Lookup("skip-bz2").Value.Get().(bool)
 	}
 
-	err = published.Publish(context.PackagePool(), context, collectionFactory, signer, context.Progress(), forceOverwrite)
+	err = published.Publish(context.PackagePool(), context, collectionFactory, signer, context.Progress(), forceOverwrite, multiDist)
 	if err != nil {
 		return fmt.Errorf("unable to publish: %s", err)
 	}
@@ -161,6 +162,7 @@ This command would switch published repository (with one component) named ppa/wh
 	cmd.Flag.String("component", "", "component names to update (for multi-component publishing, separate components with commas)")
 	cmd.Flag.Bool("force-overwrite", false, "overwrite files in package pool in case of mismatch")
 	cmd.Flag.Bool("skip-cleanup", false, "don't remove unreferenced files in prefix/component")
+	cmd.Flag.Bool("multi-dist", false, "enable multiple packages with the same filename in different distributions")
 
 	return cmd
 }

--- a/cmd/publish_update.go
+++ b/cmd/publish_update.go
@@ -17,6 +17,7 @@ func aptlyPublishUpdate(cmd *commander.Command, args []string) error {
 
 	distribution := args[0]
 	param := "."
+	multiDist := context.Flags().Lookup("multi-dist").Value.Get().(bool)
 
 	if len(args) == 2 {
 		param = args[1]
@@ -64,7 +65,7 @@ func aptlyPublishUpdate(cmd *commander.Command, args []string) error {
 		published.SkipBz2 = context.Flags().Lookup("skip-bz2").Value.Get().(bool)
 	}
 
-	err = published.Publish(context.PackagePool(), context, collectionFactory, signer, context.Progress(), forceOverwrite)
+	err = published.Publish(context.PackagePool(), context, collectionFactory, signer, context.Progress(), forceOverwrite, multiDist)
 	if err != nil {
 		return fmt.Errorf("unable to publish: %s", err)
 	}
@@ -119,6 +120,7 @@ Example:
 	cmd.Flag.Bool("skip-bz2", false, "don't generate bzipped indexes")
 	cmd.Flag.Bool("force-overwrite", false, "overwrite files in package pool in case of mismatch")
 	cmd.Flag.Bool("skip-cleanup", false, "don't remove unreferenced files in prefix/component")
+	cmd.Flag.Bool("multi-dist", false, "enable multiple packages with the same filename in different distributions")
 
 	return cmd
 }

--- a/completion.d/aptly
+++ b/completion.d/aptly
@@ -503,7 +503,7 @@ _aptly()
           "snapshot"|"repo")
             if [[ $numargs -eq 0 ]]; then
               if [[ "$cur" == -* ]]; then
-                COMPREPLY=($(compgen -W "-acquire-by-hash -batch -butautomaticupgrades= -component= -distribution= -force-overwrite -gpg-key= -keyring= -label= -suite= -codename= -notautomatic= -origin= -passphrase= -passphrase-file= -secret-keyring= -skip-contents -skip-bz2 -skip-signing" -- ${cur}))
+                COMPREPLY=($(compgen -W "-acquire-by-hash -batch -butautomaticupgrades= -component= -distribution= -force-overwrite -gpg-key= -keyring= -label= -suite= -codename= -notautomatic= -origin= -passphrase= -passphrase-file= -secret-keyring= -skip-contents -skip-bz2 -skip-signing -multi-dist" -- ${cur}))
               else
                 if [[ "$subcmd" == "snapshot" ]]; then
                   COMPREPLY=($(compgen -W "$(__aptly_snapshot_list)" -- ${cur}))

--- a/deb/publish.go
+++ b/deb/publish.go
@@ -544,7 +544,7 @@ func (p *PublishedRepo) GetCodename() string {
 
 // Publish publishes snapshot (repository) contents, links package files, generates Packages & Release files, signs them
 func (p *PublishedRepo) Publish(packagePool aptly.PackagePool, publishedStorageProvider aptly.PublishedStorageProvider,
-	collectionFactory *CollectionFactory, signer pgp.Signer, progress aptly.Progress, forceOverwrite bool) error {
+	collectionFactory *CollectionFactory, signer pgp.Signer, progress aptly.Progress, forceOverwrite, multiDist bool) error {
 	publishedStorage := publishedStorageProvider.GetPublishedStorage(p.Storage)
 
 	err := publishedStorage.MkDir(filepath.Join(p.Prefix, "pool"))
@@ -656,7 +656,12 @@ func (p *PublishedRepo) Publish(packagePool aptly.PackagePool, publishedStorageP
 						if err2 != nil {
 							return err2
 						}
-						relPath = filepath.Join("pool", component, poolDir)
+						if multiDist {
+							relPath = filepath.Join("pool", p.Distribution, component, poolDir)
+						} else {
+							relPath = filepath.Join("pool", component, poolDir)
+						}
+
 					} else {
 						if p.Distribution == aptly.DistributionFocal {
 							relPath = filepath.Join("dists", p.Distribution, component, fmt.Sprintf("%s-%s", pkg.Name, arch), "current", "legacy-images")


### PR DESCRIPTION
This change makes it possible to publish multiple distributions with packages named the same but with different content by changing structure of the generated pool hierarchy. The option not enabled by default as this changes the structure of the output which could break the expectations of other tools.

Fixes #486 

## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

Given #486 and and [this discussion on aptly-discuss](https://groups.google.com/g/aptly-discuss/c/YTLXLUqBbFo) it seems I am not alone in using aptly to self-publish some packages for a handful different distributions and wanting to publish different packages with the same filename for different distributions. As it stands, due to aptly using the default directory structure for the `pool` hierarchy, aptly will currently fail to publish such packages.

A casual look at  the [DebianRepository/Format page](https://wiki.debian.org/DebianRepository/Format) seems to indicate that the structure of the pool hierarchy is not specified, and as long as the `Filename` field in Packages references the relevant file any structure could be used.

This change introduces a new option `-multi-dist` that will create per distribution subdirectories under `pool` such that each distribution can have its own copy of some package and need not worry about two packages with the same name but different distributions colliding.

One could argue that it would be better to change the default behaviour, rather than implementing a new option, but I feel I have limited visibility into all the implications here, so having this behaviour be enabled on an opt-in basis seems the choice with less risk of functionality regressions. This change can also have storage efficiency implications, so having it be optional seems preferable for that reason as well.

## Checklist

- [x] unit-test added (if change is algorithm)
- [x] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [x] bash completion updated (if applicable)
- [ ] documentation updated
- [x] author name in `AUTHORS`
