### PR TITLE
Editing repo via api 404

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -72,3 +72,4 @@ List of contributors, in chronological order:
 * Itay Porezky (https://github.com/itayporezky)
 * JupiterRider (https://github.com/JupiterRider)
 * Agustin Henze (https://github.com/agustinhenze)
+* Tobias Assarsson (https://github.com/daedaluz)

--- a/api/repos.go
+++ b/api/repos.go
@@ -195,17 +195,18 @@ func apiReposEdit(c *gin.Context) {
 	collectionFactory := context.NewCollectionFactory()
 	collection := collectionFactory.LocalRepoCollection()
 
-	repo, err := collection.ByName(c.Params.ByName("name"))
+	name := c.Params.ByName("name")
+	repo, err := collection.ByName(name)
 	if err != nil {
 		AbortWithJSONError(c, 404, err)
 		return
 	}
 
-	if b.Name != nil {
+	if b.Name != nil && *b.Name != name {
 		_, err := collection.ByName(*b.Name)
 		if err == nil {
 			// already exists
-			AbortWithJSONError(c, 404, err)
+			AbortWithJSONError(c, 404, fmt.Errorf("local repo with name %q already exists", *b.Name))
 			return
 		}
 		repo.Name = *b.Name


### PR DESCRIPTION
# Editing repo via 

Fixes #1453 

## Description of the Change

This fixes the repo edit api by correcting the logic that checks if the target repo name already exists.
Also, replies with an error describing the issue instead of an empty 404 reply

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [x] author name in `AUTHORS`