### PR TITLE
Feature: Support Reading Filter Expressions from a File

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -7,9 +7,6 @@ import (
 	"os"
 	"text/template"
 	"time"
-	"bufio"
-	"io/ioutil"
-	"strings"
 
 	"github.com/aptly-dev/aptly/aptly"
 	"github.com/aptly-dev/aptly/deb"
@@ -131,36 +128,4 @@ package environment to new version.`,
 		cmd.Flag.Duration("meminterval", 100*time.Millisecond, "memory stats dump interval")
 	}
 	return cmd
-}
-
-// Reads the content of a file. If the file is "-", reads from stdin.
-func getContent(filterarg string) (string, error) {
-	var err error
-	// Check if filterarg starts with '@'
-	if strings.HasPrefix(filterarg, "@") {
-		// Remove the '@' character from filterarg
-		filterarg = strings.TrimPrefix(filterarg, "@")
-        if filterarg == "-" {
-			// If filterarg is "-", read from stdin
-			scanner := bufio.NewScanner(os.Stdin)
-			scanner.Split(bufio.ScanLines)
-			scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
-			var content strings.Builder
-			for scanner.Scan() {
-				content.WriteString(scanner.Text() + "\n")
-			}
-			err = scanner.Err()
-			if err == nil {
-				filterarg = content.String()
-			}
-		} else {
-			// Read the file content into a byte slice
-			var data []byte
-			data, err = ioutil.ReadFile(filterarg)
-			if err == nil {
-				filterarg = string(data)
-			}
-		}
-	}
-	return filterarg, err
 }

--- a/cmd/mirror_create.go
+++ b/cmd/mirror_create.go
@@ -46,7 +46,7 @@ func aptlyMirrorCreate(cmd *commander.Command, args []string) error {
 		return fmt.Errorf("unable to create mirror: %s", err)
 	}
 
-	repo.Filter, err = getContent(context.Flags().Lookup("filter").Value.String())
+	repo.Filter = context.Flags().Lookup("filter").Value.String()
 	repo.FilterWithDeps = context.Flags().Lookup("filter-with-deps").Value.Get().(bool)
 	repo.SkipComponentCheck = context.Flags().Lookup("force-components").Value.Get().(bool)
 	repo.SkipArchitectureCheck = context.Flags().Lookup("force-architectures").Value.Get().(bool)
@@ -106,7 +106,7 @@ Example:
 	cmd.Flag.Bool("with-installer", false, "download additional not packaged installer files")
 	cmd.Flag.Bool("with-sources", false, "download source packages in addition to binary packages")
 	cmd.Flag.Bool("with-udebs", false, "download .udeb packages (Debian installer support)")
-	cmd.Flag.String("filter", "", "filter packages in mirror")
+	AddStringOrFileFlag(&cmd.Flag, "filter", "", "filter packages in mirror, use '@file' to read filter from file or '@-' for stdin")
 	cmd.Flag.Bool("filter-with-deps", false, "when filtering, include dependencies of matching packages as well")
 	cmd.Flag.Bool("force-components", false, "(only with component list) skip check that requested components are listed in Release file")
 	cmd.Flag.Bool("force-architectures", false, "(only with architecture list) skip check that requested architectures are listed in Release file")

--- a/cmd/mirror_create.go
+++ b/cmd/mirror_create.go
@@ -46,15 +46,12 @@ func aptlyMirrorCreate(cmd *commander.Command, args []string) error {
 		return fmt.Errorf("unable to create mirror: %s", err)
 	}
 
-	repo.Filter = context.Flags().Lookup("filter").Value.String()
+	repo.Filter = context.Flags().Lookup("filter").Value.String() // allows file/stdin with @
 	repo.FilterWithDeps = context.Flags().Lookup("filter-with-deps").Value.Get().(bool)
 	repo.SkipComponentCheck = context.Flags().Lookup("force-components").Value.Get().(bool)
 	repo.SkipArchitectureCheck = context.Flags().Lookup("force-architectures").Value.Get().(bool)
 
 	if repo.Filter != "" {
-		if err != nil {
-			return fmt.Errorf("unable to read package query from file %s: %w", context.Flags().Lookup("filter").Value.String(), err)
-		}
 		_, err = query.Parse(repo.Filter)
 		if err != nil {
 			return fmt.Errorf("unable to create mirror: %s", err)

--- a/cmd/mirror_create.go
+++ b/cmd/mirror_create.go
@@ -46,12 +46,15 @@ func aptlyMirrorCreate(cmd *commander.Command, args []string) error {
 		return fmt.Errorf("unable to create mirror: %s", err)
 	}
 
-	repo.Filter = context.Flags().Lookup("filter").Value.String()
+	repo.Filter, err = getContent(context.Flags().Lookup("filter").Value.String())
 	repo.FilterWithDeps = context.Flags().Lookup("filter-with-deps").Value.Get().(bool)
 	repo.SkipComponentCheck = context.Flags().Lookup("force-components").Value.Get().(bool)
 	repo.SkipArchitectureCheck = context.Flags().Lookup("force-architectures").Value.Get().(bool)
 
 	if repo.Filter != "" {
+		if err != nil {
+			return fmt.Errorf("unable to read package query from file %s: %w", context.Flags().Lookup("filter").Value.String(), err)
+		}
 		_, err = query.Parse(repo.Filter)
 		if err != nil {
 			return fmt.Errorf("unable to create mirror: %s", err)

--- a/cmd/mirror_edit.go
+++ b/cmd/mirror_edit.go
@@ -29,12 +29,10 @@ func aptlyMirrorEdit(cmd *commander.Command, args []string) error {
 
 	fetchMirror := false
 	ignoreSignatures := context.Config().GpgDisableVerify
-	var f string
 	context.Flags().Visit(func(flag *flag.Flag) {
 		switch flag.Name {
 		case "filter":
-			repo.Filter, err = getContent(flag.Value.String())
-			f = flag.Value.String()
+			repo.Filter = flag.Value.String()
 		case "filter-with-deps":
 			repo.FilterWithDeps = flag.Value.Get().(bool)
 		case "with-installer":
@@ -50,10 +48,6 @@ func aptlyMirrorEdit(cmd *commander.Command, args []string) error {
 			ignoreSignatures = true
 		}
 	})
-
-	if repo.Filter != "" && err != nil {
-		return fmt.Errorf("unable to read package query from file %s: %w", f, err)
-	}
 
 	if repo.IsFlat() && repo.DownloadUdebs {
 		return fmt.Errorf("unable to edit: flat mirrors don't support udebs")
@@ -110,7 +104,7 @@ Example:
 	}
 
 	cmd.Flag.String("archive-url", "", "archive url is the root of archive")
-	cmd.Flag.String("filter", "", "filter packages in mirror")
+	AddStringOrFileFlag(&cmd.Flag, "filter", "", "filter packages in mirror, use '@file' to read filter from file or '@-' for stdin")
 	cmd.Flag.Bool("filter-with-deps", false, "when filtering, include dependencies of matching packages as well")
 	cmd.Flag.Bool("ignore-signatures", false, "disable verification of Release file signatures")
 	cmd.Flag.Bool("with-installer", false, "download additional not packaged installer files")

--- a/cmd/mirror_edit.go
+++ b/cmd/mirror_edit.go
@@ -32,7 +32,7 @@ func aptlyMirrorEdit(cmd *commander.Command, args []string) error {
 	context.Flags().Visit(func(flag *flag.Flag) {
 		switch flag.Name {
 		case "filter":
-			repo.Filter = flag.Value.String()
+			repo.Filter = flag.Value.String() // allows file/stdin with @
 		case "filter-with-deps":
 			repo.FilterWithDeps = flag.Value.Get().(bool)
 		case "with-installer":

--- a/cmd/package_search.go
+++ b/cmd/package_search.go
@@ -21,7 +21,11 @@ func aptlyPackageSearch(cmd *commander.Command, args []string) error {
 	}
 
 	if len(args) == 1 {
-		q, err = query.Parse(args[0])
+		value, err := GetStringOrFileContent(args[0])
+		if err != nil {
+			return fmt.Errorf("unable to read package query from file %s: %w", args[0], err)
+		}
+		q, err = query.Parse(value)
 		if err != nil {
 			return fmt.Errorf("unable to search: %s", err)
 		}
@@ -49,6 +53,7 @@ func makeCmdPackageSearch() *commander.Command {
 		Long: `
 Command search displays list of packages in whole DB that match package query.
 
+Use '@file' to read query from file or '@-' for stdin.
 If query is not specified, all the packages are displayed.
 
 Example:

--- a/cmd/package_show.go
+++ b/cmd/package_show.go
@@ -66,7 +66,11 @@ func aptlyPackageShow(cmd *commander.Command, args []string) error {
 		return commander.ErrCommandError
 	}
 
-	q, err := query.Parse(args[0])
+	value, err := GetStringOrFileContent(args[0])
+	if err != nil {
+		return fmt.Errorf("unable to read package query from file %s: %w", args[0], err)
+	}
+	q, err := query.Parse(value)
 	if err != nil {
 		return fmt.Errorf("unable to show: %s", err)
 	}
@@ -129,6 +133,8 @@ Command shows displays detailed meta-information about packages
 matching query. Information from Debian control file is displayed.
 Optionally information about package files and
 inclusion into mirrors/snapshots/local repos is shown.
+
+Use '@file' to read query from file or '@-' for stdin.
 
 Example:
 

--- a/cmd/repo_move.go
+++ b/cmd/repo_move.go
@@ -110,7 +110,11 @@ func aptlyRepoMoveCopyImport(cmd *commander.Command, args []string) error {
 
 	queries := make([]deb.PackageQuery, len(args)-2)
 	for i := 0; i < len(args)-2; i++ {
-		queries[i], err = query.Parse(args[i+2])
+		value, err := GetStringOrFileContent(args[i+2])
+		if err != nil {
+			return fmt.Errorf("unable to read package query from file %s: %w", args[i+2], err)
+		}
+		queries[i], err = query.Parse(value)
 		if err != nil {
 			return fmt.Errorf("unable to %s: %s", command, err)
 		}
@@ -185,6 +189,8 @@ func makeCmdRepoMove() *commander.Command {
 		Long: `
 Command move moves packages matching <package-query> from local repo
 <src-name> to local repo <dst-name>.
+
+Use '@file' to read package queries from file or '@-' for stdin.
 
 Example:
 

--- a/cmd/repo_remove.go
+++ b/cmd/repo_remove.go
@@ -38,7 +38,11 @@ func aptlyRepoRemove(cmd *commander.Command, args []string) error {
 
 	queries := make([]deb.PackageQuery, len(args)-1)
 	for i := 0; i < len(args)-1; i++ {
-		queries[i], err = query.Parse(args[i+1])
+		value, err := GetStringOrFileContent(args[i+1])
+		if err != nil {
+			return fmt.Errorf("unable to read package query from file %s: %w", args[i+1], err)
+		}
+		queries[i], err = query.Parse(value)
 		if err != nil {
 			return fmt.Errorf("unable to remove: %s", err)
 		}
@@ -80,6 +84,8 @@ Commands removes packages matching <package-query> from local repository
 <name>. If removed packages are not referenced by other repos or
 snapshots, they can be removed completely (including files) by running
 'aptly db cleanup'.
+
+Use '@file' to read package queries from file or '@-' for stdin.
 
 Example:
 

--- a/cmd/snapshot_filter.go
+++ b/cmd/snapshot_filter.go
@@ -60,7 +60,12 @@ func aptlySnapshotFilter(cmd *commander.Command, args []string) error {
 	// Initial queries out of arguments
 	queries := make([]deb.PackageQuery, len(args)-2)
 	for i, arg := range args[2:] {
-		queries[i], err = query.Parse(arg)
+		var q string
+		q, err = getContent(arg)
+		if err != nil {
+			return fmt.Errorf("unable to read package query from file %s: %w", arg, err)
+		}
+		queries[i], err = query.Parse(q)
 		if err != nil {
 			return fmt.Errorf("unable to parse query: %s", err)
 		}

--- a/cmd/snapshot_filter.go
+++ b/cmd/snapshot_filter.go
@@ -60,12 +60,11 @@ func aptlySnapshotFilter(cmd *commander.Command, args []string) error {
 	// Initial queries out of arguments
 	queries := make([]deb.PackageQuery, len(args)-2)
 	for i, arg := range args[2:] {
-		var q string
-		q, err = getContent(arg)
+		value, err := GetStringOrFileContent(arg)
 		if err != nil {
 			return fmt.Errorf("unable to read package query from file %s: %w", arg, err)
 		}
-		queries[i], err = query.Parse(q)
+		queries[i], err = query.Parse(value)
 		if err != nil {
 			return fmt.Errorf("unable to parse query: %s", err)
 		}
@@ -107,6 +106,8 @@ func makeCmdSnapshotFilter() *commander.Command {
 Command filter does filtering in snapshot <source>, producing another
 snapshot <destination>. Packages could be specified simply
 as 'package-name' or as package queries.
+
+Use '@file' syntax to read package queries from file and '@-' to read from stdin.
 
 Example:
 

--- a/cmd/snapshot_pull.go
+++ b/cmd/snapshot_pull.go
@@ -88,7 +88,12 @@ func aptlySnapshotPull(cmd *commander.Command, args []string) error {
 	// Initial queries out of arguments
 	queries := make([]deb.PackageQuery, len(args)-3)
 	for i, arg := range args[3:] {
-		queries[i], err = query.Parse(arg)
+		var q string
+		q, err = getContent(arg)
+		if err != nil {
+			return fmt.Errorf("unable to read package query from file %s: %w", arg, err)
+		}
+		queries[i], err = query.Parse(q)
 		if err != nil {
 			return fmt.Errorf("unable to parse query: %s", err)
 		}

--- a/cmd/snapshot_pull.go
+++ b/cmd/snapshot_pull.go
@@ -88,12 +88,11 @@ func aptlySnapshotPull(cmd *commander.Command, args []string) error {
 	// Initial queries out of arguments
 	queries := make([]deb.PackageQuery, len(args)-3)
 	for i, arg := range args[3:] {
-		var q string
-		q, err = getContent(arg)
+		value, err := GetStringOrFileContent(arg)
 		if err != nil {
 			return fmt.Errorf("unable to read package query from file %s: %w", arg, err)
 		}
-		queries[i], err = query.Parse(q)
+		queries[i], err = query.Parse(value)
 		if err != nil {
 			return fmt.Errorf("unable to parse query: %s", err)
 		}
@@ -171,6 +170,8 @@ from snapshot <source>. Pull can upgrade package version in <name> with
 versions from <source> following dependencies. New snapshot <destination>
 is created as a result of this process. Packages could be specified simply
 as 'package-name' or as package queries.
+
+Use '@file' syntax to read package queries from file and '@-' to read from stdin.
 
 Example:
 

--- a/cmd/snapshot_search.go
+++ b/cmd/snapshot_search.go
@@ -78,7 +78,11 @@ func aptlySnapshotMirrorRepoSearch(cmd *commander.Command, args []string) error 
 	list.PrepareIndex()
 
 	if len(args) == 2 {
-		q, err = query.Parse(args[1])
+		value, err := GetStringOrFileContent(args[1])
+		if err != nil {
+			return fmt.Errorf("unable to read package query from file %s: %w", args[1], err)
+		}
+		q, err = query.Parse(value)
 		if err != nil {
 			return fmt.Errorf("unable to search: %s", err)
 		}
@@ -133,6 +137,8 @@ func makeCmdSnapshotSearch() *commander.Command {
 Command search displays list of packages in snapshot that match package query
 
 If query is not specified, all the packages are displayed.
+
+Use '@file' syntax to read package query from file and '@-' to read from stdin.
 
 Example:
 

--- a/cmd/string_or_file_flag.go
+++ b/cmd/string_or_file_flag.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"io"
+	"os"
+	"strings"
+
+	"github.com/smira/flag"
+)
+
+// StringOrFileFlag is a custom flag type that can handle both string input and file input.
+// If the input starts with '@', it is treated as a filename and the contents are read from the file.
+// If the input is '@-', the contents are read from stdin.
+type StringOrFileFlag struct {
+	value string
+}
+
+func (s *StringOrFileFlag) String() string {
+	return s.value
+}
+
+func (s *StringOrFileFlag) Set(value string) error {
+	var err error
+	s.value, err = GetStringOrFileContent(value)
+	return err
+}
+
+func (s *StringOrFileFlag) Get() any {
+	return s.value
+}
+
+func AddStringOrFileFlag(flagSet *flag.FlagSet, name string, value string, usage string) *StringOrFileFlag {
+	result := &StringOrFileFlag{value: value}
+	flagSet.Var(result, name, usage)
+	return result
+}
+
+func GetStringOrFileContent(value string) (string, error) {
+	if !strings.HasPrefix(value, "@") {
+		return value, nil
+	}
+
+	filename := strings.TrimPrefix(value, "@")
+	var data []byte
+	var err error
+	if filename == "-" { // Read from stdin
+		data, err = io.ReadAll(os.Stdin)
+	} else {
+		data, err = os.ReadFile(filename)
+	}
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}

--- a/man/aptly.1
+++ b/man/aptly.1
@@ -588,7 +588,7 @@ Options:
 .
 .TP
 \-\fBfilter\fR=
-filter packages in mirror
+filter packages in mirror, use \(cq@file\(cq to read filter from file or \(cq@\-\(cq for stdin
 .
 .TP
 \-\fBfilter\-with\-deps\fR
@@ -771,7 +771,7 @@ archive url is the root of archive
 .
 .TP
 \-\fBfilter\fR=
-filter packages in mirror
+filter packages in mirror, use \(cq@file\(cq to read filter from file or \(cq@\-\(cq for stdin
 .
 .TP
 \-\fBfilter\-with\-deps\fR
@@ -1016,6 +1016,9 @@ display list in machine\-readable format
 Command move moves packages matching \fIpackage\-query\fR from local repo \fIsrc\-name\fR to local repo \fIdst\-name\fR\.
 .
 .P
+Use \(cq@file\(cq to read package queries from file or \(cq@\-\(cq for stdin\.
+.
+.P
 Example:
 .
 .P
@@ -1037,6 +1040,9 @@ follow dependencies when processing package\-spec
 .
 .P
 Commands removes packages matching \fIpackage\-query\fR from local repository \fIname\fR\. If removed packages are not referenced by other repos or snapshots, they can be removed completely (including files) by running \(cqaptly db cleanup\(cq\.
+.
+.P
+Use \(cq@file\(cq to read package queries from file or \(cq@\-\(cq for stdin\.
 .
 .P
 Example:
@@ -1263,6 +1269,9 @@ $ aptly snapshot verify wheezy\-main wheezy\-contrib wheezy\-non\-free
 Command pull pulls new packages along with its\(cq dependencies to snapshot \fIname\fR from snapshot \fIsource\fR\. Pull can upgrade package version in \fIname\fR with versions from \fIsource\fR following dependencies\. New snapshot \fIdestination\fR is created as a result of this process\. Packages could be specified simply as \(cqpackage\-name\(cq or as package queries\.
 .
 .P
+Use \(cq@file\(cq syntax to read package queries from file and \(cq@\-\(cq to read from stdin\.
+.
+.P
 Example:
 .
 .IP "" 4
@@ -1398,6 +1407,9 @@ Command search displays list of packages in snapshot that match package query
 If query is not specified, all the packages are displayed\.
 .
 .P
+Use \(cq@file\(cq syntax to read package query from file and \(cq@\-\(cq to read from stdin\.
+.
+.P
 Example:
 .
 .IP "" 4
@@ -1426,6 +1438,9 @@ include dependencies into search results
 .
 .P
 Command filter does filtering in snapshot \fIsource\fR, producing another snapshot \fIdestination\fR\. Packages could be specified simply as \(cqpackage\-name\(cq or as package queries\.
+.
+.P
+Use \(cq@file\(cq syntax to read package queries from file and \(cq@\-\(cq to read from stdin\.
 .
 .P
 Example:
@@ -2206,7 +2221,7 @@ don\(cqt sign Release files with GPG
 Command search displays list of packages in whole DB that match package query\.
 .
 .P
-If query is not specified, all the packages are displayed\.
+Use \(cq@file\(cq to read query from file or \(cq@\-\(cq for stdin\. If query is not specified, all the packages are displayed\.
 .
 .P
 Example:
@@ -2233,6 +2248,9 @@ custom format for result printing
 .
 .P
 Command shows displays detailed meta\-information about packages matching query\. Information from Debian control file is displayed\. Optionally information about package files and inclusion into mirrors/snapshots/local repos is shown\.
+.
+.P
+Use \(cq@file\(cq to read query from file or \(cq@\-\(cq for stdin\.
 .
 .P
 Example:
@@ -2652,6 +2670,9 @@ Blake Kostner (https://github\.com/btkostner)
 .
 .IP "\[ci]" 4
 Leigh London (https://github\.com/leighlondon)
+.
+.IP "\[ci]" 4
+Gordian Schönherr (https://github\.com/schoenherrg)
 .
 .IP "" 0
 

--- a/system/t03_help/MirrorCreateHelpTest_gold
+++ b/system/t03_help/MirrorCreateHelpTest_gold
@@ -21,7 +21,7 @@ Options:
   -dep-follow-source: when processing dependencies, follow from binary to Source packages
   -dep-follow-suggests: when processing dependencies, follow Suggests
   -dep-verbose-resolve: when processing dependencies, print detailed logs
-  -filter="": filter packages in mirror
+  -filter=: filter packages in mirror, use '@file' to read filter from file or '@-' for stdin
   -filter-with-deps: when filtering, include dependencies of matching packages as well
   -force-architectures: (only with architecture list) skip check that requested architectures are listed in Release file
   -force-components: (only with component list) skip check that requested components are listed in Release file

--- a/system/t03_help/MirrorCreateTest_gold
+++ b/system/t03_help/MirrorCreateTest_gold
@@ -12,7 +12,7 @@ Options:
   -dep-follow-source: when processing dependencies, follow from binary to Source packages
   -dep-follow-suggests: when processing dependencies, follow Suggests
   -dep-verbose-resolve: when processing dependencies, print detailed logs
-  -filter="": filter packages in mirror
+  -filter=: filter packages in mirror, use '@file' to read filter from file or '@-' for stdin
   -filter-with-deps: when filtering, include dependencies of matching packages as well
   -force-architectures: (only with architecture list) skip check that requested architectures are listed in Release file
   -force-components: (only with component list) skip check that requested components are listed in Release file

--- a/system/t03_help/WrongFlagTest_gold
+++ b/system/t03_help/WrongFlagTest_gold
@@ -13,7 +13,7 @@ Options:
   -dep-follow-source: when processing dependencies, follow from binary to Source packages
   -dep-follow-suggests: when processing dependencies, follow Suggests
   -dep-verbose-resolve: when processing dependencies, print detailed logs
-  -filter="": filter packages in mirror
+  -filter=: filter packages in mirror, use '@file' to read filter from file or '@-' for stdin
   -filter-with-deps: when filtering, include dependencies of matching packages as well
   -force-architectures: (only with architecture list) skip check that requested architectures are listed in Release file
   -force-components: (only with component list) skip check that requested components are listed in Release file

--- a/system/t04_mirror/CreateMirror36Test_gold
+++ b/system/t04_mirror/CreateMirror36Test_gold
@@ -1,0 +1,4 @@
+Downloading: http://repo.aptly.info/system-tests/archive.debian.org/debian-security/dists/stretch/updates/Release
+
+Mirror [mirror36]: http://repo.aptly.info/system-tests/archive.debian.org/debian-security/ stretch/updates successfully added.
+You can run 'aptly mirror update mirror36' to download repository contents.

--- a/system/t04_mirror/CreateMirror36Test_mirror_show
+++ b/system/t04_mirror/CreateMirror36Test_mirror_show
@@ -1,0 +1,22 @@
+Name: mirror36
+Archive Root URL: http://repo.aptly.info/system-tests/archive.debian.org/debian-security/
+Distribution: stretch/updates
+Components: main
+Architectures: amd64, arm64, armel, armhf, i386
+Download Sources: no
+Download .udebs: no
+Filter: nginx | Priority (required)
+Filter With Deps: no
+Last update: never
+
+Information from release file:
+Acquire-By-Hash: yes
+Architectures: amd64 arm64 armel armhf i386
+Codename: stretch
+Components: updates/main updates/contrib updates/non-free
+Description:  Debian 9 Security Updates
+
+Label: Debian-Security
+Origin: Debian
+Suite: oldoldstable
+Version: 9

--- a/system/t04_mirror/CreateMirror37Test_gold
+++ b/system/t04_mirror/CreateMirror37Test_gold
@@ -1,0 +1,4 @@
+Downloading: http://repo.aptly.info/system-tests/archive.debian.org/debian-security/dists/stretch/updates/Release
+
+Mirror [mirror37]: http://repo.aptly.info/system-tests/archive.debian.org/debian-security/ stretch/updates successfully added.
+You can run 'aptly mirror update mirror37' to download repository contents.

--- a/system/t04_mirror/CreateMirror37Test_mirror_show
+++ b/system/t04_mirror/CreateMirror37Test_mirror_show
@@ -1,0 +1,22 @@
+Name: mirror37
+Archive Root URL: http://repo.aptly.info/system-tests/archive.debian.org/debian-security/
+Distribution: stretch/updates
+Components: main
+Architectures: amd64, arm64, armel, armhf, i386
+Download Sources: no
+Download .udebs: no
+Filter: nginx | Priority (required)
+Filter With Deps: no
+Last update: never
+
+Information from release file:
+Acquire-By-Hash: yes
+Architectures: amd64 arm64 armel armhf i386
+Codename: stretch
+Components: updates/main updates/contrib updates/non-free
+Description:  Debian 9 Security Updates
+
+Label: Debian-Security
+Origin: Debian
+Suite: oldoldstable
+Version: 9


### PR DESCRIPTION
Fixes #1409

## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

<!--

Why this change is important?

-->

As mentioned in the Issue, we have filter expressions that exceed the command line length limit and thus need to be read from a file/stdin. This PR extends the Aptly command-line interface to be able to read filter expressions from a file using the `@/path/to/file` syntax or `@-` for stdin.

Our use case is only for the `-filter` argument for `mirror create`/`mirror edit`. However, there are other places in Aptly where filter expressions are accepted, so I added support for the `@file` syntax everywhere for consistency.

Commands where the `@file` syntax is supported now:

- `mirror create`
- `mirror edit`
- `package search`
- `package show`
- `repo move`
- `repo remove`
- `snapshot filter`
- `snapshot pull`
- `snapshot search`

## Checklist

- [ ] unit-test added (if change is algorithm)
- [X] functional test added/updated (if change is functional)
- [x] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [X] documentation updated
- [X] author name in `AUTHORS`
