### PR TITLE
Fix/launchpad test dependency

### DIFF
--- a/deb/ppa.go
+++ b/deb/ppa.go
@@ -28,6 +28,11 @@ func ParsePPA(ppaURL string, config *utils.ConfigStructure) (url string, distrib
 		}
 	}
 
+	baseurl := config.PpaBaseURL
+	if baseurl == "" {
+		baseurl = "http://ppa.launchpad.net"
+	}
+
 	codename := config.PpaCodename
 	if codename == "" {
 		codename, err = getCodename()
@@ -39,7 +44,7 @@ func ParsePPA(ppaURL string, config *utils.ConfigStructure) (url string, distrib
 
 	distribution = codename
 	components = []string{"main"}
-	url = fmt.Sprintf("http://ppa.launchpad.net/%s/%s/%s", matches[1], matches[2], distributorID)
+	url = fmt.Sprintf("%s/%s/%s/%s", baseurl, matches[1], matches[2], distributorID)
 
 	return
 }

--- a/debian/aptly.conf
+++ b/debian/aptly.conf
@@ -70,6 +70,9 @@ ppa_distributor_id: ubuntu
 # Codename for short PPA url expansion
 ppa_codename: ""
 
+# PPA Base URL (default: launchpad)
+# # ppa_baseurl: http://ppa.launchpad.net
+
 
 # Aptly Server
 ###############

--- a/system/t02_config/ConfigShowTest_gold
+++ b/system/t02_config/ConfigShowTest_gold
@@ -12,6 +12,7 @@
     "dependencyVerboseResolve": false,
     "ppaDistributorID": "ubuntu",
     "ppaCodename": "",
+    "ppaBaseURL": "http://ppa.launchpad.net",
     "serveInAPIMode": true,
     "enableMetricsEndpoint": true,
     "enableSwaggerEndpoint": false,

--- a/system/t02_config/ConfigShowYAMLTest_gold
+++ b/system/t02_config/ConfigShowYAMLTest_gold
@@ -11,6 +11,7 @@ dep_follow_source: false
 dep_verboseresolve: false
 ppa_distributor_id: ubuntu
 ppa_codename: ""
+ppa_baseurl: http://ppa.launchpad.net
 serve_in_api_mode: true
 enable_metrics_endpoint: true
 enable_swagger_endpoint: false

--- a/system/t02_config/CreateConfigTest_gold
+++ b/system/t02_config/CreateConfigTest_gold
@@ -70,6 +70,9 @@ ppa_distributor_id: ubuntu
 # Codename for short PPA url expansion
 ppa_codename: ""
 
+# PPA Base URL (default: launchpad)
+# # ppa_baseurl: http://ppa.launchpad.net
+
 
 # Aptly Server
 ###############

--- a/system/t04_mirror/CreateMirror18Test_gold
+++ b/system/t04_mirror/CreateMirror18Test_gold
@@ -1,4 +1,4 @@
-Downloading: http://ppa.launchpad.net/gladky-anton/gnuplot/ubuntu/dists/maverick/InRelease
+Downloading: http://repo.aptly.info/system-tests/ppa/gladky-anton/gnuplot/ubuntu/dists/maverick/InRelease
 gpgv: Signature made Sun Jul 28 07:57:01 2024 UTC
 gpgv:                using RSA key 5BFCD481D86D5824470E469F9000B1C3A01F726C
 gpgv: Good signature from "Launchpad PPA for Anton Gladky"
@@ -6,5 +6,5 @@ gpgv: Signature made Sun Jul 28 07:57:01 2024 UTC
 gpgv:                using RSA key 02219381E9161C78A46CB2BFA5279A973B1F56C0
 gpgv: Good signature from "Launchpad sim"
 
-Mirror [mirror18]: http://ppa.launchpad.net/gladky-anton/gnuplot/ubuntu/ maverick successfully added.
+Mirror [mirror18]: http://repo.aptly.info/system-tests/ppa/gladky-anton/gnuplot/ubuntu/ maverick successfully added.
 You can run 'aptly mirror update mirror18' to download repository contents.

--- a/system/t04_mirror/CreateMirror18Test_mirror_show
+++ b/system/t04_mirror/CreateMirror18Test_mirror_show
@@ -1,5 +1,5 @@
 Name: mirror18
-Archive Root URL: http://ppa.launchpad.net/gladky-anton/gnuplot/ubuntu/
+Archive Root URL: http://repo.aptly.info/system-tests/ppa/gladky-anton/gnuplot/ubuntu/
 Distribution: maverick
 Components: main
 Architectures: amd64, armel, i386, powerpc

--- a/system/t04_mirror/create.py
+++ b/system/t04_mirror/create.py
@@ -221,6 +221,7 @@ class CreateMirror18Test(BaseTest):
         "max-tries": 1,
         "ppaDistributorID": "ubuntu",
         "ppaCodename": "maverick",
+        "ppaBaseURL": "http://repo.aptly.info/system-tests/ppa",
     }
 
     fixtureCmds = [

--- a/utils/config.go
+++ b/utils/config.go
@@ -31,6 +31,7 @@ type ConfigStructure struct { // nolint: maligned
 	// PPA
 	PpaDistributorID string `json:"ppaDistributorID"              yaml:"ppa_distributor_id"`
 	PpaCodename      string `json:"ppaCodename"                   yaml:"ppa_codename"`
+	PpaBaseURL       string `json:"ppaBaseURL"                    yaml:"ppa_baseurl"`
 
 	// Server
 	ServeInAPIMode        bool `json:"serveInAPIMode"                yaml:"serve_in_api_mode"`
@@ -235,6 +236,7 @@ var Config = ConfigStructure{
 	SkipLegacyPool:         false,
 	PpaDistributorID:       "ubuntu",
 	PpaCodename:            "",
+	PpaBaseURL:             "http://ppa.launchpad.net",
 	FileSystemPublishRoots: map[string]FileSystemPublishRoot{},
 	S3PublishRoots:         map[string]S3PublishRoot{},
 	SwiftPublishRoots:      map[string]SwiftPublishRoot{},

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -85,6 +85,7 @@ func (s *ConfigSuite) TestSaveConfig(c *C) {
 		"  \"dependencyVerboseResolve\": false,\n" +
 		"  \"ppaDistributorID\": \"\",\n" +
 		"  \"ppaCodename\": \"\",\n" +
+		"  \"ppaBaseURL\": \"\",\n" +
 		"  \"serveInAPIMode\": false,\n" +
 		"  \"enableMetricsEndpoint\": false,\n" +
 		"  \"enableSwaggerEndpoint\": false,\n" +
@@ -252,6 +253,7 @@ func (s *ConfigSuite) TestSaveYAML2Config(c *C) {
 		"dep_verboseresolve: false\n" +
 		"ppa_distributor_id: \"\"\n" +
 		"ppa_codename: \"\"\n" +
+		"ppa_baseurl: \"\"\n" +
 		"serve_in_api_mode: false\n" +
 		"enable_metrics_endpoint: false\n" +
 		"enable_swagger_endpoint: false\n" +
@@ -308,6 +310,7 @@ dep_follow_source: true
 dep_verboseresolve: true
 ppa_distributor_id: Ubuntu
 ppa_codename: code
+ppa_baseurl: http://ppa.launchpad.net
 serve_in_api_mode: true
 enable_metrics_endpoint: true
 enable_swagger_endpoint: true


### PR DESCRIPTION
## Description of the Change

System Tests (i.e. CreateMirror18Test) is depending on ppa.launchpad.net to be available, which is not always the case.

This change resolves that dependency by:
* making the ppa base urla configureable
* use a mirrored ppa on s3 for testing* 


