### PR TITLE
fix ignoring signatures on remote repos with only InRelease file

### DIFF
--- a/api/mirror.go
+++ b/api/mirror.go
@@ -23,7 +23,7 @@ func getVerifier(keyRings []string) (pgp.Verifier, error) {
 		verifier.AddKeyring(keyRing)
 	}
 
-	err := verifier.InitKeyring()
+	err := verifier.InitKeyring(false)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -10,13 +10,17 @@ import (
 
 func getVerifier(flags *flag.FlagSet) (pgp.Verifier, error) {
 	keyRings := flags.Lookup("keyring").Value.Get().([]string)
+        ignoreSignatures := context.Config().GpgDisableVerify
+	if context.Flags().IsSet("ignore-signatures") {
+		ignoreSignatures = context.Flags().Lookup("ignore-signatures").Value.Get().(bool)
+	}
 
 	verifier := context.GetVerifier()
 	for _, keyRing := range keyRings {
 		verifier.AddKeyring(keyRing)
 	}
 
-	err := verifier.InitKeyring()
+	err := verifier.InitKeyring(ignoreSignatures == false)  // be verbose only if verifying signatures is requested
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -10,7 +10,7 @@ import (
 
 func getVerifier(flags *flag.FlagSet) (pgp.Verifier, error) {
 	keyRings := flags.Lookup("keyring").Value.Get().([]string)
-        ignoreSignatures := context.Config().GpgDisableVerify
+	ignoreSignatures := context.Config().GpgDisableVerify
 	if context.Flags().IsSet("ignore-signatures") {
 		ignoreSignatures = context.Flags().Lookup("ignore-signatures").Value.Get().(bool)
 	}
@@ -20,7 +20,7 @@ func getVerifier(flags *flag.FlagSet) (pgp.Verifier, error) {
 		verifier.AddKeyring(keyRing)
 	}
 
-	err := verifier.InitKeyring(ignoreSignatures == false)  // be verbose only if verifying signatures is requested
+	err := verifier.InitKeyring(ignoreSignatures == false) // be verbose only if verifying signatures is requested
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -9,10 +9,6 @@ import (
 )
 
 func getVerifier(flags *flag.FlagSet) (pgp.Verifier, error) {
-	if LookupOption(context.Config().GpgDisableVerify, flags, "ignore-signatures") {
-		return nil, nil
-	}
-
 	keyRings := flags.Lookup("keyring").Value.Get().([]string)
 
 	verifier := context.GetVerifier()

--- a/cmd/mirror_create.go
+++ b/cmd/mirror_create.go
@@ -20,6 +20,7 @@ func aptlyMirrorCreate(cmd *commander.Command, args []string) error {
 	downloadSources := LookupOption(context.Config().DownloadSourcePackages, context.Flags(), "with-sources")
 	downloadUdebs := context.Flags().Lookup("with-udebs").Value.Get().(bool)
 	downloadInstaller := context.Flags().Lookup("with-installer").Value.Get().(bool)
+	ignoreSignatures := context.Flags().Lookup("ignore-signatures").Value.Get().(bool)
 
 	var (
 		mirrorName, archiveURL, distribution string
@@ -59,7 +60,7 @@ func aptlyMirrorCreate(cmd *commander.Command, args []string) error {
 		return fmt.Errorf("unable to initialize GPG verifier: %s", err)
 	}
 
-	err = repo.Fetch(context.Downloader(), verifier)
+	err = repo.Fetch(context.Downloader(), verifier, ignoreSignatures)
 	if err != nil {
 		return fmt.Errorf("unable to fetch mirror: %s", err)
 	}

--- a/cmd/mirror_create.go
+++ b/cmd/mirror_create.go
@@ -20,7 +20,7 @@ func aptlyMirrorCreate(cmd *commander.Command, args []string) error {
 	downloadSources := LookupOption(context.Config().DownloadSourcePackages, context.Flags(), "with-sources")
 	downloadUdebs := context.Flags().Lookup("with-udebs").Value.Get().(bool)
 	downloadInstaller := context.Flags().Lookup("with-installer").Value.Get().(bool)
-        ignoreSignatures := context.Config().GpgDisableVerify
+	ignoreSignatures := context.Config().GpgDisableVerify
 	if context.Flags().IsSet("ignore-signatures") {
 		ignoreSignatures = context.Flags().Lookup("ignore-signatures").Value.Get().(bool)
 	}

--- a/cmd/mirror_create.go
+++ b/cmd/mirror_create.go
@@ -20,7 +20,10 @@ func aptlyMirrorCreate(cmd *commander.Command, args []string) error {
 	downloadSources := LookupOption(context.Config().DownloadSourcePackages, context.Flags(), "with-sources")
 	downloadUdebs := context.Flags().Lookup("with-udebs").Value.Get().(bool)
 	downloadInstaller := context.Flags().Lookup("with-installer").Value.Get().(bool)
-	ignoreSignatures := context.Flags().Lookup("ignore-signatures").Value.Get().(bool)
+        ignoreSignatures := context.Config().GpgDisableVerify
+	if context.Flags().IsSet("ignore-signatures") {
+		ignoreSignatures = context.Flags().Lookup("ignore-signatures").Value.Get().(bool)
+	}
 
 	var (
 		mirrorName, archiveURL, distribution string

--- a/cmd/mirror_edit.go
+++ b/cmd/mirror_edit.go
@@ -28,7 +28,7 @@ func aptlyMirrorEdit(cmd *commander.Command, args []string) error {
 	}
 
 	fetchMirror := false
-        ignoreSignatures := true
+        ignoreSignatures := context.Config().GpgDisableVerify
 	context.Flags().Visit(func(flag *flag.Flag) {
 		switch flag.Name {
 		case "filter":

--- a/cmd/mirror_edit.go
+++ b/cmd/mirror_edit.go
@@ -28,6 +28,7 @@ func aptlyMirrorEdit(cmd *commander.Command, args []string) error {
 	}
 
 	fetchMirror := false
+        ignoreSignatures := true
 	context.Flags().Visit(func(flag *flag.Flag) {
 		switch flag.Name {
 		case "filter":
@@ -43,6 +44,8 @@ func aptlyMirrorEdit(cmd *commander.Command, args []string) error {
 		case "archive-url":
 			repo.SetArchiveRoot(flag.Value.String())
 			fetchMirror = true
+		case "ignore-signatures":
+	                ignoreSignatures = true
 		}
 	})
 
@@ -69,7 +72,7 @@ func aptlyMirrorEdit(cmd *commander.Command, args []string) error {
 			return fmt.Errorf("unable to initialize GPG verifier: %s", err)
 		}
 
-		err = repo.Fetch(context.Downloader(), verifier)
+		err = repo.Fetch(context.Downloader(), verifier, ignoreSignatures)
 		if err != nil {
 			return fmt.Errorf("unable to edit: %s", err)
 		}

--- a/cmd/mirror_edit.go
+++ b/cmd/mirror_edit.go
@@ -28,7 +28,7 @@ func aptlyMirrorEdit(cmd *commander.Command, args []string) error {
 	}
 
 	fetchMirror := false
-        ignoreSignatures := context.Config().GpgDisableVerify
+	ignoreSignatures := context.Config().GpgDisableVerify
 	context.Flags().Visit(func(flag *flag.Flag) {
 		switch flag.Name {
 		case "filter":
@@ -45,7 +45,7 @@ func aptlyMirrorEdit(cmd *commander.Command, args []string) error {
 			repo.SetArchiveRoot(flag.Value.String())
 			fetchMirror = true
 		case "ignore-signatures":
-	                ignoreSignatures = true
+			ignoreSignatures = true
 		}
 	})
 

--- a/cmd/mirror_update.go
+++ b/cmd/mirror_update.go
@@ -42,20 +42,21 @@ func aptlyMirrorUpdate(cmd *commander.Command, args []string) error {
 		}
 	}
 
-	ignoreMismatch := context.Flags().Lookup("ignore-checksums").Value.Get().(bool)
+	ignoreSignatures := context.Flags().Lookup("ignore-signatures").Value.Get().(bool)
+	ignoreChecksums := context.Flags().Lookup("ignore-checksums").Value.Get().(bool)
 
 	verifier, err := getVerifier(context.Flags())
 	if err != nil {
 		return fmt.Errorf("unable to initialize GPG verifier: %s", err)
 	}
 
-	err = repo.Fetch(context.Downloader(), verifier)
+	err = repo.Fetch(context.Downloader(), verifier, ignoreSignatures)
 	if err != nil {
 		return fmt.Errorf("unable to update: %s", err)
 	}
 
 	context.Progress().Printf("Downloading & parsing package files...\n")
-	err = repo.DownloadPackageIndexes(context.Progress(), context.Downloader(), verifier, collectionFactory, ignoreMismatch)
+        err = repo.DownloadPackageIndexes(context.Progress(), context.Downloader(), verifier, collectionFactory, ignoreSignatures, ignoreChecksums)
 	if err != nil {
 		return fmt.Errorf("unable to update: %s", err)
 	}
@@ -183,7 +184,7 @@ func aptlyMirrorUpdate(cmd *commander.Command, args []string) error {
 						repo.PackageURL(task.File.DownloadURL()).String(),
 						task.TempDownPath,
 						&task.File.Checksums,
-						ignoreMismatch)
+						ignoreChecksums)
 					if e != nil {
 						pushError(e)
 						continue

--- a/cmd/mirror_update.go
+++ b/cmd/mirror_update.go
@@ -42,7 +42,7 @@ func aptlyMirrorUpdate(cmd *commander.Command, args []string) error {
 		}
 	}
 
-        ignoreSignatures := context.Config().GpgDisableVerify
+	ignoreSignatures := context.Config().GpgDisableVerify
 	if context.Flags().IsSet("ignore-signatures") {
 		ignoreSignatures = context.Flags().Lookup("ignore-signatures").Value.Get().(bool)
 	}
@@ -59,7 +59,7 @@ func aptlyMirrorUpdate(cmd *commander.Command, args []string) error {
 	}
 
 	context.Progress().Printf("Downloading & parsing package files...\n")
-        err = repo.DownloadPackageIndexes(context.Progress(), context.Downloader(), verifier, collectionFactory, ignoreSignatures, ignoreChecksums)
+	err = repo.DownloadPackageIndexes(context.Progress(), context.Downloader(), verifier, collectionFactory, ignoreSignatures, ignoreChecksums)
 	if err != nil {
 		return fmt.Errorf("unable to update: %s", err)
 	}

--- a/cmd/mirror_update.go
+++ b/cmd/mirror_update.go
@@ -42,7 +42,10 @@ func aptlyMirrorUpdate(cmd *commander.Command, args []string) error {
 		}
 	}
 
-	ignoreSignatures := context.Flags().Lookup("ignore-signatures").Value.Get().(bool)
+        ignoreSignatures := context.Config().GpgDisableVerify
+	if context.Flags().IsSet("ignore-signatures") {
+		ignoreSignatures = context.Flags().Lookup("ignore-signatures").Value.Get().(bool)
+	}
 	ignoreChecksums := context.Flags().Lookup("ignore-checksums").Value.Get().(bool)
 
 	verifier, err := getVerifier(context.Flags())

--- a/cmd/repo_include.go
+++ b/cmd/repo_include.go
@@ -29,7 +29,10 @@ func aptlyRepoInclude(cmd *commander.Command, args []string) error {
 
 	forceReplace := context.Flags().Lookup("force-replace").Value.Get().(bool)
 	acceptUnsigned := context.Flags().Lookup("accept-unsigned").Value.Get().(bool)
-	ignoreSignatures := context.Flags().Lookup("ignore-signatures").Value.Get().(bool)
+        ignoreSignatures := context.Config().GpgDisableVerify
+	if context.Flags().IsSet("ignore-signatures") {
+		ignoreSignatures = context.Flags().Lookup("ignore-signatures").Value.Get().(bool)
+	}
 	noRemoveFiles := context.Flags().Lookup("no-remove-files").Value.Get().(bool)
 	repoTemplateString := context.Flags().Lookup("repo").Value.Get().(string)
 	collectionFactory := context.NewCollectionFactory()

--- a/cmd/repo_include.go
+++ b/cmd/repo_include.go
@@ -29,7 +29,7 @@ func aptlyRepoInclude(cmd *commander.Command, args []string) error {
 
 	forceReplace := context.Flags().Lookup("force-replace").Value.Get().(bool)
 	acceptUnsigned := context.Flags().Lookup("accept-unsigned").Value.Get().(bool)
-        ignoreSignatures := context.Config().GpgDisableVerify
+	ignoreSignatures := context.Config().GpgDisableVerify
 	if context.Flags().IsSet("ignore-signatures") {
 		ignoreSignatures = context.Flags().Lookup("ignore-signatures").Value.Get().(bool)
 	}

--- a/deb/remote.go
+++ b/deb/remote.go
@@ -288,14 +288,14 @@ func (repo *RemoteRepo) Fetch(d aptly.Downloader, verifier pgp.Verifier, ignoreS
 			if err != nil {
 				return err
 			}
-                        if verifier == nil {
-                            return fmt.Errorf("no verifier specified")
-                        }
-                        release, err = verifier.ExtractClearsigned(inrelease)
+			if verifier == nil {
+				return fmt.Errorf("no verifier specified")
+			}
+			release, err = verifier.ExtractClearsigned(inrelease)
 			if err != nil {
 				return err
 			}
-                        goto ok
+			goto ok
 		}
 	} else {
 		// 1. try InRelease file

--- a/deb/remote_test.go
+++ b/deb/remote_test.go
@@ -21,7 +21,7 @@ import (
 type NullVerifier struct {
 }
 
-func (n *NullVerifier) InitKeyring() error {
+func (n *NullVerifier) InitKeyring(_ bool) error {
 	return nil
 }
 

--- a/deb/remote_test.go
+++ b/deb/remote_test.go
@@ -197,7 +197,7 @@ func (s *RemoteRepoSuite) TestPackageURL(c *C) {
 }
 
 func (s *RemoteRepoSuite) TestFetch(c *C) {
-	err := s.repo.Fetch(s.downloader, nil, false)
+	err := s.repo.Fetch(s.downloader, nil, true)
 	c.Assert(err, IsNil)
 	c.Assert(s.repo.Architectures, DeepEquals, []string{"amd64", "armel", "armhf", "i386", "powerpc"})
 	c.Assert(s.repo.Components, DeepEquals, []string{"main"})
@@ -218,7 +218,7 @@ func (s *RemoteRepoSuite) TestFetchNullVerifier1(c *C) {
 	downloader.ExpectResponse("http://mirror.yandex.ru/debian/dists/squeeze/Release", exampleReleaseFile)
 	downloader.ExpectResponse("http://mirror.yandex.ru/debian/dists/squeeze/Release.gpg", "GPG")
 
-	err := s.repo.Fetch(downloader, &NullVerifier{}, true)
+	err := s.repo.Fetch(downloader, &NullVerifier{}, false)
 	c.Assert(err, IsNil)
 	c.Assert(s.repo.Architectures, DeepEquals, []string{"amd64", "armel", "armhf", "i386", "powerpc"})
 	c.Assert(s.repo.Components, DeepEquals, []string{"main"})
@@ -229,7 +229,7 @@ func (s *RemoteRepoSuite) TestFetchNullVerifier2(c *C) {
 	downloader := http.NewFakeDownloader()
 	downloader.ExpectResponse("http://mirror.yandex.ru/debian/dists/squeeze/InRelease", exampleReleaseFile)
 
-	err := s.repo.Fetch(downloader, &NullVerifier{}, true)
+	err := s.repo.Fetch(downloader, &NullVerifier{}, false)
 	c.Assert(err, IsNil)
 	c.Assert(s.repo.Architectures, DeepEquals, []string{"amd64", "armel", "armhf", "i386", "powerpc"})
 	c.Assert(s.repo.Components, DeepEquals, []string{"main"})
@@ -244,7 +244,7 @@ func (s *RemoteRepoSuite) TestFetchWrongArchitecture(c *C) {
 
 func (s *RemoteRepoSuite) TestFetchWrongComponent(c *C) {
 	s.repo, _ = NewRemoteRepo("s", "http://mirror.yandex.ru/debian/", "squeeze", []string{"xyz"}, []string{"i386"}, false, false, false)
-	err := s.repo.Fetch(s.downloader, nil, false)
+	err := s.repo.Fetch(s.downloader, nil, true)
 	c.Assert(err, ErrorMatches, "component xyz not available in repo.*")
 }
 
@@ -271,14 +271,14 @@ func (s *RemoteRepoSuite) TestRefKey(c *C) {
 func (s *RemoteRepoSuite) TestDownload(c *C) {
 	s.repo.Architectures = []string{"i386"}
 
-	err := s.repo.Fetch(s.downloader, nil, false)
+	err := s.repo.Fetch(s.downloader, nil, true)
 	c.Assert(err, IsNil)
 
 	s.downloader.ExpectError("http://mirror.yandex.ru/debian/dists/squeeze/main/binary-i386/Packages.bz2", &http.Error{Code: 404})
 	s.downloader.ExpectError("http://mirror.yandex.ru/debian/dists/squeeze/main/binary-i386/Packages.gz", &http.Error{Code: 404})
 	s.downloader.ExpectResponse("http://mirror.yandex.ru/debian/dists/squeeze/main/binary-i386/Packages", examplePackagesFile)
 
-	err = s.repo.DownloadPackageIndexes(s.progress, s.downloader, nil, s.collectionFactory, false, true)
+	err = s.repo.DownloadPackageIndexes(s.progress, s.downloader, nil, s.collectionFactory, true, false)
 	c.Assert(err, IsNil)
 	c.Assert(s.downloader.Empty(), Equals, true)
 
@@ -305,7 +305,7 @@ func (s *RemoteRepoSuite) TestDownload(c *C) {
 	s.downloader.ExpectError("http://mirror.yandex.ru/debian/dists/squeeze/main/binary-i386/Packages.gz", &http.Error{Code: 404})
 	s.downloader.ExpectResponse("http://mirror.yandex.ru/debian/dists/squeeze/main/binary-i386/Packages", examplePackagesFile)
 
-	err = s.repo.DownloadPackageIndexes(s.progress, s.downloader, nil, s.collectionFactory, false, true)
+	err = s.repo.DownloadPackageIndexes(s.progress, s.downloader, nil, s.collectionFactory, true, false)
 	c.Assert(err, IsNil)
 	c.Assert(s.downloader.Empty(), Equals, true)
 
@@ -326,7 +326,7 @@ func (s *RemoteRepoSuite) TestDownload(c *C) {
 	s.downloader.ExpectError("http://mirror.yandex.ru/debian/dists/squeeze/main/binary-i386/Packages.gz", &http.Error{Code: 404})
 	s.downloader.ExpectResponse("http://mirror.yandex.ru/debian/dists/squeeze/main/binary-i386/Packages", examplePackagesFile)
 
-	err = s.repo.DownloadPackageIndexes(s.progress, s.downloader, nil, s.collectionFactory, false, true)
+	err = s.repo.DownloadPackageIndexes(s.progress, s.downloader, nil, s.collectionFactory, true, false)
 	c.Assert(err, IsNil)
 	c.Assert(s.downloader.Empty(), Equals, true)
 
@@ -353,7 +353,7 @@ func (s *RemoteRepoSuite) TestDownloadWithInstaller(c *C) {
 	s.downloader.ExpectResponse("http://mirror.yandex.ru/debian/dists/squeeze/main/installer-i386/current/images/SHA256SUMS", exampleInstallerHashSumFile)
 	s.downloader.ExpectResponse("http://mirror.yandex.ru/debian/dists/squeeze/main/installer-i386/current/images/MANIFEST", exampleInstallerManifestFile)
 
-	err = s.repo.DownloadPackageIndexes(s.progress, s.downloader, nil, s.collectionFactory, false, true)
+	err = s.repo.DownloadPackageIndexes(s.progress, s.downloader, nil, s.collectionFactory, true, false)
 	c.Assert(err, IsNil)
 	c.Assert(s.downloader.Empty(), Equals, true)
 
@@ -397,7 +397,7 @@ func (s *RemoteRepoSuite) TestDownloadWithSources(c *C) {
 	s.downloader.ExpectError("http://mirror.yandex.ru/debian/dists/squeeze/main/source/Sources.gz", &http.Error{Code: 404})
 	s.downloader.ExpectResponse("http://mirror.yandex.ru/debian/dists/squeeze/main/source/Sources", exampleSourcesFile)
 
-	err = s.repo.DownloadPackageIndexes(s.progress, s.downloader, nil, s.collectionFactory, false, true)
+	err = s.repo.DownloadPackageIndexes(s.progress, s.downloader, nil, s.collectionFactory, true, false)
 	c.Assert(err, IsNil)
 	c.Assert(s.downloader.Empty(), Equals, true)
 
@@ -441,7 +441,7 @@ func (s *RemoteRepoSuite) TestDownloadWithSources(c *C) {
 	s.downloader.ExpectError("http://mirror.yandex.ru/debian/dists/squeeze/main/source/Sources.gz", &http.Error{Code: 404})
 	s.downloader.ExpectResponse("http://mirror.yandex.ru/debian/dists/squeeze/main/source/Sources", exampleSourcesFile)
 
-	err = s.repo.DownloadPackageIndexes(s.progress, s.downloader, nil, s.collectionFactory, false, true)
+	err = s.repo.DownloadPackageIndexes(s.progress, s.downloader, nil, s.collectionFactory, true, false)
 	c.Assert(err, IsNil)
 	c.Assert(s.downloader.Empty(), Equals, true)
 
@@ -466,7 +466,7 @@ func (s *RemoteRepoSuite) TestDownloadWithSources(c *C) {
 	s.downloader.ExpectError("http://mirror.yandex.ru/debian/dists/squeeze/main/source/Sources.gz", &http.Error{Code: 404})
 	s.downloader.ExpectResponse("http://mirror.yandex.ru/debian/dists/squeeze/main/source/Sources", exampleSourcesFile)
 
-	err = s.repo.DownloadPackageIndexes(s.progress, s.downloader, nil, s.collectionFactory, false, true)
+	err = s.repo.DownloadPackageIndexes(s.progress, s.downloader, nil, s.collectionFactory, true, false)
 	c.Assert(err, IsNil)
 	c.Assert(s.downloader.Empty(), Equals, true)
 

--- a/pgp/gnupg.go
+++ b/pgp/gnupg.go
@@ -163,8 +163,8 @@ func NewGpgVerifier(finder GPGFinder) *GpgVerifier {
 }
 
 // InitKeyring verifies that gpg is installed and some keys are trusted
-func (g *GpgVerifier) InitKeyring() error {
-	if len(g.keyRings) == 0 {
+func (g *GpgVerifier) InitKeyring(verbose bool) error {
+	if len(g.keyRings) == 0 && verbose {
 		// using default keyring
 		output, err := exec.Command(g.gpg, "--no-default-keyring", "--no-auto-check-trustdb", "--keyring", "trustedkeys.gpg", "--list-keys").Output()
 		if err == nil && len(output) == 0 {

--- a/pgp/gnupg_test.go
+++ b/pgp/gnupg_test.go
@@ -94,7 +94,7 @@ func (s *Gnupg1VerifierSuite) SetUpTest(c *C) {
 	s.verifier = NewGpgVerifier(finder)
 	s.verifier.AddKeyring("./trusted.gpg")
 
-	c.Assert(s.verifier.InitKeyring(), IsNil)
+	c.Assert(s.verifier.InitKeyring(false), IsNil)
 }
 
 type Gnupg1SignerSuite struct {
@@ -122,7 +122,7 @@ func (s *Gnupg1SignerSuite) SetUpTest(c *C) {
 	s.verifier.AddKeyring("./keyrings/aptly.pub")
 	s.verifier.AddKeyring("./keyrings/aptly_passphrase.pub")
 
-	c.Assert(s.verifier.InitKeyring(), IsNil)
+	c.Assert(s.verifier.InitKeyring(false), IsNil)
 
 	s.SignerSuite.SetUpTest(c)
 }
@@ -143,7 +143,7 @@ func (s *Gnupg2VerifierSuite) SetUpTest(c *C) {
 	s.verifier = NewGpgVerifier(finder)
 	s.verifier.AddKeyring("./trusted.gpg")
 
-	c.Assert(s.verifier.InitKeyring(), IsNil)
+	c.Assert(s.verifier.InitKeyring(false), IsNil)
 }
 
 type Gnupg2SignerSuite struct {
@@ -210,7 +210,7 @@ func (s *Gnupg2SignerSuite) SetUpTest(c *C) {
 	s.verifier = &GoVerifier{}
 	s.verifier.AddKeyring("./keyrings/aptly2_trusted.pub")
 
-	c.Assert(s.verifier.InitKeyring(), IsNil)
+	c.Assert(s.verifier.InitKeyring(false), IsNil)
 
 	s.skipDefaultKey = true
 

--- a/pgp/internal.go
+++ b/pgp/internal.go
@@ -283,7 +283,7 @@ type GoVerifier struct {
 }
 
 // InitKeyring verifies that gpg is installed and some keys are trusted
-func (g *GoVerifier) InitKeyring() error {
+func (g *GoVerifier) InitKeyring(verbose bool) error {
 	var err error
 
 	if len(g.keyRingFiles) == 0 {
@@ -304,7 +304,7 @@ func (g *GoVerifier) InitKeyring() error {
 		}
 	}
 
-	if len(g.trustedKeyring) == 0 {
+	if len(g.trustedKeyring) == 0 && verbose {
 		fmt.Printf("\nLooks like your keyring with trusted keys is empty. You might consider importing some keys.\n")
 		if len(g.keyRingFiles) == 0 {
 			// using default keyring

--- a/pgp/internal_test.go
+++ b/pgp/internal_test.go
@@ -14,7 +14,7 @@ func (s *GoVerifierSuite) SetUpTest(c *C) {
 	s.verifier = &GoVerifier{}
 	s.verifier.AddKeyring("./trusted.gpg")
 
-	c.Assert(s.verifier.InitKeyring(), IsNil)
+	c.Assert(s.verifier.InitKeyring(false), IsNil)
 }
 
 type GoSignerSuite struct {
@@ -36,7 +36,7 @@ func (s *GoSignerSuite) SetUpTest(c *C) {
 	s.verifier.AddKeyring("./keyrings/aptly.pub")
 	s.verifier.AddKeyring("./keyrings/aptly_passphrase.pub")
 
-	c.Assert(s.verifier.InitKeyring(), IsNil)
+	c.Assert(s.verifier.InitKeyring(false), IsNil)
 
 	s.SignerSuite.SetUpTest(c)
 }

--- a/pgp/pgp.go
+++ b/pgp/pgp.go
@@ -51,7 +51,7 @@ type Signer interface {
 
 // Verifier interface describes signature verification factility
 type Verifier interface {
-	InitKeyring() error
+	InitKeyring(verbose bool) error
 	AddKeyring(keyring string)
 	VerifyDetachedSignature(signature, cleartext io.Reader, showKeyTip bool) error
 	IsClearSigned(clearsigned io.Reader) (bool, error)

--- a/system/t04_mirror/CreateMirror33Test_gold
+++ b/system/t04_mirror/CreateMirror33Test_gold
@@ -1,0 +1,8 @@
+Downloading: http://repo.aptly.info/system-tests/nvidia.github.io/libnvidia-container/stable/ubuntu16.04/amd64/Release
+Error (retrying): HTTP code 404 while fetching http://repo.aptly.info/system-tests/nvidia.github.io/libnvidia-container/stable/ubuntu16.04/amd64/Release
+Retrying 0 http://repo.aptly.info/system-tests/nvidia.github.io/libnvidia-container/stable/ubuntu16.04/amd64/Release...
+Download Error: http://repo.aptly.info/system-tests/nvidia.github.io/libnvidia-container/stable/ubuntu16.04/amd64/Release
+Downloading: http://repo.aptly.info/system-tests/nvidia.github.io/libnvidia-container/stable/ubuntu16.04/amd64/InRelease
+
+Mirror [mirror33]: http://repo.aptly.info/system-tests/nvidia.github.io/libnvidia-container/stable/ubuntu16.04/amd64/ ./ successfully added.
+You can run 'aptly mirror update mirror33' to download repository contents.

--- a/system/t04_mirror/CreateMirror33Test_mirror_show
+++ b/system/t04_mirror/CreateMirror33Test_mirror_show
@@ -1,0 +1,20 @@
+Name: mirror33
+Archive Root URL: http://repo.aptly.info/system-tests/nvidia.github.io/libnvidia-container/stable/ubuntu16.04/amd64/
+Distribution: ./
+Components: 
+Architectures: 
+Download Sources: no
+Download .udebs: no
+Last update: never
+
+Information from release file:
+Architectures: amd64
+Codename: xenial
+Components: main
+Date: Wed, 27 Sep 2017 23:08:53 +0000
+Description:  NVIDIA container runtime library repository
+
+Label: NVIDIA CORPORATION <cudatools@nvidia.com>
+Origin: https://nvidia.github.io/libnvidia-container
+Suite: xenial
+Version: 1.0

--- a/system/t04_mirror/create.py
+++ b/system/t04_mirror/create.py
@@ -436,3 +436,17 @@ class CreateMirror32Test(BaseTest):
     def check(self):
         self.check_output()
         self.check_cmd_output("aptly mirror show mirror32", "mirror_show")
+
+
+class CreateMirror33Test(BaseTest):
+    """
+    create mirror: repo with only InRelease file but no verification
+    """
+    configOverride = {"max-tries": 1}
+    runCmd = "aptly mirror create -ignore-signatures mirror33 http://repo.aptly.info/system-tests/nvidia.github.io/libnvidia-container/stable/ubuntu16.04/amd64 ./"
+    fixtureGpg = False
+    requiresGPG2 = False
+
+    def check(self):
+        self.check_output()
+        self.check_cmd_output("aptly mirror show mirror33", "mirror_show")


### PR DESCRIPTION
Fixes #237

## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

If a remote repo has only InRelease but no Release file, aptly is not able to mirror it, even when -ignore-signatures is specified.

This change fixes this behavior, by trying to download the InRelease if Release file is not found, and strips and ignores the signature.

## Checklist

- [ ] functional test added/updated (if change is functional)

