### PR TITLE
Fix `-with-sources` not fetching differently named source packages

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -67,3 +67,4 @@ List of contributors, in chronological order:
 * Christoph Fiehe (https://github.com/cfiehe)
 * Blake Kostner (https://github.com/btkostner)
 * Leigh London (https://github.com/leighlondon)
+* Gordian Schönherr (https://github.com/schoenherrg)

--- a/api/api.go
+++ b/api/api.go
@@ -227,8 +227,13 @@ func showPackages(c *gin.Context, reflist *deb.PackageRefList, collectionFactory
 
 		list.PrepareIndex()
 
-		list, err = list.Filter([]deb.PackageQuery{q}, withDeps,
-			nil, context.DependencyOptions(), architecturesList)
+		list, err = list.Filter(deb.FilterOptions{
+			Queries:           []deb.PackageQuery{q},
+			WithDependencies:  withDeps,
+			Source:            nil,
+			DependencyOptions: context.DependencyOptions(),
+			Architectures:     architecturesList,
+		})
 		if err != nil {
 			AbortWithJSONError(c, 500, fmt.Errorf("unable to search: %s", err))
 			return
@@ -244,8 +249,9 @@ func showPackages(c *gin.Context, reflist *deb.PackageRefList, collectionFactory
 				fmt.Println("filter packages by version, query string parse err: ", err)
 				c.AbortWithError(500, fmt.Errorf("unable to parse %s maximum version query string: %s", p.Name, err))
 			} else {
-				tmpList, err := list.Filter([]deb.PackageQuery{versionQ}, false,
-					nil, 0, []string{})
+				tmpList, err := list.Filter(deb.FilterOptions{
+					Queries: []deb.PackageQuery{versionQ},
+				})
 
 				if err == nil {
 					if tmpList.Len() > 0 {

--- a/api/mirror.go
+++ b/api/mirror.go
@@ -306,8 +306,12 @@ func apiMirrorsPackages(c *gin.Context) {
 
 		list.PrepareIndex()
 
-		list, err = list.Filter([]deb.PackageQuery{q}, withDeps,
-			nil, context.DependencyOptions(), architecturesList)
+		list, err = list.Filter(deb.FilterOptions{
+			Queries:           []deb.PackageQuery{q},
+			WithDependencies:  withDeps,
+			DependencyOptions: context.DependencyOptions(),
+			Architectures:     architecturesList,
+		})
 		if err != nil {
 			AbortWithJSONError(c, 500, fmt.Errorf("unable to search: %s", err))
 		}

--- a/api/repos.go
+++ b/api/repos.go
@@ -586,7 +586,14 @@ func apiReposCopyPackage(c *gin.Context) {
 			return &task.ProcessReturnValue{Code: http.StatusUnprocessableEntity, Value: nil}, fmt.Errorf("unable to parse query '%s': %s", fileName, err)
 		}
 
-		toProcess, err := srcList.FilterWithProgress(queries, jsonBody.WithDeps, dstList, context.DependencyOptions(), architecturesList, context.Progress())
+		toProcess, err := srcList.Filter(deb.FilterOptions{
+			Queries:           queries,
+			WithDependencies:  jsonBody.WithDeps,
+			Source:            dstList,
+			DependencyOptions: context.DependencyOptions(),
+			Architectures:     architecturesList,
+			Progress:          context.Progress(),
+		})
 		if err != nil {
 			return &task.ProcessReturnValue{Code: http.StatusInternalServerError, Value: nil}, fmt.Errorf("filter error: %s", err)
 		}

--- a/api/snapshot.go
+++ b/api/snapshot.go
@@ -636,7 +636,14 @@ func apiSnapshotsPull(c *gin.Context) {
 		}
 
 		// Filter with dependencies as requested
-		destinationPackageList, err := sourcePackageList.FilterWithProgress(queries, !noDeps, toPackageList, context.DependencyOptions(), architecturesList, context.Progress())
+		destinationPackageList, err := sourcePackageList.Filter(deb.FilterOptions{
+			Queries:           queries,
+			WithDependencies:  !noDeps,
+			Source:            toPackageList,
+			DependencyOptions: context.DependencyOptions(),
+			Architectures:     architecturesList,
+			Progress:          context.Progress(),
+		})
 		if err != nil {
 			return &task.ProcessReturnValue{Code: http.StatusInternalServerError, Value: nil}, err
 		}

--- a/cmd/repo_move.go
+++ b/cmd/repo_move.go
@@ -116,7 +116,14 @@ func aptlyRepoMoveCopyImport(cmd *commander.Command, args []string) error {
 		}
 	}
 
-	toProcess, err := srcList.FilterWithProgress(queries, withDeps, dstList, context.DependencyOptions(), architecturesList, context.Progress())
+	toProcess, err := srcList.Filter(deb.FilterOptions{
+		Queries:           queries,
+		WithDependencies:  withDeps,
+		Source:            dstList,
+		DependencyOptions: context.DependencyOptions(),
+		Architectures:     architecturesList,
+		Progress:          context.Progress(),
+	})
 	if err != nil {
 		return fmt.Errorf("unable to %s: %s", command, err)
 	}

--- a/cmd/repo_remove.go
+++ b/cmd/repo_remove.go
@@ -45,7 +45,7 @@ func aptlyRepoRemove(cmd *commander.Command, args []string) error {
 	}
 
 	list.PrepareIndex()
-	toRemove, err := list.Filter(queries, false, nil, 0, nil)
+	toRemove, err := list.Filter(deb.FilterOptions{Queries: queries})
 	if err != nil {
 		return fmt.Errorf("unable to remove: %s", err)
 	}

--- a/cmd/snapshot_filter.go
+++ b/cmd/snapshot_filter.go
@@ -67,7 +67,14 @@ func aptlySnapshotFilter(cmd *commander.Command, args []string) error {
 	}
 
 	// Filter with dependencies as requested
-	result, err := packageList.FilterWithProgress(queries, withDeps, nil, context.DependencyOptions(), architecturesList, context.Progress())
+	result, err := packageList.Filter(deb.FilterOptions{
+		Queries:           queries,
+		WithDependencies:  withDeps,
+		Source:            nil,
+		DependencyOptions: context.DependencyOptions(),
+		Architectures:     architecturesList,
+		Progress:          context.Progress(),
+	})
 	if err != nil {
 		return fmt.Errorf("unable to filter: %s", err)
 	}

--- a/cmd/snapshot_pull.go
+++ b/cmd/snapshot_pull.go
@@ -97,7 +97,14 @@ func aptlySnapshotPull(cmd *commander.Command, args []string) error {
 	}
 
 	// Filter with dependencies as requested
-	result, err := sourcePackageList.FilterWithProgress(queries, !noDeps, packageList, context.DependencyOptions(), architecturesList, context.Progress())
+	result, err := sourcePackageList.Filter(deb.FilterOptions{
+		Queries:           queries,
+		WithDependencies:  !noDeps,
+		Source:            packageList,
+		DependencyOptions: context.DependencyOptions(),
+		Architectures:     architecturesList,
+		Progress:          context.Progress(),
+	})
 	if err != nil {
 		return fmt.Errorf("unable to pull: %s", err)
 	}

--- a/cmd/snapshot_search.go
+++ b/cmd/snapshot_search.go
@@ -103,8 +103,13 @@ func aptlySnapshotMirrorRepoSearch(cmd *commander.Command, args []string) error 
 		}
 	}
 
-	result, err := list.FilterWithProgress([]deb.PackageQuery{q}, withDeps,
-		nil, context.DependencyOptions(), architecturesList, context.Progress())
+	result, err := list.Filter(deb.FilterOptions{
+		Queries:           []deb.PackageQuery{q},
+		WithDependencies:  withDeps,
+		DependencyOptions: context.DependencyOptions(),
+		Architectures:     architecturesList,
+		Progress:          context.Progress(),
+	})
 	if err != nil {
 		return fmt.Errorf("unable to search: %s", err)
 	}

--- a/deb/list.go
+++ b/deb/list.go
@@ -508,11 +508,11 @@ func (l *PackageList) Search(dep Dependency, allMatches bool, searchProvided boo
 type FilterOptions struct {
 	Queries           []PackageQuery
 	WithDependencies  bool
-	WithSources       bool // Source packages correspond to binary packages are included
+	WithSources       bool // Source packages corresponding to binary packages are included
 	Source            *PackageList
 	DependencyOptions int
 	Architectures     []string
-	Progress          aptly.Progress // set to non-nil to report progress
+	Progress          aptly.Progress // set to non-nil value to report progress
 }
 
 // SourceRegex is a regular expression to match source package names.

--- a/deb/list_test.go
+++ b/deb/list_test.go
@@ -131,7 +131,7 @@ func (s *PackageListSuite) TestAddLen(c *C) {
 	c.Check(s.list.Len(), Equals, 1)
 	c.Check(s.list.Add(s.p3), IsNil)
 	c.Check(s.list.Len(), Equals, 2)
-        c.Check(s.list.Add(s.p4), ErrorMatches, "package already exists and is different: .*")
+	c.Check(s.list.Add(s.p4), ErrorMatches, "package already exists and is different: .*")
 }
 
 func (s *PackageListSuite) TestRemove(c *C) {
@@ -311,7 +311,11 @@ func (s *PackageListSuite) TestSearch(c *C) {
 }
 
 func (s *PackageListSuite) TestFilter(c *C) {
-	c.Check(func() { s.list.Filter([]PackageQuery{&PkgQuery{"abcd", "0.3", "i386"}}, false, nil, 0, nil) }, Panics, "list not indexed, can't filter")
+	c.Check(func() {
+		s.list.Filter(FilterOptions{
+			Queries: []PackageQuery{&PkgQuery{"abcd", "0.3", "i386"}},
+		})
+	}, Panics, "list not indexed, can't filter")
 
 	plString := func(l *PackageList) string {
 		list := make([]string, 0, l.Len())
@@ -324,81 +328,111 @@ func (s *PackageListSuite) TestFilter(c *C) {
 		return strings.Join(list, " ")
 	}
 
-	result, err := s.il.Filter([]PackageQuery{&PkgQuery{"app", "1.1~bp1", "i386"}}, false, nil, 0, nil)
+	result, err := s.il.Filter(FilterOptions{Queries: []PackageQuery{&PkgQuery{"app", "1.1~bp1", "i386"}}})
 	c.Check(err, IsNil)
 	c.Check(plString(result), Equals, "app_1.1~bp1_i386")
 
-	result, err = s.il.Filter([]PackageQuery{&PkgQuery{"app", "1.1~bp1", "i386"}, &PkgQuery{"dpkg", "1.7", "source"},
-		&PkgQuery{"dpkg", "1.8", "amd64"}}, false, nil, 0, nil)
+	result, err = s.il.Filter(FilterOptions{Queries: []PackageQuery{&PkgQuery{"app", "1.1~bp1", "i386"}, &PkgQuery{"dpkg", "1.7", "source"},
+		&PkgQuery{"dpkg", "1.8", "amd64"}}})
 	c.Check(err, IsNil)
 	c.Check(plString(result), Equals, "app_1.1~bp1_i386 dpkg_1.7_source")
 
-	result, err = s.il.Filter([]PackageQuery{
+	result, err = s.il.Filter(FilterOptions{Queries: []PackageQuery{
 		&DependencyQuery{Dep: Dependency{Pkg: "app"}},
 		&DependencyQuery{Dep: Dependency{Pkg: "dpkg", Relation: VersionGreater, Version: "1.6.1-3"}},
 		&DependencyQuery{Dep: Dependency{Pkg: "app", Relation: VersionGreaterOrEqual, Version: "1.0"}},
 		&DependencyQuery{Dep: Dependency{Pkg: "xyz"}},
-		&DependencyQuery{Dep: Dependency{Pkg: "aa", Relation: VersionGreater, Version: "3.0"}}}, false, nil, 0, nil)
+		&DependencyQuery{Dep: Dependency{Pkg: "aa", Relation: VersionGreater, Version: "3.0"}}}})
 	c.Check(err, IsNil)
 	c.Check(plString(result), Equals, "app_1.0_s390 app_1.1~bp1_amd64 app_1.1~bp1_arm app_1.1~bp1_i386 dpkg_1.7_i386 dpkg_1.7_source")
 
-	result, err = s.il.Filter([]PackageQuery{&DependencyQuery{Dep: Dependency{Pkg: "app", Architecture: "i386"}}}, true, NewPackageList(), 0, []string{"i386"})
+	result, err = s.il.Filter(FilterOptions{
+		Queries:          []PackageQuery{&DependencyQuery{Dep: Dependency{Pkg: "app", Architecture: "i386"}}},
+		WithDependencies: true,
+		Source:           NewPackageList(),
+		Architectures:    []string{"i386"},
+	})
 	c.Check(err, IsNil)
 	c.Check(plString(result), Equals, "app_1.1~bp1_i386 data_1.1~bp1_all dpkg_1.7_i386 lib_1.0_i386 mailer_3.5.8_i386")
 
-	result, err = s.il.Filter([]PackageQuery{
-		&DependencyQuery{Dep: Dependency{Pkg: "app", Relation: VersionGreaterOrEqual, Version: "0.9"}},
-		&DependencyQuery{Dep: Dependency{Pkg: "lib"}},
-		&DependencyQuery{Dep: Dependency{Pkg: "data"}}}, true, NewPackageList(), 0, []string{"i386", "amd64"})
+	result, err = s.il.Filter(FilterOptions{
+		Queries: []PackageQuery{
+			&DependencyQuery{Dep: Dependency{Pkg: "app", Relation: VersionGreaterOrEqual, Version: "0.9"}},
+			&DependencyQuery{Dep: Dependency{Pkg: "lib"}},
+			&DependencyQuery{Dep: Dependency{Pkg: "data"}}},
+		WithDependencies: true,
+		Source:           NewPackageList(),
+		Architectures:    []string{"i386", "amd64"},
+	})
 	c.Check(err, IsNil)
 	c.Check(plString(result), Equals, "app_1.0_s390 app_1.1~bp1_amd64 app_1.1~bp1_arm app_1.1~bp1_i386 data_1.1~bp1_all dpkg_1.6.1-3_amd64 dpkg_1.7_i386 lib_1.0_i386 mailer_3.5.8_i386")
 
-	result, err = s.il.Filter([]PackageQuery{&OrQuery{&PkgQuery{"app", "1.1~bp1", "i386"},
-		&DependencyQuery{Dep: Dependency{Pkg: "dpkg", Relation: VersionGreater, Version: "1.6.1-3"}}}}, false, nil, 0, nil)
+	result, err = s.il.Filter(FilterOptions{
+		Queries: []PackageQuery{&OrQuery{&PkgQuery{"app", "1.1~bp1", "i386"},
+			&DependencyQuery{Dep: Dependency{Pkg: "dpkg", Relation: VersionGreater, Version: "1.6.1-3"}}}},
+	})
 	c.Check(err, IsNil)
 	c.Check(plString(result), Equals, "app_1.1~bp1_i386 dpkg_1.7_i386 dpkg_1.7_source")
 
-	result, err = s.il.Filter([]PackageQuery{&AndQuery{&PkgQuery{"app", "1.1~bp1", "i386"},
-		&DependencyQuery{Dep: Dependency{Pkg: "dpkg", Relation: VersionGreater, Version: "1.6.1-3"}}}}, false, nil, 0, nil)
+	result, err = s.il.Filter(FilterOptions{
+		Queries: []PackageQuery{&AndQuery{&PkgQuery{"app", "1.1~bp1", "i386"},
+			&DependencyQuery{Dep: Dependency{Pkg: "dpkg", Relation: VersionGreater, Version: "1.6.1-3"}}}},
+	})
 	c.Check(err, IsNil)
 	c.Check(plString(result), Equals, "")
 
-	result, err = s.il.Filter([]PackageQuery{&OrQuery{&PkgQuery{"app", "1.1~bp1", "i386"},
-		&FieldQuery{Field: "$Architecture", Relation: VersionEqual, Value: "s390"}}}, false, nil, 0, nil)
+	//result, err = s.il.Filter([]PackageQuery{&OrQuery{&PkgQuery{"app", "1.1~bp1", "i386"},
+	//	&FieldQuery{Field: "$Architecture", Relation: VersionEqual, Value: "s390"}}}, false, nil, 0, nil)
+	result, err = s.il.Filter(FilterOptions{
+		Queries: []PackageQuery{&OrQuery{&PkgQuery{"app", "1.1~bp1", "i386"},
+			&FieldQuery{Field: "$Architecture", Relation: VersionEqual, Value: "s390"}}},
+	})
 	c.Check(err, IsNil)
 	c.Check(plString(result), Equals, "app_1.0_s390 app_1.1~bp1_i386 data_1.1~bp1_all")
 
-	result, err = s.il.Filter([]PackageQuery{&AndQuery{&FieldQuery{Field: "Version", Relation: VersionGreaterOrEqual, Value: "1.0"},
-		&FieldQuery{Field: "$Architecture", Relation: VersionEqual, Value: "s390"}}}, false, nil, 0, nil)
+	result, err = s.il.Filter(FilterOptions{
+		Queries: []PackageQuery{&AndQuery{&FieldQuery{Field: "Version", Relation: VersionGreaterOrEqual, Value: "1.0"},
+			&FieldQuery{Field: "$Architecture", Relation: VersionEqual, Value: "s390"}}},
+	})
 	c.Check(err, IsNil)
 	c.Check(plString(result), Equals, "app_1.0_s390 data_1.1~bp1_all")
 
-	result, err = s.il.Filter([]PackageQuery{&AndQuery{
-		&FieldQuery{Field: "$Architecture", Relation: VersionPatternMatch, Value: "i*6"}, &PkgQuery{"app", "1.1~bp1", "i386"}}}, false, nil, 0, nil)
+	result, err = s.il.Filter(FilterOptions{
+		Queries: []PackageQuery{&AndQuery{
+			&FieldQuery{Field: "$Architecture", Relation: VersionPatternMatch, Value: "i*6"}, &PkgQuery{"app", "1.1~bp1", "i386"}}},
+	})
 	c.Check(err, IsNil)
 	c.Check(plString(result), Equals, "app_1.1~bp1_i386")
 
-	result, err = s.il.Filter([]PackageQuery{&NotQuery{
-		&FieldQuery{Field: "$Architecture", Relation: VersionPatternMatch, Value: "i*6"}}}, false, nil, 0, nil)
+	result, err = s.il.Filter(FilterOptions{
+		Queries: []PackageQuery{&NotQuery{
+			&FieldQuery{Field: "$Architecture", Relation: VersionPatternMatch, Value: "i*6"}}},
+	})
 	c.Check(err, IsNil)
 	c.Check(plString(result), Equals, "app_1.0_s390 app_1.1~bp1_amd64 app_1.1~bp1_arm data_1.1~bp1_all dpkg_1.6.1-3_amd64 dpkg_1.6.1-3_arm dpkg_1.6.1-3_source dpkg_1.7_source libx_1.5_arm")
 
-	result, err = s.il.Filter([]PackageQuery{&AndQuery{
-		&FieldQuery{Field: "$Architecture", Relation: VersionRegexp, Value: "i.*6", Regexp: regexp.MustCompile("i.*6")}, &PkgQuery{"app", "1.1~bp1", "i386"}}}, false, nil, 0, nil)
+	result, err = s.il.Filter(FilterOptions{
+		Queries: []PackageQuery{&AndQuery{
+			&FieldQuery{Field: "$Architecture", Relation: VersionRegexp, Value: "i.*6", Regexp: regexp.MustCompile("i.*6")}, &PkgQuery{"app", "1.1~bp1", "i386"}}},
+	})
 	c.Check(err, IsNil)
 	c.Check(plString(result), Equals, "app_1.1~bp1_i386")
 
-	result, err = s.il.Filter([]PackageQuery{&AndQuery{
-		&FieldQuery{Field: "Name", Relation: VersionRegexp, Value: "a", Regexp: regexp.MustCompile("a")},
-		&NotQuery{Q: &FieldQuery{Field: "Name", Relation: VersionEqual, Value: "data"}},
-	}}, false, nil, 0, nil)
+	result, err = s.il.Filter(FilterOptions{
+		Queries: []PackageQuery{&AndQuery{
+			&FieldQuery{Field: "Name", Relation: VersionRegexp, Value: "a", Regexp: regexp.MustCompile("a")},
+			&NotQuery{Q: &FieldQuery{Field: "Name", Relation: VersionEqual, Value: "data"}},
+		}},
+	})
 	c.Check(err, IsNil)
 	c.Check(plString(result), Equals, "aa_2.0-1_i386 app_1.0_s390 app_1.1~bp1_amd64 app_1.1~bp1_arm app_1.1~bp1_i386 mailer_3.5.8_i386")
 
-	result, err = s.il.Filter([]PackageQuery{&AndQuery{
-		&NotQuery{Q: &FieldQuery{Field: "Name", Relation: VersionEqual, Value: "data"}},
-		&FieldQuery{Field: "Name", Relation: VersionRegexp, Value: "a", Regexp: regexp.MustCompile("a")},
-	}}, false, nil, 0, nil)
+	result, err = s.il.Filter(FilterOptions{
+		Queries: []PackageQuery{&AndQuery{
+			&NotQuery{Q: &FieldQuery{Field: "Name", Relation: VersionEqual, Value: "data"}},
+			&FieldQuery{Field: "Name", Relation: VersionRegexp, Value: "a", Regexp: regexp.MustCompile("a")},
+		}},
+	})
 	c.Check(err, IsNil)
 	c.Check(plString(result), Equals, "aa_2.0-1_i386 app_1.0_s390 app_1.1~bp1_amd64 app_1.1~bp1_arm app_1.1~bp1_i386 mailer_3.5.8_i386")
 }

--- a/deb/package.go
+++ b/deb/package.go
@@ -450,7 +450,7 @@ func (p *Package) GetArchitecture() string {
 	return p.Architecture
 }
 
-// GetDependencies compiles list of dependncies by flags from options
+// GetDependencies compiles list of dependencies by flags from options
 func (p *Package) GetDependencies(options int) (dependencies []string) {
 	deps := p.Deps()
 

--- a/deb/remote.go
+++ b/deb/remote.go
@@ -596,7 +596,14 @@ func (repo *RemoteRepo) ApplyFilter(dependencyOptions int, filterQuery PackageQu
 	emptyList.PrepareIndex()
 
 	oldLen = repo.packageList.Len()
-	repo.packageList, err = repo.packageList.FilterWithProgress([]PackageQuery{filterQuery}, repo.FilterWithDeps, emptyList, dependencyOptions, repo.Architectures, progress)
+	repo.packageList, err = repo.packageList.Filter(FilterOptions{
+		Queries:           []PackageQuery{filterQuery},
+		WithDependencies:  repo.FilterWithDeps,
+		Source:            emptyList,
+		DependencyOptions: dependencyOptions,
+		Architectures:     repo.Architectures,
+		Progress:          progress,
+	})
 	if repo.packageList != nil {
 		newLen = repo.packageList.Len()
 	}

--- a/deb/remote.go
+++ b/deb/remote.go
@@ -600,6 +600,7 @@ func (repo *RemoteRepo) ApplyFilter(dependencyOptions int, filterQuery PackageQu
 		Queries:           []PackageQuery{filterQuery},
 		WithDependencies:  repo.FilterWithDeps,
 		Source:            emptyList,
+		WithSources:       repo.DownloadSources,
 		DependencyOptions: dependencyOptions,
 		Architectures:     repo.Architectures,
 		Progress:          progress,

--- a/system/t04_mirror/UpdateMirror10Test_gold
+++ b/system/t04_mirror/UpdateMirror10Test_gold
@@ -2,7 +2,7 @@
 
 Applying filter...
 Building download queue...
-Download queue: 11 items (39.66 MiB)
+Download queue: 17 items (47.22 MiB)
 Downloading & parsing package files...
 Downloading: http://repo.aptly.info/system-tests/cloud.r-project.org/bin/linux/debian/bullseye-cran40/InRelease
 Downloading: http://repo.aptly.info/system-tests/cloud.r-project.org/bin/linux/debian/bullseye-cran40/Packages.bz2
@@ -16,10 +16,16 @@ Downloading: http://repo.aptly.info/system-tests/cloud.r-project.org/bin/linux/d
 Downloading: http://repo.aptly.info/system-tests/cloud.r-project.org/bin/linux/debian/bullseye-cran40/rkward-data_0.7.5-1~bullseyecran.0_all.deb
 Downloading: http://repo.aptly.info/system-tests/cloud.r-project.org/bin/linux/debian/bullseye-cran40/rkward-dbgsym_0.7.5-1~bullseyecran.0_amd64.deb
 Downloading: http://repo.aptly.info/system-tests/cloud.r-project.org/bin/linux/debian/bullseye-cran40/rkward-dbgsym_0.7.5-1~bullseyecran.0_i386.deb
+Downloading: http://repo.aptly.info/system-tests/cloud.r-project.org/bin/linux/debian/bullseye-cran40/rkward_0.7.5-1~bullseyecran.0.debian.tar.xz
+Downloading: http://repo.aptly.info/system-tests/cloud.r-project.org/bin/linux/debian/bullseye-cran40/rkward_0.7.5-1~bullseyecran.0.dsc
 Downloading: http://repo.aptly.info/system-tests/cloud.r-project.org/bin/linux/debian/bullseye-cran40/rkward_0.7.5-1~bullseyecran.0_amd64.deb
 Downloading: http://repo.aptly.info/system-tests/cloud.r-project.org/bin/linux/debian/bullseye-cran40/rkward_0.7.5-1~bullseyecran.0_i386.deb
+Downloading: http://repo.aptly.info/system-tests/cloud.r-project.org/bin/linux/debian/bullseye-cran40/rkward_0.7.5.orig.tar.gz
+Downloading: http://repo.aptly.info/system-tests/cloud.r-project.org/bin/linux/debian/bullseye-cran40/rpy2_3.5.12-1~bullseyecran.0.debian.tar.xz
+Downloading: http://repo.aptly.info/system-tests/cloud.r-project.org/bin/linux/debian/bullseye-cran40/rpy2_3.5.12-1~bullseyecran.0.dsc
+Downloading: http://repo.aptly.info/system-tests/cloud.r-project.org/bin/linux/debian/bullseye-cran40/rpy2_3.5.12.orig.tar.gz
 Mirror `flat-src` has been updated successfully.
-Packages filtered: 110 -> 11.
+Packages filtered: 110 -> 13.
 gpgv:                using RSA key 7BA040A510E4E66ED3743EC1B8F25A8A73EACF41
 gpgv: Good signature from "Johannes Ranke <johannes.ranke@jrwb.de>"
 gpgv: Signature made Thu Nov  2 07:43:52 2023 UTC

--- a/system/t06_publish/snapshot.py
+++ b/system/t06_publish/snapshot.py
@@ -1344,6 +1344,26 @@ class PublishSnapshot41Test(BaseTest):
         self.check_exists('public/pool/main/libx/libxslt/libxslt1.1_1.1.32-2.2~deb10u2_i386.deb')
         self.check_exists('public/pool/main/libz/libzstd/libzstd1_1.3.8+dfsg-3+deb10u2_i386.deb')
         self.check_exists('public/pool/main/z/zlib/zlib1g_1.2.11.dfsg-1+deb10u2_i386.deb')
+        # check source packages with different names
+        self.check_exists('public/pool/main/u/util-linux/util-linux_2.33.1-0.1+deb10u1.dsc')
+        self.check_exists('public/pool/main/u/util-linux/util-linux_2.33.1-0.1+deb10u1.debian.tar.xz')
+        self.check_exists('public/pool/main/u/util-linux/util-linux_2.33.1.orig.tar.xz')
+        self.check_exists('public/pool/main/g/glibc/glibc_2.28-10+deb10u2.debian.tar.xz')
+        self.check_exists('public/pool/main/g/glibc/glibc_2.28-10+deb10u2.dsc')
+        self.check_exists('public/pool/main/g/glibc/glibc_2.28.orig.tar.xz')
+        self.check_exists('public/pool/main/n/ncurses/ncurses_6.1+20181013-2+deb10u5.debian.tar.xz')
+        self.check_exists('public/pool/main/n/ncurses/ncurses_6.1+20181013-2+deb10u5.dsc')
+        self.check_exists('public/pool/main/n/ncurses/ncurses_6.1+20181013.orig.tar.gz')
+        self.check_exists('public/pool/main/z/zlib/zlib_1.2.11.dfsg-1+deb10u2.debian.tar.xz')
+        self.check_exists('public/pool/main/z/zlib/zlib_1.2.11.dfsg-1+deb10u2.dsc')
+        self.check_exists('public/pool/main/z/zlib/zlib_1.2.11.dfsg.orig.tar.gz')
+        self.check_exists('public/pool/main/x/xz-utils/xz-utils_5.2.4-1+deb10u1.debian.tar.xz')
+        self.check_exists('public/pool/main/x/xz-utils/xz-utils_5.2.4-1+deb10u1.dsc')
+        self.check_exists('public/pool/main/x/xz-utils/xz-utils_5.2.4.orig.tar.xz')
+        self.check_exists('public/pool/main/e/e2fsprogs/e2fsprogs_1.44.5-1+deb10u2.debian.tar.xz')
+        self.check_exists('public/pool/main/e/e2fsprogs/e2fsprogs_1.44.5-1+deb10u2.dsc')
+        self.check_exists('public/pool/main/e/e2fsprogs/e2fsprogs_1.44.5.orig.tar.gz')
+        self.check_exists('public/pool/main/e/e2fsprogs/e2fsprogs_1.44.5.orig.tar.gz.asc')
 
 
 class PublishSnapshot42Test(BaseTest):


### PR DESCRIPTION
Fixes #1403

## Description of the Change

This fixes a bug where aptly doesn't behave as specified in the documentation.

The core of the change is to just add an option to `Filter` to indicate that source packages need to be included and, if that option is set, add the missing packages to the result.

```diff
--- a/deb/list.go
+++ b/deb/list.go
@@ -524,6 +537,37 @@ func (l *PackageList) Filter(options FilterOptions) (*PackageList, error) {
  for _, query := range options.Queries {
          _ = result.Append(query.Query(l))
  }
+ // The above loop already finds source packages that are named equal to their binary package, but we still need
+ // to account for those that are named differently.
+ if options.WithSources {
+         sourceQueries := make([]PackageQuery, 0)
+         for _, pkg := range result.packages {
+                 // Find sourceName, sourceVersion
+                 // ...
+                 sourceQueries = append(sourceQueries, &DependencyQuery{Dependency{
+                         Pkg:          sourceName,
+                         Version:      sourceVersion,
+                         Relation:     VersionEqual,
+                         Architecture: ArchitectureSource,
+                 }})
+         }
+         for _, query := range sourceQueries {
+                 _ = result.Append(query.Query(l))
+         }
+ }
```


Note that I also refactored `Filter` to take a struct of options, because I didn't want to add yet another argument to the already very long argument list.

```diff
--- a/deb/list.go
+++ b/deb/list.go

-// Filter filters package index by specified queries (ORed together), possibly pulling dependencies
-func (l *PackageList) Filter(queries []PackageQuery, withDependencies bool, source *PackageList, dependencyOptions int, architecturesList []string) (*PackageList, error) {
-   return l.FilterWithProgress(queries, withDependencies, source, dependencyOptions, architecturesList, nil)
+// FilterOptions specifies options for Filter()
+type FilterOptions struct {
+ Queries           []PackageQuery
+ WithDependencies  bool
+ Source            *PackageList
+ DependencyOptions int
+ Architectures     []string
+ Progress          aptly.Progress // set to non-nil to report progress
 }

-// FilterWithProgress filters package index by specified queries (ORed together), possibly pulling dependencies and displays progress
-func (l *PackageList) FilterWithProgress(queries []PackageQuery, withDependencies bool, source *PackageList, dependencyOptions int, architecturesList []string, progress aptly.Progress) (*PackageList, error) {
+// Filter filters package index by specified queries (ORed together), possibly pulling dependencies
+func (l *PackageList) Filter(options FilterOptions) (*PackageList, error) {
```

A call to `Filter` now looks like this (you can leave out arguments that have the default value):

```diff
-   repo.packageList, err = repo.packageList.FilterWithProgress([]PackageQuery{filterQuery}, repo.FilterWithDeps, emptyList, dependencyOptions, repo.Architectures, progress)
+ repo.packageList, err = repo.packageList.Filter(FilterOptions{
+         Queries:           []PackageQuery{filterQuery},
+         WithDependencies:  repo.FilterWithDeps,
+         Source:            emptyList,
+         DependencyOptions: dependencyOptions,
+         Architectures:     repo.Architectures,
+         Progress:          progress,
+ })
```

This change is independent of the bugfix though and I can revert it if you don't like it.

## Checklist

- [X] unit-test added (if change is algorithm)
- [x] functional test added/updated (if change is functional)
- [x] author name in `AUTHORS`
