### PR TITLE
Dont lock the go version to the .0 release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aptly-dev/aptly
 
-go 1.25.0
+go 1.25
 
 require (
 	github.com/AlekSi/pointer v1.1.0


### PR DESCRIPTION
the .0 release of go 1.25 is not the latest version of that release so missing out on security fixes etc

Ideally aptly should be on the 1.26 release as that is the latest stable version as when 1.27 of golang is released 1.25 will no longer be maintained, if you need a easy way to keep golang up to date on you system take a look at  
which is my personal github account https://github.com/L1ghtn1ng/go-updater