### PR TITLE
s3: match the SymLink metadata key case-insensitively in ReadLink

### DIFF
--- a/s3/public.go
+++ b/s3/public.go
@@ -576,5 +576,14 @@ func (storage *PublishedStorage) ReadLink(path string) (string, error) {
 		return "", err
 	}
 
-	return output.Metadata["SymLink"], nil
+	// S3 lowercases user metadata keys, so the value SymLink writes as
+	// "SymLink" is returned as "symlink" and a case-sensitive lookup finds
+	// nothing. Matched case-insensitively so either spelling resolves.
+	for key, value := range output.Metadata {
+		if strings.EqualFold(key, "SymLink") {
+			return value, nil
+		}
+	}
+
+	return "", nil
 }

--- a/s3/public_test.go
+++ b/s3/public_test.go
@@ -409,6 +409,34 @@ func (s *PublishedStorageSuite) TestSymLink(c *C) {
 	c.Skip("copy not available in s3test")
 }
 
+func (s *PublishedStorageSuite) TestReadLinkMetadataKeyIsCaseInsensitive(c *C) {
+	// S3 lowercases user metadata keys, so a value written as "SymLink" comes
+	// back as "symlink". A case-sensitive map lookup therefore returns "" with
+	// a nil error, which reads as "this is not a link" rather than as failure.
+	//
+	// deb.packageIndexByHash relies on ReadLink to find the physical file its
+	// .old pointer refers to, and removes it before rotating. With "" returned
+	// the Remove is a no-op whose error is discarded, so every superseded
+	// by-hash index file is left behind. On a live S3-backed archive that is
+	// one leaked object per index per hash algorithm per publish, forever;
+	// filesystem backends are unaffected because they have real symlinks.
+	//
+	// Written with PutObject rather than SymLink because the test server has
+	// no CopyObject, which is why TestSymLink above is skipped and why this
+	// path was never covered.
+	_, err := s.storage.s3.PutObject(context.TODO(), &s3.PutObjectInput{
+		Bucket:   aws.String("test"),
+		Key:      aws.String("a/b.link"),
+		Body:     bytes.NewReader([]byte("test")),
+		Metadata: map[string]string{"symlink": "a/b"},
+	})
+	c.Assert(err, IsNil)
+
+	link, err := s.storage.ReadLink("a/b.link")
+	c.Check(err, IsNil)
+	c.Check(link, Equals, "a/b")
+}
+
 func (s *PublishedStorageSuite) TestFileExists(c *C) {
 	s.PutFile(c, "a/b", []byte("test"))
 

--- a/s3/public_test.go
+++ b/s3/public_test.go
@@ -437,6 +437,24 @@ func (s *PublishedStorageSuite) TestReadLinkMetadataKeyIsCaseInsensitive(c *C) {
 	c.Check(link, Equals, "a/b")
 }
 
+func (s *PublishedStorageSuite) TestReadLinkOnPlainObject(c *C) {
+	// An object that is not a link has no SymLink metadata, and ReadLink
+	// returns an empty string with a nil error rather than failing.
+	// packageIndexByHash relies on that: it calls ReadLink on a path it has
+	// only just confirmed exists, and treats an error as "leave it alone".
+	s.PutFile(c, "a/plain", []byte("test"))
+
+	link, err := s.storage.ReadLink("a/plain")
+	c.Check(err, IsNil)
+	c.Check(link, Equals, "")
+
+	// A HeadObject that fails is an error, not an empty link. The two are
+	// distinguishable so a caller can tell "this is not a link" from "I could
+	// not find out".
+	_, err = s.noSuchBucketStorage.ReadLink("a/plain")
+	c.Check(err, NotNil)
+}
+
 func (s *PublishedStorageSuite) TestFileExists(c *C) {
 	s.PutFile(c, "a/b", []byte("test"))
 


### PR DESCRIPTION
## Description of the Change

S3 lowercases user metadata keys. `SymLink` writes `"SymLink"`, but `ReadLink`
looks up `output.Metadata["SymLink"]` and the value comes back under
`"symlink"` — so the lookup misses and `ReadLink` returns an empty string with a
**nil error**. To the caller that reads as "this object is not a link" rather
than as a failure.

`deb.packageIndexByHash` uses `ReadLink` to find the physical file its `.old`
pointer refers to, and removes it before rotating:

```go
linkTarget, err = file.parent.publishedStorage.ReadLink(oldIndexPath)
if err == nil {
    // If we managed to resolve the link target: delete it. This is the
    // oldest physical index file we no longer need.
    _ = file.parent.publishedStorage.Remove(linkTarget)
}
```

With `""` returned, the `Remove` is a no-op and its error is discarded. The
pointers rotate correctly, so the bug is invisible in the published metadata —
but every superseded by-hash index file is left behind, one per index file per
hash algorithm per publish, indefinitely.

Filesystem backends are unaffected: they have real symlinks and never go
through this path.

## Evidence

Measured on a live R2-backed archive publishing three suites a few times a day,
with `Acquire-By-Hash` enabled on 2026-08-24:

```
dists/ total 711  ->  by-hash 672, plain 39
```

Only 39 index files are current. The other 672 are orphaned by-hash copies,
accruing at roughly 48 per publish. Reading the metadata back from R2 directly
shows the casing:

```
Packages       metadata keys: ['symlink']
Packages.old   metadata keys: ['symlink']
```

## Why the existing test does not catch it

`TestSymLink` round-trips `SymLink` → `ReadLink`, but ends with
`c.Skip("copy not available in s3test")`, so it never runs — the test server has
no `CopyObject`. This path has therefore never been covered.

The regression test added here writes the metadata with `PutObject` instead, so
it needs no `CopyObject` support. It fails before the change with
`obtained string = ""` and passes after.

## Checklist

- [x] allow Maintainers to edit PR (rebase, run coverage, help with tests, ...)
- [x] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional) — the functional
      suite has no S3 backend; the unit test covers the decoding directly
- [ ] man page updated (if applicable) — no user-visible interface change
- [x] `go build ./s3/...`, `go vet ./s3/...`, `gofmt -l s3/` and `go test ./s3/...`
      all clean