### PR TITLE
Make HTTP server wait for tasks before shutdown

### DIFF
--- a/cmd/api_serve.go
+++ b/cmd/api_serve.go
@@ -65,6 +65,7 @@ func aptlyAPIServe(cmd *commander.Command, args []string) error {
 	signal.Notify(sigchan, syscall.SIGINT, syscall.SIGTERM)
 	go (func() {
 		if _, ok := <-sigchan; ok {
+			context.TaskList().Wait()
 			server.Shutdown(stdcontext.Background())
 		}
 	})()

--- a/cmd/api_serve.go
+++ b/cmd/api_serve.go
@@ -65,6 +65,7 @@ func aptlyAPIServe(cmd *commander.Command, args []string) error {
 	signal.Notify(sigchan, syscall.SIGINT, syscall.SIGTERM)
 	go (func() {
 		if _, ok := <-sigchan; ok {
+			fmt.Printf("\nShutdown signal received, waiting for background tasks...\n")
 			context.TaskList().Wait()
 			server.Shutdown(stdcontext.Background())
 		}

--- a/context/context.go
+++ b/context/context.go
@@ -13,6 +13,7 @@ import (
 	"runtime/pprof"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/aptly-dev/aptly/aptly"
@@ -359,10 +360,7 @@ func (context *AptlyContext) ReOpenDatabase() error {
 
 // NewCollectionFactory builds factory producing all kinds of collections
 func (context *AptlyContext) NewCollectionFactory() *deb.CollectionFactory {
-	context.Lock()
-	defer context.Unlock()
-
-	db, err := context._database()
+	db, err := context.Database()
 	if err != nil {
 		Fatal(err)
 	}
@@ -560,7 +558,7 @@ func (context *AptlyContext) GoContextHandleSignals() {
 
 	// Catch ^C
 	sigch := make(chan os.Signal, 1)
-	signal.Notify(sigch, os.Interrupt)
+	signal.Notify(sigch, syscall.SIGINT, syscall.SIGTERM)
 
 	var cancel gocontext.CancelFunc
 

--- a/http/download.go
+++ b/http/download.go
@@ -133,6 +133,8 @@ func retryableError(err error) bool {
 	}
 
 	switch err {
+	case context.Canceled:
+		return false
 	case io.EOF:
 		return true
 	case io.ErrUnexpectedEOF:

--- a/http/download_test.go
+++ b/http/download_test.go
@@ -154,3 +154,13 @@ func (s *DownloaderSuite) TestGetLengthConnectError(c *C) {
 
 	c.Assert(err, ErrorMatches, ".*no such host")
 }
+
+func (s *DownloaderSuite) TestContextCancel(c *C) {
+	ctx, cancel := context.WithCancel(s.ctx)
+	s.ctx = ctx
+
+	cancel()
+	_, err := s.d.GetLength(s.ctx, "http://nosuch.host.invalid./")
+
+	c.Assert(err, ErrorMatches, ".*context canceled.*")
+}


### PR DESCRIPTION
Fixes #1335 

## Description of the Change

This code change prevents SIGINT/SIGTERM signals from stopping the Aptly API server before it has cleaned up any resource locks in the database. Normally for CLI aptly commands, it would clear these locks if it detects the PID that had the previous lock is no longer running. However, if Aptly is running as an API server in a container, it always runs as PID 1, which means the PID no longer works as a unique identifier to detect what is running at any given time, leaving these locks indefinitely.

Even with this MR, this issue can still present itself if an Aptly container is SIGKILLed (docker rm -f), however that is a more difficult problem to solve that would likely take some significant rearchitecting (since the API was tacked on to aptly after the fact). 


## Checklist

- [x] unit-test added (if change is algorithm)