### PR TITLE
api: fix OOM with sync tasks

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -175,6 +175,7 @@ func maybeRunTaskInBackground(c *gin.Context, name string, resources []string, p
 
 		retValue, _ := context.TaskList().GetTaskReturnValueByID(task.ID)
 		err, _ := context.TaskList().GetTaskErrorByID(task.ID)
+		context.TaskList().DeleteTaskByID(task.ID)
 		if err != nil {
 			AbortWithJSONError(c, retValue.Code, err)
 			return


### PR DESCRIPTION

Fixes #1323

## Description of the Change

since sync API calls also use tasks internally, this lead to out of memory due to aptly never removing them.

This change fixes this behavior and deletes the internal task with sync calls.