### PR TITLE
api: fix snasphot-pull

### DIFF
--- a/api/snapshot.go
+++ b/api/snapshot.go
@@ -800,6 +800,10 @@ func apiSnapshotsPull(c *gin.Context) {
 		if err != nil {
 			return &task.ProcessReturnValue{Code: http.StatusInternalServerError, Value: nil}, err
 		}
+		err = taskCollectionFactory.SnapshotCollection().LoadComplete(freshToSnapshot)
+		if err != nil {
+			return &task.ProcessReturnValue{Code: http.StatusInternalServerError, Value: nil}, err
+		}
 		freshSourceSnapshot, err := taskCollectionFactory.SnapshotCollection().ByName(body.Source)
 		if err != nil {
 			return &task.ProcessReturnValue{Code: http.StatusInternalServerError, Value: nil}, err


### PR DESCRIPTION
in the API, snapshotPull never finished reading the target repository within the async block. So the target was treated as an empty snapshot, and a pull would only carry over the content from the sources

Fixes #1610

## Description of the Change

This PR adds calls `LoadComplete` on  `freshToSnapshot`. 

## Checklist

As this is a very minor change, i did not attribute myself in Authors.

- [x] allow Maintainers to edit PR (rebase, run coverage, help with tests, ...)
- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [ ] author name in `AUTHORS`
