### PR TITLE
repo add: improve error message

### DIFF
--- a/deb/import.go
+++ b/deb/import.go
@@ -218,7 +218,7 @@ func ImportPackageFiles(list *PackageList, packageFiles []string, forceReplace b
 
 		err = list.Add(p)
 		if err != nil {
-			reporter.Warning("Unable to add package to repo %s: %s", p, err)
+			reporter.Warning("Unable to add package: %s", err)
 			failedFiles = append(failedFiles, file)
 			continue
 		}

--- a/deb/list.go
+++ b/deb/list.go
@@ -138,7 +138,7 @@ func (l *PackageList) Add(p *Package) error {
 	existing, ok := l.packages[key]
 	if ok {
 		if !existing.Equals(p) {
-			return &PackageConflictError{fmt.Errorf("conflict in package %s", p)}
+			return &PackageConflictError{fmt.Errorf("package already exists and is different: %s", p)}
 		}
 		return nil
 	}
@@ -201,7 +201,7 @@ func (l *PackageList) Append(pl *PackageList) error {
 		existing, ok := l.packages[k]
 		if ok {
 			if !existing.Equals(p) {
-				return fmt.Errorf("conflict in package %s", p)
+				return fmt.Errorf("package already exists and is different: %s", p)
 			}
 		} else {
 			l.packages[k] = p

--- a/deb/list_test.go
+++ b/deb/list_test.go
@@ -131,7 +131,7 @@ func (s *PackageListSuite) TestAddLen(c *C) {
 	c.Check(s.list.Len(), Equals, 1)
 	c.Check(s.list.Add(s.p3), IsNil)
 	c.Check(s.list.Len(), Equals, 2)
-	c.Check(s.list.Add(s.p4), ErrorMatches, "conflict in package.*")
+        c.Check(s.list.Add(s.p4), ErrorMatches, "package already exists and is different: .*")
 }
 
 func (s *PackageListSuite) TestRemove(c *C) {
@@ -243,7 +243,7 @@ func (s *PackageListSuite) TestAppend(c *C) {
 	list.Add(s.p4)
 
 	err = s.list.Append(list)
-	c.Check(err, ErrorMatches, "conflict.*")
+	c.Check(err, ErrorMatches, "package already exists and is different: .*")
 
 	s.list.PrepareIndex()
 	c.Check(func() { s.list.Append(s.il) }, Panics, "Append not supported when indexed")

--- a/deb/reflist_test.go
+++ b/deb/reflist_test.go
@@ -65,7 +65,7 @@ func (s *PackageRefListSuite) TestNewPackageListFromRefList(c *C) {
 	list, err := NewPackageListFromRefList(reflist, coll, nil)
 	c.Assert(err, IsNil)
 	c.Check(list.Len(), Equals, 4)
-	c.Check(list.Add(s.p4), ErrorMatches, "conflict in package.*")
+        c.Check(list.Add(s.p4), ErrorMatches, "package already exists and is different: .*")
 
 	list, err = NewPackageListFromRefList(nil, coll, nil)
 	c.Assert(err, IsNil)

--- a/system/t09_repo/AddRepo8Test_gold
+++ b/system/t09_repo/AddRepo8Test_gold
@@ -1,5 +1,5 @@
 Loading packages...
-[!] Unable to add package to repo pyspi_0.6.1-1.3_source: conflict in package pyspi_0.6.1-1.3_source
+[!] Unable to add package: package already exists and is different: pyspi_0.6.1-1.3_source
 [!] Some files were skipped due to errors:
   /pyspi_0.6.1-1.3.conflict.dsc
 ERROR: some files failed to be added


### PR DESCRIPTION
## Description of the Change

the error message "conflict in package" is due to the package already existing but being different (hash, ..). this change makes the error message more specific.

## Checklist

- [x] unit-test added (if change is algorithm)
- [x] functional test added/updated (if change is functional)

