### PR TITLE
fix path traversal

### DIFF
--- a/api/files.go
+++ b/api/files.go
@@ -73,7 +73,7 @@ func apiFilesUpload(c *gin.Context) {
 		return
 	}
 
-	path := filepath.Join(context.UploadPath(), utils.PathSanitize(c.Params.ByName("dir")))
+	path := filepath.Join(context.UploadPath(), utils.SanitizePath(c.Params.ByName("dir")))
 	err := os.MkdirAll(path, 0777)
 
 	if err != nil {
@@ -129,7 +129,7 @@ func apiFilesListFiles(c *gin.Context) {
 
 	list := []string{}
 	listLock := &sync.Mutex{}
-	root := filepath.Join(context.UploadPath(), utils.PathSanitize(c.Params.ByName("dir")))
+	root := filepath.Join(context.UploadPath(), utils.SanitizePath(c.Params.ByName("dir")))
 
 	err := filepath.Walk(root, func(path string, _ os.FileInfo, err error) error {
 		if err != nil {
@@ -165,7 +165,7 @@ func apiFilesDeleteDir(c *gin.Context) {
 		return
 	}
 
-	err := os.RemoveAll(filepath.Join(context.UploadPath(), utils.PathSanitize(c.Params.ByName("dir"))))
+	err := os.RemoveAll(filepath.Join(context.UploadPath(), utils.SanitizePath(c.Params.ByName("dir"))))
 	if err != nil {
 		AbortWithJSONError(c, 500, err)
 		return
@@ -180,8 +180,8 @@ func apiFilesDeleteFile(c *gin.Context) {
 		return
 	}
 
-	dir := utils.PathSanitize(c.Params.ByName("dir"))
-	name := utils.PathSanitize(c.Params.ByName("name"))
+	dir := utils.SanitizePath(c.Params.ByName("dir"))
+	name := utils.SanitizePath(c.Params.ByName("name"))
 	if !verifyPath(name) {
 		AbortWithJSONError(c, 400, fmt.Errorf("wrong file"))
 		return

--- a/api/files.go
+++ b/api/files.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/aptly-dev/aptly/utils"
 	"github.com/gin-gonic/gin"
 	"github.com/saracen/walker"
 )
@@ -72,7 +73,7 @@ func apiFilesUpload(c *gin.Context) {
 		return
 	}
 
-	path := filepath.Join(context.UploadPath(), c.Params.ByName("dir"))
+	path := filepath.Join(context.UploadPath(), utils.PathSanitize(c.Params.ByName("dir")))
 	err := os.MkdirAll(path, 0777)
 
 	if err != nil {
@@ -128,7 +129,7 @@ func apiFilesListFiles(c *gin.Context) {
 
 	list := []string{}
 	listLock := &sync.Mutex{}
-	root := filepath.Join(context.UploadPath(), c.Params.ByName("dir"))
+	root := filepath.Join(context.UploadPath(), utils.PathSanitize(c.Params.ByName("dir")))
 
 	err := filepath.Walk(root, func(path string, _ os.FileInfo, err error) error {
 		if err != nil {
@@ -164,7 +165,7 @@ func apiFilesDeleteDir(c *gin.Context) {
 		return
 	}
 
-	err := os.RemoveAll(filepath.Join(context.UploadPath(), c.Params.ByName("dir")))
+	err := os.RemoveAll(filepath.Join(context.UploadPath(), utils.PathSanitize(c.Params.ByName("dir"))))
 	if err != nil {
 		AbortWithJSONError(c, 500, err)
 		return
@@ -179,12 +180,14 @@ func apiFilesDeleteFile(c *gin.Context) {
 		return
 	}
 
-	if !verifyPath(c.Params.ByName("name")) {
+	dir := utils.PathSanitize(c.Params.ByName("dir"))
+	name := utils.PathSanitize(c.Params.ByName("name"))
+	if !verifyPath(name) {
 		AbortWithJSONError(c, 400, fmt.Errorf("wrong file"))
 		return
 	}
 
-	err := os.Remove(filepath.Join(context.UploadPath(), c.Params.ByName("dir"), c.Params.ByName("name")))
+	err := os.Remove(filepath.Join(context.UploadPath(), dir, name))
 	if err != nil {
 		if err1, ok := err.(*os.PathError); !ok || !os.IsNotExist(err1.Err) {
 			AbortWithJSONError(c, 500, err)

--- a/api/gpg.go
+++ b/api/gpg.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/aptly-dev/aptly/pgp"
+	"github.com/aptly-dev/aptly/utils"
 	"github.com/gin-gonic/gin"
 )
 
@@ -23,6 +24,10 @@ func apiGPGAddKey(c *gin.Context) {
 	if c.Bind(&b) != nil {
 		return
 	}
+	b.Keyserver = utils.SanitizePath(b.Keyserver)
+	b.GpgKeyID = utils.SanitizePath(b.GpgKeyID)
+	b.GpgKeyArmor = utils.SanitizePath(b.GpgKeyArmor)
+	// b.Keyring can be an absolute path
 
 	var err error
 	args := []string{"--no-default-keyring", "--allow-non-selfsigned-uid"}

--- a/api/publish.go
+++ b/api/publish.go
@@ -44,10 +44,10 @@ func getSigner(options *SigningOptions) (pgp.Signer, error) {
 	return signer, nil
 }
 
-// Replace '_' with '/' and double '__' with single '_', PathSanitize
+// Replace '_' with '/' and double '__' with single '_', SanitizePath
 func slashEscape(path string) string {
 	result := strings.Replace(strings.Replace(path, "_", "/", -1), "//", "_", -1)
-	result = utils.PathSanitize(result)
+	result = utils.SanitizePath(result)
 	if result == "" {
 		result = "."
 	}
@@ -115,7 +115,7 @@ func apiPublishRepoOrSnapshot(c *gin.Context) {
 		return
 	}
 
-	b.Distribution = utils.PathSanitize(b.Distribution)
+	b.Distribution = utils.SanitizePath(b.Distribution)
 
 	signer, err := getSigner(&b.Signing)
 	if err != nil {
@@ -254,7 +254,7 @@ func apiPublishRepoOrSnapshot(c *gin.Context) {
 func apiPublishUpdateSwitch(c *gin.Context) {
 	param := slashEscape(c.Params.ByName("prefix"))
 	storage, prefix := deb.ParsePrefix(param)
-	distribution := utils.PathSanitize(c.Params.ByName("distribution"))
+	distribution := utils.SanitizePath(c.Params.ByName("distribution"))
 
 	var b struct {
 		ForceOverwrite bool

--- a/api/repos.go
+++ b/api/repos.go
@@ -343,8 +343,8 @@ func apiReposPackageFromDir(c *gin.Context) {
 		return
 	}
 
-	dirParam := utils.PathSanitize(c.Params.ByName("dir"))
-	fileParam := utils.PathSanitize(c.Params.ByName("file"))
+	dirParam := utils.SanitizePath(c.Params.ByName("dir"))
+	fileParam := utils.SanitizePath(c.Params.ByName("file"))
 	if fileParam != "" && !verifyPath(fileParam) {
 		AbortWithJSONError(c, 400, fmt.Errorf("wrong file"))
 		return
@@ -620,8 +620,8 @@ func apiReposIncludePackageFromDir(c *gin.Context) {
 
 	var sources []string
 	var taskName string
-	dirParam := utils.PathSanitize(c.Params.ByName("dir"))
-	fileParam := utils.PathSanitize(c.Params.ByName("file"))
+	dirParam := utils.SanitizePath(c.Params.ByName("dir"))
+	fileParam := utils.SanitizePath(c.Params.ByName("file"))
 	if fileParam != "" && !verifyPath(fileParam) {
 		AbortWithJSONError(c, 400, fmt.Errorf("wrong file"))
 		return

--- a/api/repos.go
+++ b/api/repos.go
@@ -343,8 +343,8 @@ func apiReposPackageFromDir(c *gin.Context) {
 		return
 	}
 
-	dirParam := c.Params.ByName("dir")
-	fileParam := c.Params.ByName("file")
+	dirParam := utils.PathSanitize(c.Params.ByName("dir"))
+	fileParam := utils.PathSanitize(c.Params.ByName("file"))
 	if fileParam != "" && !verifyPath(fileParam) {
 		AbortWithJSONError(c, 400, fmt.Errorf("wrong file"))
 		return
@@ -620,8 +620,8 @@ func apiReposIncludePackageFromDir(c *gin.Context) {
 
 	var sources []string
 	var taskName string
-	dirParam := c.Params.ByName("dir")
-	fileParam := c.Params.ByName("file")
+	dirParam := utils.PathSanitize(c.Params.ByName("dir"))
+	fileParam := utils.PathSanitize(c.Params.ByName("file"))
 	if fileParam != "" && !verifyPath(fileParam) {
 		AbortWithJSONError(c, 400, fmt.Errorf("wrong file"))
 		return

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aptly-dev/aptly
 
-go 1.22
+go 1.22.7
 
 require (
 	github.com/AlekSi/pointer v1.1.0

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,6 +4,7 @@ package utils
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"golang.org/x/sys/unix"
 )
@@ -21,4 +22,11 @@ func DirIsAccessible(filename string) error {
 		}
 	}
 	return nil
+}
+
+// Remove leading '/', remove '..'
+func PathSanitize(path string) (result string) {
+	result = strings.Replace(path, "..", "", -1)
+	result = strings.TrimLeft(result, "/")
+	return
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -24,9 +24,11 @@ func DirIsAccessible(filename string) error {
 	return nil
 }
 
-// Remove leading '/', remove '..'
-func PathSanitize(path string) (result string) {
+// Remove leading '/', remove '..', '$' and '`'
+func SanitizePath(path string) (result string) {
 	result = strings.Replace(path, "..", "", -1)
+	result = strings.Replace(result, "$", "", -1)
+	result = strings.Replace(result, "`", "", -1)
 	result = strings.TrimLeft(result, "/")
 	return
 }


### PR DESCRIPTION
## Description of the Change

API parameters might be used for filesystem operations, and CodeQL complains about potential path traversal issues. 
This change introduces PathSanitize which removes any leading slashes and `..` from the parameter.

about 30 CodeQL complaints are addressed.
