### PR TITLE
api/publish: allow setting custom Codename on the Release file

### DIFF
--- a/api/publish.go
+++ b/api/publish.go
@@ -160,6 +160,8 @@ type publishedRepoCreateParams struct {
 	Sources []sourceParams `binding:"required"    json:"Sources"`
 	// Distribution name, if missing Aptly would try to guess from sources
 	Distribution string `                         json:"Distribution"          example:"bookworm"`
+	// Value of Codename: field in published repository stanza, if missing equals Distribution
+	Codename string `                             json:"Codename"              example:"bookworm"`
 	// Value of Label: field in published repository stanza
 	Label string `                                json:"Label"                 example:""`
 	// Value of Origin: field in published repository stanza
@@ -354,6 +356,7 @@ func apiPublishRepoOrSnapshot(c *gin.Context) {
 		if b.ButAutomaticUpgrades != "" {
 			published.ButAutomaticUpgrades = b.ButAutomaticUpgrades
 		}
+		published.Codename = b.Codename
 		published.Label = b.Label
 
 		published.SkipContents = context.Config().SkipContentsPublishing

--- a/system/t12_api/publish.py
+++ b/system/t12_api/publish.py
@@ -75,7 +75,7 @@ class PublishAPITestRepo(APITest):
         self.check_exists(
             "public/" + prefix + "/pool/main/b/boost-defaults/libboost-program-options-dev_1.49.0.1_i386.deb")
 
-        # publishing under root, custom distribution, architectures
+        # publishing under root, custom distribution, architectures, codename
         distribution = self.random_name()
         task = self.post_task(
             "/api/publish/:.",
@@ -85,13 +85,14 @@ class PublishAPITestRepo(APITest):
                  "Signing": DefaultSigningOptions,
                  "Distribution": distribution,
                  "Architectures": ["i386", "amd64"],
+                 "Codename": distribution,
             }
         )
         self.check_task(task)
         repo2_expected = {
             'AcquireByHash': False,
             'Architectures': ['amd64', 'i386'],
-            'Codename': '',
+            'Codename': distribution,
             'Distribution': distribution,
             'Label': '',
             'Origin': '',


### PR DESCRIPTION
## Description of the Change

Currently, when publishing via the API, the Codename is always set to the same string as the Distribution.  This does not match the `aptly` CLI behaviour, where it is possible to set a `-codename` flag.

The CLI does not support updating the Codename after the published repo has been created (on Update), so I did not add `Codename` to the Update params here either. I think that it is ok not to support Codename updates (the Distribution cannot be changed either), but let me know if you think otherwise.

We are already using this patch internally, it would be nice to have it merged so that we can use upstream builds.

## Checklist

- [x] allow Maintainers to edit PR (rebase, run coverage, help with tests, ...)
- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [ ] author name in `AUTHORS`
