### PR TITLE
Fix/mirror download already downloaded

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -155,7 +155,7 @@ func maybeRunTaskInBackground(c *gin.Context, name string, resources []string, p
 	// Run this task in background if configured globally or per-request
 	background := truthy(c.DefaultQuery("_async", strconv.FormatBool(context.Config().AsyncAPI)))
 	if background {
-		log.Info().Msg("Executing task asynchronously")
+		log.Debug().Msg("Executing task asynchronously")
 		task, conflictErr := runTaskInBackground(name, resources, proc)
 		if conflictErr != nil {
 			AbortWithJSONError(c, 409, conflictErr)
@@ -163,7 +163,7 @@ func maybeRunTaskInBackground(c *gin.Context, name string, resources []string, p
 		}
 		c.JSON(202, task)
 	} else {
-		log.Info().Msg("Executing task synchronously")
+		log.Debug().Msg("Executing task synchronously")
 		out := context.Progress()
 		detail := task.Detail{}
 		retValue, err := proc(out, &detail)


### PR DESCRIPTION
Fixes  #1194

might fix #1289 ?

## Description of the Change

    mirror: do not download already downloaded packages
    
    this change imports downloaded packages into the pool immediately after download.
    in case mirroring is aborted and later resumed, already downloaded packages will not be downloaded anymore.


## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [ ] author name in `AUTHORS`
