### PR TITLE
Allow snapshotting empty mirrors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,9 +44,9 @@ Debian / Ubuntu
 
 Aptly is provided in the following debian packages:
 
-* aptly (main binary)
-* aptly-api (systemd service for REST API)
-* aptly-dbgsym (debugging symbols)
+* **aptly**: Includes the main Aptly binary, man pages, and shell completions
+* **aptly-api**: A systemd service for the REST API, using the global /etc/aptly.conf
+* **aptly-dbg**: Debug symbols for troubleshooting
 
 The packages can be installed on official `Debian <https://packages.debian.org/search?keywords=aptly>`_ and `Ubuntu <https://packages.ubuntu.com/search?keywords=aptly>`_ distributions.
 

--- a/deb/snapshot.go
+++ b/deb/snapshot.go
@@ -45,7 +45,7 @@ type Snapshot struct {
 
 // NewSnapshotFromRepository creates snapshot from current state of repository
 func NewSnapshotFromRepository(name string, repo *RemoteRepo) (*Snapshot, error) {
-	if repo.packageRefs == nil || repo.packageRefs.Len() == 0 {
+	if repo.packageRefs == nil {
 		return nil, errors.New("mirror not updated")
 	}
 

--- a/system/t05_snapshot/CreateSnapshot10Test_gold
+++ b/system/t05_snapshot/CreateSnapshot10Test_gold
@@ -1,0 +1,3 @@
+
+Snapshot oh-snap successfully created.
+You can run 'aptly publish snapshot oh-snap' to publish snapshot as Debian repository.

--- a/system/t05_snapshot/create.py
+++ b/system/t05_snapshot/create.py
@@ -106,3 +106,14 @@ class CreateSnapshot9Test(BaseTest):
         "aptly repo create local-repo",
     ]
     runCmd = "aptly snapshot create snap9 from repo local-repo"
+
+
+class CreateSnapshot10Test(BaseTest):
+    """
+    create snapshot: from empty mirror
+    """
+    fixtureCmds = [
+        "aptly mirror create -ignore-signatures non-free http://repo.aptly.info/system-tests/security.debian.org/debian-security bookworm-security updates/non-free",
+        "aptly mirror update -ignore-signatures non-free"
+    ]
+    runCmd = "aptly snapshot create oh-snap from mirror non-free"


### PR DESCRIPTION
Fixes https://github.com/aptly-dev/aptly/issues/1416

- allow to create snapshots of empty mirrors
- add test

- [x] uploaded relevant test files to repo.aptly.info