### PR TITLE
Release/1.6.1

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -1,0 +1,15 @@
+# Creating a Release
+
+- create branch release/1.x.y
+- update debian/changelog
+- create PR, merge when approved
+- on updated master, git tag and push:
+    ```
+    version=$(dpkg-parsechangelog -S Version)
+    git tag -a v$version -m 'aptly: release $version'
+    git push aptly-dev v$version
+    ```
+- run swagger locally
+- add generated swagger-1.x.y.json to www.aptly.info
+- releae www.aptly.info
+- create release announcement on https://github.com/aptly-dev/aptly/discussions

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+aptly (1.6.1) stable; urgency=medium
+
+  * update golang-github-syndtr-goleveldb-dev dependency (v1.0.1-0.20220721030215-126854af5e6d) to fix segfault on arm64
+    (bug in golang-github-golang-snappy-dev)
+  * allow snapshotting empty mirrors again (regression)
+  * debian compliance: add postrm (note: `apt purge aptly-api` will remove all data in ~aptly-api/)
+  * update other dependencies (x/net 0.33.0, gin-gonic/gin 1.9.1)
+
+ -- André Roth <neolynx@gmail.com>  Sat, 15 Feb 2025 13:03:16 +0100
+
 aptly (1.6.0) stable; urgency=medium
 
   * support reading filters from file or stdin


### PR DESCRIPTION
  * update golang-github-syndtr-goleveldb-dev dependency (v1.0.1-0.20220721030215-126854af5e6d) to fix segfault on arm64
  * allow snapshotting empty mirrors again (regression)
  * debian compliance: add postrm (note: `apt purge aptly-api` will remove all data in ~aptly-api/)
  * update other dependencies (x/net 0.33.0, gin-gonic/gin 1.9.1)
