### PR TITLE
fix `t06_publish/PublishSnapshot43Test_gold` gold error

### DIFF
--- a/system/t06_publish/PublishSnapshot43Test_gold
+++ b/system/t06_publish/PublishSnapshot43Test_gold
@@ -5,7 +5,7 @@ Signing file 'Release' with gpg, please enter your passphrase when prompted:
 Clearsigning file 'Release' with gpg, please enter your passphrase when prompted:
 
 Snapshot snap43 has been successfully published.
-Please setup your webserver to serve directory '/home/runner/.aptly/public' with autoindexing.
+Please setup your webserver to serve directory '${HOME}/.aptly/public' with autoindexing.
 Now you can add following line to apt sources:
   deb http://your-server/ maverick main
 Don't forget to add your GPG key to apt with apt-key.


### PR DESCRIPTION
Fixes #

## Requirements


## Description of the Change


Without this fix `make docker-system-test` failed as:

```
. t06_publish   ➔ PublishSnapshot43Test               FAIL      2s
running command: aptly snapshot create snap43 from mirror gnuplot-maverick

Exception: content doesn't match:
--- 
+++ 
@@ -5,7 +5,7 @@
 Generating metadata files and linking package files...
 Loading packages...
 Now you can add following line to apt sources:
-Please setup your webserver to serve directory '/home/runner/.aptly/public' with autoindexing.
+Please setup your webserver to serve directory '/var/lib/aptly/.aptly/public' with autoindexing.
 Signing file 'Release' with gpg, please enter your passphrase when prompted:
 Snapshot snap43 has been successfully published.
 You can also use `aptly serve` to publish your repositories over HTTP quickly.
...

```

## Checklist

- [x] allow Maintainers to edit PR (rebase, run coverage, help with tests, ...)
- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [ ] author name in `AUTHORS`
