### PR TITLE
Improve dev tooling

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,13 @@
+{
+    "recommendations": [
+        "aaron-bond.better-comments",
+        "jeff-hykin.better-go-syntax",
+        "ms-azuretools.vscode-docker",
+        "golang.go",
+        "stkb.rewrap",
+        "gruntfuggly.todo-tree",
+        "ms-python.vscode-pylance",
+        "ms-python.python",
+        "ms-python.debugpy"
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Package",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}",
+            "args": [
+                "api",
+                "serve"
+            ]
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+    "editor.wordWrap": "wordWrapColumn",
+    "editor.wordWrapColumn": 120,
+    "editor.formatOnSave": true,
+    "rewrap.reformat": true,
+    "rewrap.autoWrap.enabled": true,
+    "go.toolsManagement.autoUpdate": true,
+    "go.testFlags": [
+        "-v"
+    ],
+    "go.survey.prompt": false,
+    "gopls": {
+        "ui.semanticTokens": true
+    }
+}

--- a/system/Dockerfile
+++ b/system/Dockerfile
@@ -1,25 +1,33 @@
 FROM debian:bookworm-slim
 
+ARG USER_ID
+ARG GROUP_ID
+
 RUN echo deb http://deb.debian.org/debian bookworm-backports main > /etc/apt/sources.list.d/backports.list
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends curl gnupg bzip2 xz-utils ca-certificates vim procps \
-        golang/bookworm-backports golang-go/bookworm-backports golang-doc/bookworm-backports golang-src/bookworm-backports \
-        make git python3 python3-requests-unixsocket python3-termcolor python3-swiftclient python3-boto python3-azure-storage \
-        g++ python3-etcd3 python3-plyvel graphviz devscripts sudo dh-golang binutils-i686-linux-gnu binutils-aarch64-linux-gnu \
-        binutils-arm-linux-gnueabihf bash-completion zip ruby3.1-dev && \
+    golang/bookworm-backports golang-go/bookworm-backports golang-doc/bookworm-backports golang-src/bookworm-backports \
+    make git python3 python3-requests-unixsocket python3-termcolor python3-swiftclient python3-boto python3-azure-storage \
+    g++ python3-etcd3 python3-plyvel graphviz devscripts sudo dh-golang binutils-i686-linux-gnu binutils-aarch64-linux-gnu \
+    binutils-arm-linux-gnueabihf bash-completion zip ruby3.1-dev && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN useradd -m --shell /bin/bash --home-dir /var/lib/aptly aptly
+RUN useradd -m --shell /bin/bash --home-dir /var/lib/aptly -u $USER_ID -g $GROUP_ID aptly
 RUN sed -i 's/#force_color_prompt=yes/force_color_prompt=yes/' /var/lib/aptly/.bashrc
 
 RUN mkdir /work
 WORKDIR /work/src
 RUN chown aptly /work
 
-RUN cd /var/lib/aptly; git clone https://github.com/aptly-dev/aptly-fixture-db.git
-RUN cd /var/lib/aptly; git clone https://github.com/aptly-dev/aptly-fixture-pool.git
-RUN cd /var/lib/aptly; curl -O http://repo.aptly.info/system-tests/etcd.db.xz && xz -d etcd.db.xz
-RUN echo "aptly ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/aptly
 ADD system/t13_etcd/install-etcd.sh /src/
 RUN /src/install-etcd.sh
 RUN rm -rf /src
+RUN echo "aptly ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/aptly
+
+USER aptly
+
+RUN cd /var/lib/aptly; git clone https://github.com/aptly-dev/aptly-fixture-db.git
+RUN cd /var/lib/aptly; git clone https://github.com/aptly-dev/aptly-fixture-pool.git
+RUN cd /var/lib/aptly; curl -O http://repo.aptly.info/system-tests/etcd.db.xz && xz -d etcd.db.xz
+
+ENTRYPOINT [ "/work/src/system/docker-wrapper" ]

--- a/system/docker-wrapper
+++ b/system/docker-wrapper
@@ -1,11 +1,5 @@
 #!/bin/sh -e
 
-# make sure files are written with correct user ownership
-if [ `stat -c %u /work/src` -ne 0 ]; then
-    usermod -u `stat -c %u /work/src` aptly >/dev/null
-    chown -R `stat -c %u /work/src` /var/lib/aptly
-fi
-
 args="$@"
 if [ -z "$args" ]; then
     cp /work/src/completion.d/aptly /usr/share/bash-completion/completions/
@@ -14,5 +8,7 @@ else
     cmd="make $@"
 fi
 
-cd /work/src
-sudo -u aptly PATH=$PATH:/work/src/build GOPATH=/work/src/.go $cmd
+export PATH=$PATH:/work/src/build
+export GOPATH=/work/src/.go
+
+exec $cmd


### PR DESCRIPTION
* Add vscode recommended config and plugins
* Update docker machinery
* Simplify Makefile, eliminate the need of editing to enable CAPTURE for new tests. Now simply `make (docker-)system-test CAPTURE=yes`

Previously created docker stuff did not work (at
least in Dokcer Desktop for Mac). Let's try and
create something more generalzied. Yet, changes
were not tested on WSL.