### PR TITLE
Enable SkipArchitectureCheck and IgnoreSignatures in mirror API

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -58,3 +58,4 @@ List of contributors, in chronological order:
 * Ryan Gonzalez (https://github.com/refi64)
 * Paul Cacheux (https://github.com/paulcacheux)
 * Nic Waller (https://github.com/sf-nwaller)
+* iofq (https://github.com/iofq)

--- a/api/mirror.go
+++ b/api/mirror.go
@@ -52,19 +52,20 @@ func apiMirrorsList(c *gin.Context) {
 func apiMirrorsCreate(c *gin.Context) {
 	var err error
 	var b struct {
-		Name               string `binding:"required"`
-		ArchiveURL         string `binding:"required"`
-		Distribution       string
-		Filter             string
-		Components         []string
-		Architectures      []string
-		Keyrings           []string
-		DownloadSources    bool
-		DownloadUdebs      bool
-		DownloadInstaller  bool
-		FilterWithDeps     bool
-		SkipComponentCheck bool
-		IgnoreSignatures   bool
+		Name                  string `binding:"required"`
+		ArchiveURL            string `binding:"required"`
+		Distribution          string
+		Filter                string
+		Components            []string
+		Architectures         []string
+		Keyrings              []string
+		DownloadSources       bool
+		DownloadUdebs         bool
+		DownloadInstaller     bool
+		FilterWithDeps        bool
+		SkipComponentCheck    bool
+		SkipArchitectureCheck bool
+		IgnoreSignatures      bool
 	}
 
 	b.DownloadSources = context.Config().DownloadSourcePackages
@@ -105,6 +106,7 @@ func apiMirrorsCreate(c *gin.Context) {
 	repo.Filter = b.Filter
 	repo.FilterWithDeps = b.FilterWithDeps
 	repo.SkipComponentCheck = b.SkipComponentCheck
+	repo.SkipArchitectureCheck = b.SkipArchitectureCheck
 	repo.DownloadSources = b.DownloadSources
 	repo.DownloadUdebs = b.DownloadUdebs
 
@@ -275,20 +277,21 @@ func apiMirrorsUpdate(c *gin.Context) {
 	)
 
 	var b struct {
-		Name                 string
-		ArchiveURL           string
-		Filter               string
-		Architectures        []string
-		Components           []string
-		Keyrings             []string
-		FilterWithDeps       bool
-		DownloadSources      bool
-		DownloadUdebs        bool
-		SkipComponentCheck   bool
-		IgnoreChecksums      bool
-		IgnoreSignatures     bool
-		ForceUpdate          bool
-		SkipExistingPackages bool
+		Name                  string
+		ArchiveURL            string
+		Filter                string
+		Architectures         []string
+		Components            []string
+		Keyrings              []string
+		FilterWithDeps        bool
+		DownloadSources       bool
+		DownloadUdebs         bool
+		SkipComponentCheck    bool
+		SkipArchitectureCheck bool
+		IgnoreChecksums       bool
+		IgnoreSignatures      bool
+		ForceUpdate           bool
+		SkipExistingPackages  bool
 	}
 
 	collectionFactory := context.NewCollectionFactory()
@@ -304,10 +307,13 @@ func apiMirrorsUpdate(c *gin.Context) {
 	b.DownloadUdebs = remote.DownloadUdebs
 	b.DownloadSources = remote.DownloadSources
 	b.SkipComponentCheck = remote.SkipComponentCheck
+	b.SkipArchitectureCheck = remote.SkipArchitectureCheck
 	b.FilterWithDeps = remote.FilterWithDeps
 	b.Filter = remote.Filter
 	b.Architectures = remote.Architectures
 	b.Components = remote.Components
+
+	b.IgnoreSignatures = context.Config().GpgDisableVerify
 
 	log.Info().Msgf("%s: Starting mirror update\n", b.Name)
 
@@ -338,6 +344,7 @@ func apiMirrorsUpdate(c *gin.Context) {
 	remote.DownloadUdebs = b.DownloadUdebs
 	remote.DownloadSources = b.DownloadSources
 	remote.SkipComponentCheck = b.SkipComponentCheck
+	remote.SkipArchitectureCheck = b.SkipArchitectureCheck
 	remote.FilterWithDeps = b.FilterWithDeps
 	remote.Filter = b.Filter
 	remote.Architectures = b.Architectures


### PR DESCRIPTION
Fixes #

The command line flags `-force-architectures` and `-ignore-signatures` are not consistently implemented in the mirror API like they are in the mirror CLI. Discovered because the example repo I'm attempting to use, `https://pkg.duosecurity.com/Ubuntu`, is non-standard and breaks without these specified.

## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

`SkipArchitectureCheck` and `IgnoreSignatures` are implemented as params for the create/POST and update/PUT handlers under `/api/mirrors`. 

Did not implement unit tests as there doesn't appear to be a good harness for mocking downloads.

Updating functional tests would be nice, seems we can add to https://github.com/aptly-dev/aptly/blob/master/system/t12_api/mirrors.py if we potentially upload some system test files first. Would need some guidance to get started on that if desired. 

## Checklist

- [x] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [x] man page updated (if applicable)
- [x] bash completion updated (if applicable)
- [ ] documentation updated - See [Merge Request](https://github.com/aptly-dev/www.aptly.info/pull/109)
- [x] author name in `AUTHORS`
