### PR TITLE
deb publish: Create unique temporary files each time

### DIFF
--- a/deb/publish.go
+++ b/deb/publish.go
@@ -893,7 +893,7 @@ func (p *PublishedRepo) Publish(packagePool aptly.PackagePool, publishedStorageP
 
 	var suffix string
 	if p.rePublishing {
-		suffix = ".tmp"
+		suffix = ".tmp." + uuid.NewString()
 	}
 
 	if progress != nil {


### PR DESCRIPTION
If two publish jobs run concurrently (which they arguably shouldn’t), they’d step on each other toes and remove Packages.tmp file the other job’s just created.

The API has locking for concurrent publish/drop operations on the same prefix, but command-line operations bypass that lock. Also, not having a predictable temporary filename is generally good from a security standpoint, given that cryptographic signing is involved.

Work around the issue by creating a per-job temporary file.