### PR TITLE
Fix broken MD5 hash cache.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -63,3 +63,4 @@ List of contributors, in chronological order:
 * Ramón N.Rodriguez (https://github.com/runitonmetal)
 * Golf Hu (https://github.com/hudeng-go)
 * Cookie Fei (https://github.com/wuhuang26)
+* Kevin Martin (https://github.com/melraidin)

--- a/s3/public.go
+++ b/s3/public.go
@@ -191,7 +191,7 @@ func (storage *PublishedStorage) getMD5(path string) (string, error) {
 		return "", err
 	}
 
-	return output.Metadata["Md5"], nil
+	return output.Metadata["md5"], nil
 }
 
 // putFile uploads file-like object to
@@ -431,11 +431,7 @@ func (storage *PublishedStorage) internalFilelist(prefix string, hidePlusWorkaro
 				continue
 			}
 
-			if prefix == "" {
-				paths = append(paths, *key.Key)
-			} else {
-				paths = append(paths, (*key.Key)[len(prefix):])
-			}
+			paths = append(paths, *key.Key)
 			md5s = append(md5s, strings.Replace(*key.ETag, "\"", "", -1))
 		}
 	}


### PR DESCRIPTION
This change fixes issues causing no matches to occur for existing objects at S3 in some cases. This issue caused all versions of a package in a repo to be uploaded again to S3.

Lookups in the cache of file MD5s were failing as the key in the map had its prefix stripped while the key used for the lookup did not have the prefix stripped. This change stops stripping the prefix when building the cache.

Retrieving object MD5s from object metadata (as opposed to the etag that comes with the object list) were failing as the key in the metadata map is now "md5" (all lowercase) vs. "Md5" that was used pre-v2 AWS SDK.


## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [ ] author name in `AUTHORS`
