### PR TITLE
postrm: remove aptly-api user and home directory on purge

### DIFF
--- a/debian/aptly-api.postrm
+++ b/debian/aptly-api.postrm
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+
+# source debconf library
+. /usr/share/debconf/confmodule
+
+case "$1" in
+    purge|remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+	# only remove aptly-api user and its homedir on purge
+	if [ "${1}" = "purge" ] ; then
+	    userdel -r aptly-api
+	fi
+    ;;
+
+    *)
+        echo "postrm called with unknown argument \`$1'" >&2
+        exit 1
+    ;;
+esac
+
+#DEBHELPER#
+
+exit 0


### PR DESCRIPTION
## Description of the Change

according to debian policy, purge should leave no trace. 

this change removes the user and aptly data on apt-get purge.

See: https://piuparts.debian.org/sid-strict/fail/aptly-api_1.6.0+ds1-3.log
