### PR TITLE
feat: Support for only downloading the latest version of packages

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -74,3 +74,4 @@ List of contributors, in chronological order:
 * JupiterRider (https://github.com/JupiterRider)
 * Agustin Henze (https://github.com/agustinhenze)
 * Tobias Assarsson (https://github.com/daedaluz)
+* Juan Calderon-Perez (https://github.com/gaby)

--- a/api/mirror.go
+++ b/api/mirror.go
@@ -343,6 +343,8 @@ type mirrorUpdateParams struct {
 	ForceUpdate bool `            json:"ForceUpdate"`
 	// Set "true" to skip downloading already downloaded packages
 	SkipExistingPackages bool `   json:"SkipExistingPackages"`
+	// Set "true" to download only the latest version per package/architecture
+	LatestOnly bool `             json:"LatestOnly"`
 }
 
 // @Summary Update Mirror
@@ -434,7 +436,7 @@ func apiMirrorsUpdate(c *gin.Context) {
 		}
 
 		queue, downloadSize, err := remote.BuildDownloadQueue(context.PackagePool(), collectionFactory.PackageCollection(),
-			collectionFactory.ChecksumCollection(nil), b.SkipExistingPackages)
+			collectionFactory.ChecksumCollection(nil), b.SkipExistingPackages, b.LatestOnly)
 		if err != nil {
 			return &task.ProcessReturnValue{Code: http.StatusInternalServerError, Value: nil}, fmt.Errorf("unable to update: %s", err)
 		}

--- a/cmd/mirror_update.go
+++ b/cmd/mirror_update.go
@@ -87,10 +87,11 @@ func aptlyMirrorUpdate(cmd *commander.Command, args []string) error {
 	)
 
 	skipExistingPackages := context.Flags().Lookup("skip-existing-packages").Value.Get().(bool)
+	latestOnly := context.Flags().Lookup("latest").Value.Get().(bool)
 
 	context.Progress().Printf("Building download queue...\n")
 	queue, downloadSize, err = repo.BuildDownloadQueue(context.PackagePool(), collectionFactory.PackageCollection(),
-		collectionFactory.ChecksumCollection(nil), skipExistingPackages)
+		collectionFactory.ChecksumCollection(nil), skipExistingPackages, latestOnly)
 
 	if err != nil {
 		return fmt.Errorf("unable to update: %s", err)
@@ -292,6 +293,7 @@ Example:
 	cmd.Flag.Bool("ignore-checksums", false, "ignore checksum mismatches while downloading package files and metadata")
 	cmd.Flag.Bool("ignore-signatures", false, "disable verification of Release file signatures")
 	cmd.Flag.Bool("skip-existing-packages", false, "do not check file existence for packages listed in the internal database of the mirror")
+	cmd.Flag.Bool("latest", false, "download only latest version of each package (per architecture)")
 	cmd.Flag.Int64("download-limit", 0, "limit download speed (kbytes/sec)")
 	cmd.Flag.String("downloader", "default", "downloader to use (e.g. grab)")
 	cmd.Flag.Int("max-tries", 1, "max download tries till process fails with download error")

--- a/completion.d/_aptly
+++ b/completion.d/_aptly
@@ -211,6 +211,7 @@ local keyring="*-keyring=[gpg keyring to use when verifying Release file (could 
                             $keyring \
                             "-max-tries=[max download tries till process fails with download error]:number: " \
                             "-skip-existing-packages=[do not check file existence for packages listed in the internal database of the mirror]:$bool" \
+                            "-latest=[download only latest version of each package (per architecture)]:$bool" \
                             "(-)2:mirror name:$mirrors"
                         ;;
                     rename)

--- a/completion.d/aptly
+++ b/completion.d/aptly
@@ -263,7 +263,7 @@ _aptly()
           "update")
             if [[ $numargs -eq 0 ]]; then
               if [[ "$cur" == -* ]]; then
-                COMPREPLY=($(compgen -W "-force -download-limit= -downloader= -ignore-checksums -ignore-signatures -keyring= -skip-existing-packages" -- ${cur}))
+                COMPREPLY=($(compgen -W "-force -download-limit= -downloader= -ignore-checksums -ignore-signatures -keyring= -skip-existing-packages -latest" -- ${cur}))
               else
                 COMPREPLY=($(compgen -W "$(__aptly_mirror_list)" -- ${cur}))
               fi

--- a/deb/remote.go
+++ b/deb/remote.go
@@ -612,7 +612,19 @@ func (repo *RemoteRepo) ApplyFilter(dependencyOptions int, filterQuery PackageQu
 }
 
 // BuildDownloadQueue builds queue, discards current PackageList
-func (repo *RemoteRepo) BuildDownloadQueue(packagePool aptly.PackagePool, packageCollection *PackageCollection, checksumStorage aptly.ChecksumStorage, skipExistingPackages bool) (queue []PackageDownloadTask, downloadSize int64, err error) {
+func (repo *RemoteRepo) BuildDownloadQueue(packagePool aptly.PackagePool, packageCollection *PackageCollection, checksumStorage aptly.ChecksumStorage, skipExistingPackages, latestOnly bool) (queue []PackageDownloadTask, downloadSize int64, err error) {
+	if repo.packageList == nil {
+		err = fmt.Errorf("package list is empty, please (re)download package indexes")
+		return
+	}
+
+	if latestOnly {
+		repo.packageList, err = repo.packageList.FilterLatest()
+		if err != nil {
+			return
+		}
+	}
+
 	queue = make([]PackageDownloadTask, 0, repo.packageList.Len())
 	seen := make(map[string]int, repo.packageList.Len())
 

--- a/man/aptly.1
+++ b/man/aptly.1
@@ -738,6 +738,10 @@ max download tries till process fails with download error
 \-\fBskip\-existing\-packages\fR
 do not check file existence for packages listed in the internal database of the mirror
 .
+.TP
+\-\fBlatest\fR
+download only latest version of each package (per architecture)
+.
 .SH "RENAMES MIRROR"
 \fBaptly\fR \fBmirror\fR \fBrename\fR \fIold\-name\fR \fInew\-name\fR
 .


### PR DESCRIPTION
Fixes #1315 #1372

## Description of the Change

This PR enhances the mirror update functionality by adding support for downloading only the latest version of each package per architecture.

Being able to download only the latest version would allow savings on bandwidth and storage usage.

## Checklist

- [x] unit-test added (if change is algorithm)
- [x] functional test added/updated (if change is functional)
- [x] man page updated (if applicable)
- [x] bash completion updated (if applicable)
- [x] documentation updated
- [ ] author name in `AUTHORS`
