### PR TITLE
deb: rename published indexes concurrently

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -84,3 +84,4 @@ List of contributors, in chronological order:
 * Zhang Xiao (https://github.com/xzhang1)
 * Tom Nguyen (https://github.com/lecafard)
 * Philip Cramer (https://github.com/PhilipCramer)
+* Martin Simon (https://github.com/barnumbirr)

--- a/deb/index_files.go
+++ b/deb/index_files.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/aptly-dev/aptly/aptly"
 	"github.com/aptly-dev/aptly/pgp"
@@ -442,15 +443,48 @@ func (files *indexFiles) FinalizeAll(progress aptly.Progress, signer pgp.Signer)
 	return
 }
 
-func (files *indexFiles) RenameFiles() error {
-	var err error
+// How many index renames are in flight at once. Every rename is a round trip,
+// and on an S3 backend it is a CopyObject followed by a DeleteObject, so a
+// publish rewriting a dozen indexes spent most of its wall clock waiting on
+// them one at a time. Four matches the default used for concurrent package
+// uploads.
+const renameConcurrency = 4
 
+func (files *indexFiles) RenameFiles() error {
+	type renamePair struct{ oldName, newName string }
+
+	pairs := make([]renamePair, 0, len(files.renameMap))
 	for oldName, newName := range files.renameMap {
-		err = files.publishedStorage.RenameFile(oldName, newName)
-		if err != nil {
-			return fmt.Errorf("unable to rename: %s", err)
-		}
+		pairs = append(pairs, renamePair{oldName, newName})
 	}
 
-	return nil
+	var (
+		wg       sync.WaitGroup
+		mu       sync.Mutex
+		firstErr error
+	)
+	sem := make(chan struct{}, renameConcurrency)
+
+	for _, pair := range pairs {
+		wg.Add(1)
+
+		go func(pair renamePair) {
+			defer wg.Done()
+
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			if err := files.publishedStorage.RenameFile(pair.oldName, pair.newName); err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = fmt.Errorf("unable to rename: %s", err)
+				}
+				mu.Unlock()
+			}
+		}(pair)
+	}
+
+	wg.Wait()
+
+	return firstErr
 }

--- a/deb/index_files_rename_test.go
+++ b/deb/index_files_rename_test.go
@@ -1,0 +1,108 @@
+package deb
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/aptly-dev/aptly/aptly"
+
+	. "gopkg.in/check.v1"
+)
+
+type IndexFilesSuite struct{}
+
+var _ = Suite(&IndexFilesSuite{})
+
+// Only RenameFile is exercised by RenameFiles, so the rest of the interface is
+// embedded and left nil: a call to anything else would panic, which is the
+// loudest way to notice this fake drifting from what the code under test does.
+type renameRecordingStorage struct {
+	aptly.PublishedStorage
+
+	mu       sync.Mutex
+	renamed  map[string]string
+	failOn   string
+	inFlight int
+	maxSeen  int
+}
+
+func (s *renameRecordingStorage) RenameFile(oldName, newName string) error {
+	s.mu.Lock()
+	s.inFlight++
+	if s.inFlight > s.maxSeen {
+		s.maxSeen = s.inFlight
+	}
+	s.mu.Unlock()
+
+	defer func() {
+		s.mu.Lock()
+		s.inFlight--
+		s.mu.Unlock()
+	}()
+
+	if oldName == s.failOn {
+		return fmt.Errorf("rename refused for %s", oldName)
+	}
+
+	s.mu.Lock()
+	s.renamed[oldName] = newName
+	s.mu.Unlock()
+	return nil
+}
+
+func newRenameFiles(storage aptly.PublishedStorage, n int) (*indexFiles, *renameRecordingStorage) {
+	rec, ok := storage.(*renameRecordingStorage)
+	if !ok {
+		rec = &renameRecordingStorage{renamed: make(map[string]string)}
+	}
+	files := &indexFiles{
+		publishedStorage: rec,
+		renameMap:        make(map[string]string, n),
+	}
+	for i := 0; i < n; i++ {
+		files.renameMap[fmt.Sprintf("dists/x/Packages.tmp.%d", i)] = fmt.Sprintf("dists/x/Packages.%d", i)
+	}
+	return files, rec
+}
+
+func (s *IndexFilesSuite) TestRenameFilesRenamesEveryEntry(c *C) {
+	files, rec := newRenameFiles(nil, 20)
+
+	c.Assert(files.RenameFiles(), IsNil)
+
+	c.Check(len(rec.renamed), Equals, 20)
+	for i := 0; i < 20; i++ {
+		c.Check(rec.renamed[fmt.Sprintf("dists/x/Packages.tmp.%d", i)], Equals,
+			fmt.Sprintf("dists/x/Packages.%d", i))
+	}
+}
+
+func (s *IndexFilesSuite) TestRenameFilesStaysWithinTheConcurrencyLimit(c *C) {
+	files, rec := newRenameFiles(nil, 50)
+
+	c.Assert(files.RenameFiles(), IsNil)
+
+	// An upper bound, so this cannot flake: fewer in flight than the limit is
+	// always acceptable, more never is.
+	c.Check(rec.maxSeen <= renameConcurrency, Equals, true,
+		Commentf("saw %d renames in flight, limit is %d", rec.maxSeen, renameConcurrency))
+}
+
+func (s *IndexFilesSuite) TestRenameFilesReportsAFailure(c *C) {
+	files, rec := newRenameFiles(nil, 10)
+	rec.failOn = "dists/x/Packages.tmp.4"
+
+	err := files.RenameFiles()
+
+	c.Assert(err, NotNil)
+	c.Check(err, ErrorMatches, "unable to rename: rename refused for dists/x/Packages.tmp.4")
+	// The failure is reported, and it does not abandon the rest: every other
+	// entry is still renamed rather than left staged.
+	c.Check(len(rec.renamed), Equals, 9)
+}
+
+func (s *IndexFilesSuite) TestRenameFilesWithNothingToDo(c *C) {
+	files, _ := newRenameFiles(nil, 0)
+
+	c.Assert(files.RenameFiles(), IsNil)
+}


### PR DESCRIPTION
Fixes #1632

## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

`RenameFiles` walks `renameMap` one entry at a time. Every rename is a round trip, and on an S3 backend `RenameFile` is a `CopyObject` followed by a `Remove`, so a publish that rewrites a dozen indexes spends most of its wall clock waiting on them in sequence. #1632 has the traces and the background.

This runs them concurrently, bounded at four in flight to match the default used for concurrent package uploads in #1616. The first error is returned rather than the last, and the remaining renames still run, so a failure does not leave part of the set staged behind a half finished switch.

Nothing else changes: the same renames happen, the published object set and its sizes are identical before and after, and the `.tmp` staging that makes every index and the signature switch together is untouched.

### Measurements

Against MinIO behind a proxy adding 50ms each way, publishing a repository whose `Contents` is dominated by one package carrying 19,500 files. `publish update`, n=5 each:

| | median | range |
| --- | --- | --- |
| master | 2703ms | 2659-2760 |
| this PR | 1624ms | 1622-1679 |

A 40% cut. For reference, removing the staging entirely gets to 1240ms, so this captures about 75% of what the rename phase could ever give back. The rest is not worth it: writing indexes straight to their final names means a failure part way through the upload leaves the archive with some indexes new and some old and no way back, which is exactly what the `.tmp` set prevents.

Four in flight is a constant rather than a config key, since nothing yet asks for a different value. Happy to make it configurable the way #1616 does if you would rather the two matched.

### Notes for review

`FinalizeAll` is serial in the same way, so the upload phase has similar headroom, but it calls the signer and I have not looked at whether that is safe to run concurrently. Batching the `Remove` calls into one `DeleteObjects` was also considered; it can only reach part of what survives this change and would need a change to the `PublishedStorage` interface that every backend implements.

The test file is named `index_files_rename_test.go` rather than `index_files_test.go` deliberately: #1626 adds a file by the latter name, and this way the two can land in either order without an add/add conflict.

## Checklist

- [x] allow Maintainers to edit PR (rebase, run coverage, help with tests, ...)
- [x] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [x] author name in `AUTHORS`

`RenameFiles` had no coverage at all before this. It now has four cases: every entry renamed, the concurrency limit respected, a failure reported without abandoning the rest, and an empty rename map. Locally `go test ./deb/` passes with `RenameFiles` at 100%, `golangci-lint` v2.12.2 reports 0 issues, and `gofmt`, `go vet` and `go build ./...` are clean.
