### PR TITLE
Fix: Null pointer when dropping a multi-dist published repo

### DIFF
--- a/deb/publish.go
+++ b/deb/publish.go
@@ -1660,6 +1660,11 @@ func (collection *PublishedRepoCollection) Remove(publishedStorageProvider aptly
 		return err
 	}
 
+	err = collection.LoadComplete(repo, collectionFactory)
+	if err != nil {
+		return err
+	}
+
 	removePrefix := true
 	removePoolComponents := repo.Components()
 	cleanComponents := []string{}


### PR DESCRIPTION
This commit fixes a null pointer when a multi-dist published repo gets dropped.

Signed-off-by: Christoph Fiehe <c.fiehe@eurodata.de>