### PR TITLE
CONTRIBUTING: Python3 is supportet

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ This section describes local setup to start contributing to aptly source.
 
 ### Go & Python
 
-You would need `Go` (latest version is recommended) and `Python` 2.7.x (3.x is not supported yet).
+You would need `Go` (latest version is recommended) and `Python` 3.9 (or newer, the CI currently tests against 3.11).
 
 If you're new to Go, follow [getting started guide](https://golang.org/doc/install) to install it and perform
 initial setup. With Go 1.8+, default `$GOPATH` is `$HOME/go`, so rest of this document assumes that.


### PR DESCRIPTION
Explicitly state that Python3 is supported and required.

Since aptly `v1.5.0` (with commit 035d5314b08263a20059f8bfca6f7524e5a80cb4) the tests are ported to Python3.

With a687df2f4f44a87670570ecc9a7fe137f1bac270 the system tests are run with `python3` per default.

With f4a152ab228442acd40d6cb49fcc8e99307519c9 (after `v1.5.0` aptly tag) the tests run against Python 3.11.

## Checklist

- [ ] ~~unit-test added (if change is algorithm)~~
- [ ] ~~functional test added/updated (if change is functional)~~
- [ ] ~~man page updated (if applicable)~~
- [ ] ~~bash completion updated (if applicable)~~
- [x] documentation updated
- [ ] author name in `AUTHORS`
  - I don't think this little change warrants my addition to the AUTHORS file
